### PR TITLE
Handle href for Linear Gradient

### DIFF
--- a/lib/extract/extractGradient.js
+++ b/lib/extract/extractGradient.js
@@ -28,18 +28,31 @@ function percentToFloat(percent) {
 
 const offsetComparator = (object, other) => object[0] - other[0];
 
+const childHRefCache = {}
+
 export default function extractGradient(props, parent) {
-  const { id, children, gradientTransform, transform, gradientUnits } = props;
+  const { id, children, gradientTransform, transform, gradientUnits, href } = props;
   if (!id) {
     return null;
   }
 
   const stops = [];
-  const childArray = Children.map(children, child =>
+  const childArray = ( href )
+    ? childHRefCache[href]
+    : Children.map(children, child =>
     React.cloneElement(child, {
       parent,
     }),
   );
+
+  if ( !childArray ) {
+    return null;
+  }
+
+  if ( !href ) {
+    childHRefCache["#" + id] = childArray
+  }
+
   const l = childArray.length;
   for (let i = 0; i < l; i++) {
     const {


### PR DESCRIPTION
For Issue https://github.com/react-native-community/react-native-svg/issues/919

Cache the children incase an href is used.
This wont handle id's which are loaded after a href