### PR TITLE
fix: [web] Don't apply SvgTouchableMixin on every component

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -41,7 +41,10 @@ module.exports = {
         'ts-expect-error': 'allow-with-description',
       },
     ],
-    '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+    '@typescript-eslint/no-unused-vars': [
+      'error',
+      { argsIgnorePattern: '^_', ignoreRestSiblings: true },
+    ],
     '@typescript-eslint/no-var-requires': 'warn',
     eqeqeq: 'error',
     'no-unreachable': 'error',

--- a/src/web/WebShape.ts
+++ b/src/web/WebShape.ts
@@ -1,6 +1,6 @@
 import React, { type JSX } from 'react';
 import {
-  GestureResponderEvent,
+  TouchableWithoutFeedback,
   // @ts-ignore it is not seen in exports
   unstable_createElement as createElement,
 } from 'react-native';
@@ -8,9 +8,27 @@ import {
 import { BaseProps } from './types';
 import { prepare } from './utils/prepare';
 import { convertInt32ColorToRGBA } from './utils/convertInt32Color';
-import { getAttributeName, remeasure } from './utils';
+import { getAttributeName } from './utils';
 import { hasTouchableProperty } from './utils/hasProperty';
-import SvgTouchableMixin from '../lib/SvgTouchableMixin';
+
+/**
+ * `TouchableWithoutFeedback` clones its child and injects props on it
+ * (`focusable`, `accessibilityDisabled` and the responder handlers). Those props
+ * need `unstable_createElement` to be turned into DOM attributes, so the child
+ * has to be a component that calls it, not an already created element.
+ */
+const TouchableSvgElement = React.forwardRef<
+  SVGElement,
+  {
+    tag: React.ElementType;
+    elementProps: Record<string, unknown>;
+    children?: React.ReactNode;
+  }
+>(({ tag, elementProps, ...injectedProps }, ref) =>
+  createElement(tag, { ...elementProps, ...injectedProps, ref })
+);
+
+TouchableSvgElement.displayName = 'TouchableSvgElement';
 
 export class WebShape<
   P extends BaseProps = BaseProps,
@@ -83,30 +101,6 @@ export class WebShape<
     }
   }
 
-  _remeasureMetricsOnActivation: () => void;
-  touchableHandleStartShouldSetResponder?: (
-    e: GestureResponderEvent
-  ) => boolean;
-
-  touchableHandleResponderMove?: (e: GestureResponderEvent) => void;
-  touchableHandleResponderGrant?: (e: GestureResponderEvent) => void;
-  touchableHandleResponderRelease?: (e: GestureResponderEvent) => void;
-  touchableHandleResponderTerminate?: (e: GestureResponderEvent) => void;
-  touchableHandleResponderTerminationRequest?: (
-    e: GestureResponderEvent
-  ) => boolean;
-
-  constructor(props: P) {
-    super(props);
-
-    // Do not attach touchable mixin handlers if SVG element doesn't have a touchable prop
-    if (hasTouchableProperty(props)) {
-      SvgTouchableMixin(this);
-    }
-
-    this._remeasureMetricsOnActivation = remeasure.bind(this);
-  }
-
   render(): JSX.Element {
     if (!this.tag) {
       throw new Error(
@@ -114,9 +108,63 @@ export class WebShape<
       );
     }
     this.lastMergedProps = {};
-    return createElement(
-      this.tag,
-      prepare(this, this.prepareProps(this.props))
+
+    const cleanProps = prepare(this, this.prepareProps(this.props));
+
+    // Only touchable elements are wrapped, so only they become keyboard
+    // focusable. A plain shape stays out of the tab order.
+    if (!hasTouchableProperty(this.props)) {
+      return createElement(this.tag, cleanProps);
+    }
+
+    const { children, ref, ...elementProps } = cleanProps as Record<
+      string,
+      unknown
+    >;
+
+    const {
+      delayLongPress,
+      delayPressIn,
+      delayPressOut,
+      disabled,
+      focusable,
+      onBlur,
+      onFocus,
+      onLongPress,
+      onPress,
+      onPressIn,
+      onPressOut,
+      rejectResponderTermination,
+    } = this.props;
+
+    return React.createElement(
+      TouchableWithoutFeedback,
+      {
+        delayLongPress,
+        delayPressIn,
+        delayPressOut,
+        disabled,
+        // A touchable element is a keyboard tab stop unless it opts out with
+        // `focusable={false}`.
+        focusable,
+        onBlur,
+        onFocus,
+        onLongPress,
+        onPress,
+        onPressIn,
+        onPressOut,
+        rejectResponderTermination,
+      },
+      React.createElement(
+        TouchableSvgElement,
+        {
+          tag: this.tag,
+          elementProps,
+          // TouchableWithoutFeedback merges this ref with its own host ref
+          ref: ref as React.Ref<SVGElement>,
+        },
+        children as React.ReactNode
+      )
     );
   }
 }

--- a/src/web/types.ts
+++ b/src/web/types.ts
@@ -22,6 +22,7 @@ export interface BaseProps {
   delayPressIn?: number;
   delayPressOut?: number;
   disabled?: boolean;
+  focusable?: boolean;
   hitSlop?: EdgeInsetsProp;
   href?: RNImageProps['source'] | string | number;
   nativeID?: string;

--- a/src/web/utils/index.ts
+++ b/src/web/utils/index.ts
@@ -12,39 +12,6 @@ export const getBoundingClientRect = (node: SVGElement) => {
   throw new Error('Can not get boundingClientRect of ' + node || 'undefined');
 };
 
-const measureLayout = (
-  node: SVGElement,
-  callback: (
-    x: number,
-    y: number,
-    width: number,
-    height: number,
-    left: number,
-    top: number
-  ) => void
-) => {
-  const relativeNode = node?.parentNode;
-  if (relativeNode) {
-    setTimeout(() => {
-      // @ts-expect-error TODO: handle it better
-      const relativeRect = getBoundingClientRect(relativeNode);
-      const { height, left, top, width } = getBoundingClientRect(node);
-      const x = left - relativeRect.left;
-      const y = top - relativeRect.top;
-      callback(x, y, width, height, left, top);
-    }, 0);
-  }
-};
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function remeasure(this: any) {
-  const tag = this.state.touchable.responderID;
-  if (tag === null) {
-    return;
-  }
-  measureLayout(tag, this._handleQueryLayout);
-}
-
 /* Taken from here: https://gist.github.com/jennyknuth/222825e315d45a738ed9d6e04c7a88d0 */
 export function encodeSvg(svgString: string) {
   return svgString

--- a/src/web/utils/prepare.ts
+++ b/src/web/utils/prepare.ts
@@ -1,10 +1,6 @@
-import {
-  GestureResponderEvent,
-  type ImageProps as RNImageProps,
-} from 'react-native';
+import { type ImageProps as RNImageProps } from 'react-native';
 import { BaseProps } from '../types';
 import { WebShape } from '../WebShape';
-import { hasTouchableProperty } from './hasProperty';
 import { parseTransformProp } from './parseTransform';
 import { resolve } from '../../lib/resolve';
 import { NumberProp } from '../../lib/extract/types';
@@ -35,18 +31,31 @@ export const prepare = <T extends BaseProps>(
     forwardedRef,
     gradientTransform,
     patternTransform,
+
+    // Handled by the TouchableWithoutFeedback wrapper in WebShape, and only
+    // when the element is touchable. Passing them to the DOM element would
+    // make it focusable and add unsupported attributes.
+    delayLongPress,
+    delayPressIn,
+    delayPressOut,
+    disabled,
+    onBlur,
+    onFocus,
+    onLongPress,
     onPress,
+    onPressIn,
+    onPressOut,
+    rejectResponderTermination,
+
+    // Unsupported by react-native-web
+    hitSlop,
+    pressRetentionOffset,
+    touchSoundDisabled,
+
     ...rest
   } = props;
 
   const clean: {
-    onStartShouldSetResponder?: (e: GestureResponderEvent) => boolean;
-    onResponderMove?: (e: GestureResponderEvent) => void;
-    onResponderGrant?: (e: GestureResponderEvent) => void;
-    onResponderRelease?: (e: GestureResponderEvent) => void;
-    onResponderTerminate?: (e: GestureResponderEvent) => void;
-    onResponderTerminationRequest?: (e: GestureResponderEvent) => boolean;
-    onClick?: (e: GestureResponderEvent) => void;
     transform?: string;
     gradientTransform?: string;
     patternTransform?: string;
@@ -54,21 +63,7 @@ export const prepare = <T extends BaseProps>(
     href?: RNImageProps['source'] | string | null;
     style?: object;
     ref?: unknown;
-  } = {
-    ...(hasTouchableProperty(props)
-      ? {
-          onStartShouldSetResponder:
-            self.touchableHandleStartShouldSetResponder,
-          onResponderTerminationRequest:
-            self.touchableHandleResponderTerminationRequest,
-          onResponderGrant: self.touchableHandleResponderGrant,
-          onResponderMove: self.touchableHandleResponderMove,
-          onResponderRelease: self.touchableHandleResponderRelease,
-          onResponderTerminate: self.touchableHandleResponderTerminate,
-        }
-      : null),
-    ...rest,
-  };
+  } = { ...rest };
 
   if (origin != null) {
     clean['transform-origin'] = origin.toString().replace(',', ' ');
@@ -119,9 +114,6 @@ export const prepare = <T extends BaseProps>(
     styles.fontStyle = fontStyle;
   }
   clean.style = resolve(style, styles);
-  if (onPress !== null) {
-    clean.onClick = props.onPress;
-  }
   if (props.href !== null && props.href !== undefined) {
     clean.href = resolveAssetUri(props.href)?.uri;
   }


### PR DESCRIPTION
Hi 👋

Do you remember [this bug](https://github.com/react-native-community/react-native-svg/issues/1244)? Well, it happens again, for a different reason. 😄

By default, every component of this lib implements the `SvgTouchableMixin`, even if no Touchable properties are used, making every component accessible by default again.

# Summary

- `hasTouchableProperty` is now a function, `SvgTouchableMixin` is applied only if it returns `true`.

## Test Plan

### What's required for testing (prerequisites)?

1. Init a project with `create-react-app` and `react-native-web`
2. Add `react-native-svg` dependency and render a random SVG using it

### What are the steps to reproduce (after prerequisites)?

1. SVG elements should not be accessible and focusable if Touchable props are not present.
2. SVG elements should be accessible and focusable if Touchable props are present.

## Checklist

- [X] I have tested this on a browser
- [ ] I added documentation in `README.md`
- [ ] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
