### PR TITLE
Fix scale 0 is ignored

### DIFF
--- a/src/lib/extract/extractTransform.ts
+++ b/src/lib/extract/extractTransform.ts
@@ -31,7 +31,7 @@ function universal2axis(
   universal: NumberProp | NumberProp[] | undefined,
   axisX: NumberProp | void,
   axisY: NumberProp | void,
-  defaultValue?: number,
+  defaultValue: number,
 ): [number, number] {
   let x;
   let y;
@@ -64,7 +64,7 @@ function universal2axis(
     y = axisY;
   }
 
-  return [x || defaultValue || 0, y || defaultValue || 0];
+  return [x ?? defaultValue, y ?? defaultValue];
 }
 
 export function props2transform(
@@ -116,10 +116,11 @@ export function props2transform(
     translate,
     translateX || (Array.isArray(x) ? x[0] : x),
     translateY || (Array.isArray(y) ? y[0] : y),
+    0
   );
-  const or = universal2axis(origin, originX, originY);
+  const or = universal2axis(origin, originX, originY, 0);
   const sc = universal2axis(scale, scaleX, scaleY, 1);
-  const sk = universal2axis(skew, skewX, skewY);
+  const sk = universal2axis(skew, skewX, skewY, 0);
 
   return {
     rotation: rotation == null ? 0 : +rotation || 0,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

```scale={0}```  is not worked currently. Because scale `0` is fallback to default value (1).

## Test Plan

Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

```
<Rect x={0} y={0} width={100} height={100} scale={0} fill="black" />
```

![スクリーンショット 2020-08-12 12 09 05](https://user-images.githubusercontent.com/31937/89970862-b6e5b780-dc94-11ea-8ba2-da3294df6387.png)

---

![スクリーンショット 2020-08-12 12 09 24](https://user-images.githubusercontent.com/31937/89970865-b816e480-dc94-11ea-9fb4-b014019f15b2.png)

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [x] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
