### PR TITLE
fix: bundle size increasing issue

### DIFF
--- a/__tests__/css.test.tsx
+++ b/__tests__/css.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
-import { SvgCss, parse, inlineStyles } from '../src/ReactNativeSVG';
+import { parse } from '../src/ReactNativeSVG';
+import { SvgCss, inlineStyles } from '../css';
 
 const xml = `<?xml version="1.0" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"

--- a/css/index.ts
+++ b/css/index.ts
@@ -1,0 +1,2 @@
+export * from '../src/css';
+export { LocalSvg, WithLocalSvg, loadLocalRawResource } from '../src/LocalSvg';

--- a/package.json
+++ b/package.json
@@ -10,7 +10,10 @@
   "license": "MIT",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",
-  "react-native": "src/index.ts",
+  "react-native": [
+    "src/index.ts",
+    "css/index.ts"
+  ],
   "types": "src/index.d.ts",
   "files": [
     "__tests__",
@@ -19,6 +22,7 @@
     "ios",
     "lib",
     "src",
+    "css",
     "RNSVG.podspec"
   ],
   "@react-native-community/bob": {

--- a/src/LocalSvg.tsx
+++ b/src/LocalSvg.tsx
@@ -4,7 +4,7 @@ import { NativeModules, Platform } from 'react-native';
 import resolveAssetSource from 'react-native/Libraries/Image/resolveAssetSource';
 
 import { fetchText } from './xml';
-import { SvgCss, SvgWithCss } from './css';
+import { SvgCss, SvgWithCss } from '../css';
 
 const { getRawResource } = NativeModules.RNSVGRenderableManager || {};
 

--- a/src/ReactNativeSVG.ts
+++ b/src/ReactNativeSVG.ts
@@ -25,14 +25,6 @@ import Marker from './elements/Marker';
 import ForeignObject from './elements/ForeignObject';
 import { parse, SvgAst, SvgFromUri, SvgFromXml, SvgUri, SvgXml } from './xml';
 import {
-  SvgCss,
-  SvgCssUri,
-  SvgWithCss,
-  SvgWithCssUri,
-  inlineStyles,
-} from './css';
-import { LocalSvg, WithLocalSvg, loadLocalRawResource } from './LocalSvg';
-import {
   RNSVGCircle,
   RNSVGClipPath,
   RNSVGDefs,
@@ -87,14 +79,6 @@ export {
   SvgFromXml,
   SvgUri,
   SvgXml,
-  SvgCss,
-  SvgCssUri,
-  SvgWithCss,
-  SvgWithCssUri,
-  inlineStyles,
-  LocalSvg,
-  WithLocalSvg,
-  loadLocalRawResource,
   Shape,
   RNSVGMarker,
   RNSVGMask,

--- a/src/css.tsx
+++ b/src/css.tsx
@@ -14,6 +14,7 @@ import {
   XmlProps,
   XmlState,
 } from './xml';
+
 import csstree, {
   Atrule,
   AtrulePrelude,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,5 +22,8 @@
   "files": [
     "src/index.d.ts"
   ],
-  "include": ["src/index.ts"]
+  "include": [
+    "src/index.ts",
+    "css/index.ts"
+  ]
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

As https://github.com/react-native-community/react-native-svg/issues/1264 bug report explains, The bundle size increased drastically from version 9.11.1 to 11.0.1+. It has climbed from 55kb to 173kb. This significant increase occurred due to `css-tree` library. 

This PR makes `css-tree` and all css related code optional. All CSS related functions, component, etc exports. have been moved out from the `src/index.ts` into `css/index.ts`. It makes possible to use the latest SVG improvement, features without huge bundle size change. For using CSS related code, it is needed to be imported separately e.g. 

```
import { SvgCss } from 'react-native-svg/css'
```

These are **BREAKING CHANGES** and it needs to be mentioned in the next release.

Thank you, [Fedir Ushakov](https://github.com/todorone) and [Mikael Sand](https://github.com/msand) for suggesting the possible solution. 🎉 
Thank you, [William Lauzé](https://github.com/wilau2) for helping and testing these changes. 🙏 

## Test Plan

The tests are updated accordingly

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅   |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [x] I updated the typed files (typescript)
- [x] I added a test for the API in the `__tests__` folder