### PR TITLE
Fix nested SVGs in iOS #1437

### DIFF
--- a/apple/Elements/RNSVGSvgView.m
+++ b/apple/Elements/RNSVGSvgView.m
@@ -177,6 +177,9 @@
 
 - (void)drawToContext:(CGContextRef)context withRect:(CGRect)rect {
     rendered = true;
+    _clipPaths = nil;
+    _templates = nil;
+    _painters = nil;
     self.initialCTM = CGContextGetCTM(context);
     self.invInitialCTM = CGAffineTransformInvert(self.initialCTM);
     if (self.align) {
@@ -195,6 +198,11 @@
     for (RNSVGView *node in self.subviews) {
         if ([node isKindOfClass:[RNSVGNode class]]) {
             RNSVGNode *svg = (RNSVGNode *)node;
+            if (svg.responsible && !self.responsible) {
+                self.responsible = YES;
+            }
+
+            [svg parseReference];
             [svg renderTo:context
                      rect:rect];
         } else {
@@ -209,23 +217,8 @@
     if ([parent isKindOfClass:[RNSVGNode class]]) {
         return;
     }
-    rendered = true;
-    _clipPaths = nil;
-    _templates = nil;
-    _painters = nil;
     _boundingBox = rect;
     CGContextRef context = UIGraphicsGetCurrentContext();
-
-    for (RNSVGPlatformView *node in self.subviews) {
-        if ([node isKindOfClass:[RNSVGNode class]]) {
-            RNSVGNode *svg = (RNSVGNode *)node;
-            if (svg.responsible && !self.responsible) {
-                self.responsible = YES;
-            }
-
-            [svg parseReference];
-        }
-    }
 
     [self drawToContext:context withRect:rect];
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Fixes #1437  #1495.
Nested SVGs with gradients are rendered now in iOS

In the current implementation nested SVGs don't call the [`[svg parseReference];`](https://github.com/react-native-svg/react-native-svg/blob/fa9a25d36b6f863d3148bdd5dd1ac76e91339402/apple/Elements/RNSVGSvgView.m#L222-L226) which is needed for the brush creation.
This happens because of this if-clause [RNSVGSvgView.m:208-210](https://github.com/react-native-svg/react-native-svg/blob/fa9a25d36b6f863d3148bdd5dd1ac76e91339402/apple/Elements/RNSVGSvgView.m#L208-L210).

Moved the call of [`[svg parseReference];`](https://github.com/react-native-svg/react-native-svg/blob/fa9a25d36b6f863d3148bdd5dd1ac76e91339402/apple/Elements/RNSVGSvgView.m#L222-L226) from [`- (void)drawRect:(CGRect)rect`](https://github.com/react-native-svg/react-native-svg/blob/fa9a25d36b6f863d3148bdd5dd1ac76e91339402/apple/Elements/RNSVGSvgView.m#L206) to 
[`- (void)drawToContext:(CGContextRef)context withRect:(CGRect)rect `](https://github.com/react-native-svg/react-native-svg/blob/fa9a25d36b6f863d3148bdd5dd1ac76e91339402/apple/Elements/RNSVGSvgView.m#L178).
Since it also [loops through the subviews](https://github.com/react-native-svg/react-native-svg/blob/fa9a25d36b6f863d3148bdd5dd1ac76e91339402/apple/Elements/RNSVGSvgView.m#L195-L201) and is called for all SVGs.

## Test Plan

Code shown in #1437.

<img src="https://user-images.githubusercontent.com/71780728/122250377-e6270f80-cec9-11eb-9868-8bd90727d495.png"  height="400">

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [ ] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
