### PR TITLE
Add documentation explaining how to use the web compatibility code

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ Install the JavaScript with:
 
 ##### React Native Web
 
+> If you use React Native Web via Expo CLI (or @expo/webpack-config) the following configuration is not necessary. 
+
 `react-native-svg` has a compatibility layer for the web. This compatibility layer is exposed via `.web.js` files.
 If your project targets `react-native-web`, be sure that your bundler is set up to resolve these files.
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,22 @@ Install the JavaScript with:
    react-native link react-native-svg
    ```
 
+##### React Native Web
+
+`react-native-svg` has a compatibility layer for the web. This compatibility layer is exposed via `.web.js` files.
+If your project targets `react-native-web`, be sure that your bundler is set up to resolve these files.
+
+Webpack users can simply configure Webpack to resolve files with the `.web.js` extension alongside any other extensions:
+
+```
+ resolve: {
+    extensions: [ '.web.js', '.js',  ... ]
+  }
+}
+```
+
+Please note that some components (such as `SvgXml` and `SvgCss`) may not work in the web compatibility layer.
+
 # NOTICE:
 
 Due to breaking changes in react-native, the version given in the left column


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

I'm totally new to `react-native-svg` and I was interested in using it for a `react-native-web` application. I couldn't figure out how to get this library to work with `react-native-web` without doing some digging, so I figured I'd add some documentation that will help people get past the issue that I was stuck on for a while.

Resolves https://github.com/react-native-svg/react-native-svg/issues/1530

## Test Plan

This is just a documentation addition.



## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I added documentation in `README.md`
