### PR TITLE
Fix memory leak of a CGPathRef

### DIFF
--- a/apple/Elements/RNSVGUse.m
+++ b/apple/Elements/RNSVGUse.m
@@ -138,7 +138,7 @@
         return nil;
     }
     CGPathRef path = [template getPath:context];
-    return CGPathCreateCopyByTransformingPath(path, &transform);
+    return (CGPathRef) CFAutorelease(CGPathCreateCopyByTransformingPath(path, &transform));
 }
 
 @end


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
Regarding issue #1385
Fixes memory leak of a CGPathRef.

Explain the **motivation** for making this change: here are some points to help you:

CGPath leaks listed in Xcode:

<img width="384" alt="leaked objects" src="https://user-images.githubusercontent.com/5883925/135925704-76783cae-f60b-4c2f-a7f0-be7ce76bc6a6.png">

Backtrace of leaked object, identifying RNSVGUse as the object that leaked the CGPathRef:

<img width="384" alt="svg leak" src="https://user-images.githubusercontent.com/5883925/135925520-fd07dc45-3017-4b75-9e73-a25a65c47b96.png">

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
Issue #1385

* What is the feature? (if applicable)
Memory leak fix

* How did you implement the solution?
Added a call to autorelease returned CGPathRef in line with the other implementations of `getPath:`

* What areas of the library does it impact?

## Test Plan

Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

### What's required for testing (prerequisites)?
Running an app that uses react-native-svg in the Xcode debugger with malloc stack tracing enabled.

### What are the steps to reproduce (after prerequisites)?
Halt the app in the debugger and examine memory graph, specifically the leaked objects filter (by clicking on the blue triangle icon)

<img width="430" alt="directions" src="https://user-images.githubusercontent.com/5883925/135926802-38da9929-fd1d-454b-9b5c-276c41b52286.png">

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [ ] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
