### PR TITLE
Add clipRule property to ClipPath

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -245,6 +245,7 @@ export type Circle = React.ComponentClass<CircleProps>;
 
 export interface ClipPathProps {
   id?: string;
+  clipRule?: FillRule;
 }
 export const ClipPath: React.ComponentClass<ClipPathProps>;
 export type ClipPath = React.ComponentClass<ClipPathProps>;


### PR DESCRIPTION
Adding the typescript definiton for the property `clipRule` of the ClipPath component.