### PR TITLE
Web: Support for transform prop

### DIFF
--- a/src/ReactNativeSVG.web.ts
+++ b/src/ReactNativeSVG.web.ts
@@ -151,7 +151,7 @@ const prepare = <T extends BaseProps>(
         transformArray.push(`translate(0 ${value})`);
       } else if (key === 'originX') {
         transformArray.push(`translate(${-value} 0)`);
-      } else if (key === 'originX') {
+      } else if (key === 'originY') {
         transformArray.push(`translate(0 ${-value})`);
       } else if (key === 'origin') {
         if (Array.isArray(value)) {


### PR DESCRIPTION
# Summary

Transform prop is ignored on web. This PR stringify transform props so it is compatible with web SVG. It is an extension of https://github.com/react-native-svg/react-native-svg/issues/1824

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    no change     |
| Android |    no change    |
| Web |    ✅     |

## Checklist

- [X ] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [ ] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
