### PR TITLE
fix: handle null passed to SvgLength

### DIFF
--- a/android/src/main/java/com/horcrux/svg/SVGLength.java
+++ b/android/src/main/java/com/horcrux/svg/SVGLength.java
@@ -104,11 +104,11 @@ class SVGLength {
   }
 
   static SVGLength from(String string) {
-    return new SVGLength(string);
+    return string != null ? new SVGLength(string) : new SVGLength();
   }
 
   static SVGLength from(Double value) {
-    return new SVGLength(value);
+    return value != null ? new SVGLength(value) : new SVGLength();
   }
 
   static String toString(Dynamic dynamic) {


### PR DESCRIPTION
`SvgLength` `from` method should be able to parse `null` since it is a correct value, we then use the empty constructor since it provides default values.