### PR TITLE
fix: handle null passed to matrix and tintColor

### DIFF
--- a/android/src/main/java/com/horcrux/svg/SvgView.java
+++ b/android/src/main/java/com/horcrux/svg/SvgView.java
@@ -186,7 +186,7 @@ public class SvgView extends ReactViewGroup implements ReactCompoundView, ReactC
   }
 
   public void setTintColor(Integer tintColor) {
-    mTintColor = tintColor;
+    mTintColor = tintColor != null ? tintColor : 0;
     invalidate();
     clearChildCache();
   }

--- a/android/src/main/java/com/horcrux/svg/VirtualView.java
+++ b/android/src/main/java/com/horcrux/svg/VirtualView.java
@@ -291,30 +291,27 @@ public abstract class VirtualView extends ReactViewGroup {
   }
 
   public void setMatrix(Dynamic matrixArray) {
-    ReadableType type = matrixArray.getType();
-    if (!matrixArray.isNull() && type.equals(ReadableType.Array)) {
-      ReadableArray matrix = matrixArray.asArray();
-      setMatrix(matrix);
+    boolean isArrayType = !matrixArray.isNull() && matrixArray.getType().equals(ReadableType.Array);
+    setMatrix(isArrayType ? matrixArray.asArray() : null);
+  }
+
+  public void setMatrix(@Nullable ReadableArray matrixArray) {
+    if (matrixArray != null) {
+      int matrixSize = PropHelper.toMatrixData(matrixArray, sRawMatrix, mScale);
+      if (matrixSize == 6) {
+        if (mMatrix == null) {
+          mMatrix = new Matrix();
+          mInvMatrix = new Matrix();
+        }
+        mMatrix.setValues(sRawMatrix);
+        mInvertible = mMatrix.invert(mInvMatrix);
+      } else if (matrixSize != -1) {
+        FLog.w(ReactConstants.TAG, "RNSVG: Transform matrices must be of size 6");
+      }
     } else {
       mMatrix.reset();
       mInvMatrix.reset();
       mInvertible = true;
-      super.invalidate();
-      clearParentCache();
-    }
-  }
-
-  public void setMatrix(ReadableArray matrixArray) {
-    int matrixSize = PropHelper.toMatrixData(matrixArray, sRawMatrix, mScale);
-    if (matrixSize == 6) {
-      if (mMatrix == null) {
-        mMatrix = new Matrix();
-        mInvMatrix = new Matrix();
-      }
-      mMatrix.setValues(sRawMatrix);
-      mInvertible = mMatrix.invert(mInvMatrix);
-    } else if (matrixSize != -1) {
-      FLog.w(ReactConstants.TAG, "RNSVG: Transform matrices must be of size 6");
     }
     super.invalidate();
     clearParentCache();


### PR DESCRIPTION
PR adding handling of `null` values passed to `matrix` and `tintColor` props on `Android`. It should not happen from normal `render` method, but can still be passed with `Animated` or `Reanimated` through native updates or `setNativeProps`. Should fix https://github.com/software-mansion/react-native-svg/issues/1900, https://github.com/software-mansion/react-native-svg/issues/1899.