### PR TITLE
fix: make svg compile on older versions

### DIFF
--- a/android/src/main/java/com/horcrux/svg/RenderableViewManager.java
+++ b/android/src/main/java/com/horcrux/svg/RenderableViewManager.java
@@ -134,6 +134,7 @@ import com.facebook.react.viewmanagers.RNSVGTextPathManagerDelegate;
 import com.facebook.react.viewmanagers.RNSVGTextPathManagerInterface;
 import com.facebook.react.viewmanagers.RNSVGUseManagerDelegate;
 import com.facebook.react.viewmanagers.RNSVGUseManagerInterface;
+import java.util.Locale;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -460,8 +461,13 @@ class VirtualViewManager<V extends VirtualView> extends ViewGroupManager<Virtual
 
   @ReactProp(name = ViewProps.POINTER_EVENTS)
   public void setPointerEvents(V view, @Nullable String pointerEventsStr) {
-    PointerEvents pointerEvents = PointerEvents.parsePointerEvents(pointerEventsStr);
-    view.setPointerEvents(pointerEvents);
+    if (pointerEventsStr == null) {
+      view.setPointerEvents(PointerEvents.AUTO);
+    } else {
+      PointerEvents pointerEvents =
+          PointerEvents.valueOf(pointerEventsStr.toUpperCase(Locale.US).replace("-", "_"));
+      view.setPointerEvents(pointerEvents);
+    }
   }
 
   @ReactProp(name = "onLayout")

--- a/android/src/main/java/com/horcrux/svg/SvgPackage.java
+++ b/android/src/main/java/com/horcrux/svg/SvgPackage.java
@@ -25,12 +25,12 @@ import com.facebook.react.module.model.ReactModuleInfoProvider;
 import com.facebook.react.turbomodule.core.interfaces.TurboModule;
 import com.facebook.react.uimanager.ViewManager;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nonnull;
+import javax.inject.Provider;
 
 @ReactModuleList(
     nativeModules = {
@@ -45,47 +45,194 @@ public class SvgPackage extends TurboReactPackage implements ViewManagerOnDemand
     if (mViewManagers == null) {
       Map<String, ModuleSpec> specs = MapBuilder.newHashMap();
       specs.put(
-          GroupViewManager.REACT_CLASS, ModuleSpec.viewManagerSpec(() -> new GroupViewManager()));
+          GroupViewManager.REACT_CLASS,
+          ModuleSpec.viewManagerSpec(
+              new Provider<NativeModule>() {
+                @Override
+                public NativeModule get() {
+                  return new GroupViewManager();
+                }
+              }));
       specs.put(
-          PathViewManager.REACT_CLASS, ModuleSpec.viewManagerSpec(() -> new PathViewManager()));
+          PathViewManager.REACT_CLASS,
+          ModuleSpec.viewManagerSpec(
+              new Provider<NativeModule>() {
+                @Override
+                public NativeModule get() {
+                  return new PathViewManager();
+                }
+              }));
       specs.put(
-          CircleViewManager.REACT_CLASS, ModuleSpec.viewManagerSpec(() -> new CircleViewManager()));
+          CircleViewManager.REACT_CLASS,
+          ModuleSpec.viewManagerSpec(
+              new Provider<NativeModule>() {
+                @Override
+                public NativeModule get() {
+                  return new CircleViewManager();
+                }
+              }));
       specs.put(
           EllipseViewManager.REACT_CLASS,
-          ModuleSpec.viewManagerSpec(() -> new EllipseViewManager()));
+          ModuleSpec.viewManagerSpec(
+              new Provider<NativeModule>() {
+                @Override
+                public NativeModule get() {
+                  return new EllipseViewManager();
+                }
+              }));
       specs.put(
-          LineViewManager.REACT_CLASS, ModuleSpec.viewManagerSpec(() -> new LineViewManager()));
+          LineViewManager.REACT_CLASS,
+          ModuleSpec.viewManagerSpec(
+              new Provider<NativeModule>() {
+                @Override
+                public NativeModule get() {
+                  return new LineViewManager();
+                }
+              }));
       specs.put(
-          RectViewManager.REACT_CLASS, ModuleSpec.viewManagerSpec(() -> new RectViewManager()));
+          RectViewManager.REACT_CLASS,
+          ModuleSpec.viewManagerSpec(
+              new Provider<NativeModule>() {
+                @Override
+                public NativeModule get() {
+                  return new RectViewManager();
+                }
+              }));
       specs.put(
-          TextViewManager.REACT_CLASS, ModuleSpec.viewManagerSpec(() -> new TextViewManager()));
+          TextViewManager.REACT_CLASS,
+          ModuleSpec.viewManagerSpec(
+              new Provider<NativeModule>() {
+                @Override
+                public NativeModule get() {
+                  return new TextViewManager();
+                }
+              }));
       specs.put(
-          TSpanViewManager.REACT_CLASS, ModuleSpec.viewManagerSpec(() -> new TSpanViewManager()));
+          TSpanViewManager.REACT_CLASS,
+          ModuleSpec.viewManagerSpec(
+              new Provider<NativeModule>() {
+                @Override
+                public NativeModule get() {
+                  return new TSpanViewManager();
+                }
+              }));
       specs.put(
           TextPathViewManager.REACT_CLASS,
-          ModuleSpec.viewManagerSpec(() -> new TextPathViewManager()));
+          ModuleSpec.viewManagerSpec(
+              new Provider<NativeModule>() {
+                @Override
+                public NativeModule get() {
+                  return new TextPathViewManager();
+                }
+              }));
       specs.put(
-          ImageViewManager.REACT_CLASS, ModuleSpec.viewManagerSpec(() -> new ImageViewManager()));
+          ImageViewManager.REACT_CLASS,
+          ModuleSpec.viewManagerSpec(
+              new Provider<NativeModule>() {
+                @Override
+                public NativeModule get() {
+                  return new ImageViewManager();
+                }
+              }));
       specs.put(
           ClipPathViewManager.REACT_CLASS,
-          ModuleSpec.viewManagerSpec(() -> new ClipPathViewManager()));
+          ModuleSpec.viewManagerSpec(
+              new Provider<NativeModule>() {
+                @Override
+                public NativeModule get() {
+                  return new ClipPathViewManager();
+                }
+              }));
       specs.put(
-          DefsViewManager.REACT_CLASS, ModuleSpec.viewManagerSpec(() -> new DefsViewManager()));
-      specs.put(UseViewManager.REACT_CLASS, ModuleSpec.viewManagerSpec(() -> new UseViewManager()));
-      specs.put(SymbolManager.REACT_CLASS, ModuleSpec.viewManagerSpec(() -> new SymbolManager()));
+          DefsViewManager.REACT_CLASS,
+          ModuleSpec.viewManagerSpec(
+              new Provider<NativeModule>() {
+                @Override
+                public NativeModule get() {
+                  return new DefsViewManager();
+                }
+              }));
+      specs.put(
+          UseViewManager.REACT_CLASS,
+          ModuleSpec.viewManagerSpec(
+              new Provider<NativeModule>() {
+                @Override
+                public NativeModule get() {
+                  return new UseViewManager();
+                }
+              }));
+      specs.put(
+          SymbolManager.REACT_CLASS,
+          ModuleSpec.viewManagerSpec(
+              new Provider<NativeModule>() {
+                @Override
+                public NativeModule get() {
+                  return new SymbolManager();
+                }
+              }));
       specs.put(
           LinearGradientManager.REACT_CLASS,
-          ModuleSpec.viewManagerSpec(() -> new LinearGradientManager()));
+          ModuleSpec.viewManagerSpec(
+              new Provider<NativeModule>() {
+                @Override
+                public NativeModule get() {
+                  return new LinearGradientManager();
+                }
+              }));
       specs.put(
           RadialGradientManager.REACT_CLASS,
-          ModuleSpec.viewManagerSpec(() -> new RadialGradientManager()));
-      specs.put(PatternManager.REACT_CLASS, ModuleSpec.viewManagerSpec(() -> new PatternManager()));
-      specs.put(MaskManager.REACT_CLASS, ModuleSpec.viewManagerSpec(() -> new MaskManager()));
+          ModuleSpec.viewManagerSpec(
+              new Provider<NativeModule>() {
+                @Override
+                public NativeModule get() {
+                  return new RadialGradientManager();
+                }
+              }));
+      specs.put(
+          PatternManager.REACT_CLASS,
+          ModuleSpec.viewManagerSpec(
+              new Provider<NativeModule>() {
+                @Override
+                public NativeModule get() {
+                  return new PatternManager();
+                }
+              }));
+      specs.put(
+          MaskManager.REACT_CLASS,
+          ModuleSpec.viewManagerSpec(
+              new Provider<NativeModule>() {
+                @Override
+                public NativeModule get() {
+                  return new MaskManager();
+                }
+              }));
       specs.put(
           ForeignObjectManager.REACT_CLASS,
-          ModuleSpec.viewManagerSpec(() -> new ForeignObjectManager()));
-      specs.put(MarkerManager.REACT_CLASS, ModuleSpec.viewManagerSpec(() -> new MarkerManager()));
-      specs.put(SvgViewManager.REACT_CLASS, ModuleSpec.viewManagerSpec(() -> new SvgViewManager()));
+          ModuleSpec.viewManagerSpec(
+              new Provider<NativeModule>() {
+                @Override
+                public NativeModule get() {
+                  return new ForeignObjectManager();
+                }
+              }));
+      specs.put(
+          MarkerManager.REACT_CLASS,
+          ModuleSpec.viewManagerSpec(
+              new Provider<NativeModule>() {
+                @Override
+                public NativeModule get() {
+                  return new MarkerManager();
+                }
+              }));
+      specs.put(
+          SvgViewManager.REACT_CLASS,
+          ModuleSpec.viewManagerSpec(
+              new Provider<NativeModule>() {
+                @Override
+                public NativeModule get() {
+                  return new SvgViewManager();
+                }
+              }));
       mViewManagers = specs;
     }
     return mViewManagers;
@@ -93,8 +240,8 @@ public class SvgPackage extends TurboReactPackage implements ViewManagerOnDemand
 
   /** {@inheritDoc} */
   @Override
-  public Collection<String> getViewManagerNames(ReactApplicationContext reactContext) {
-    return getViewManagersMap(reactContext).keySet();
+  public List<String> getViewManagerNames(ReactApplicationContext reactContext) {
+    return (List<String>) getViewManagersMap(reactContext).keySet();
   }
 
   @Override
@@ -131,30 +278,33 @@ public class SvgPackage extends TurboReactPackage implements ViewManagerOnDemand
     } catch (ClassNotFoundException e) {
       // ReactModuleSpecProcessor does not run at build-time. Create this ReactModuleInfoProvider by
       // hand.
-      return () -> {
-        final Map<String, ReactModuleInfo> reactModuleInfoMap = new HashMap<>();
+      return new ReactModuleInfoProvider() {
+        @Override
+        public Map<String, ReactModuleInfo> getReactModuleInfos() {
+          final Map<String, ReactModuleInfo> reactModuleInfoMap = new HashMap<>();
 
-        Class<? extends NativeModule>[] moduleList =
-            new Class[] {
-              SvgViewModule.class, RNSVGRenderableManager.class,
-            };
+          Class<? extends NativeModule>[] moduleList =
+              new Class[] {
+                SvgViewModule.class, RNSVGRenderableManager.class,
+              };
 
-        for (Class<? extends NativeModule> moduleClass : moduleList) {
-          ReactModule reactModule = moduleClass.getAnnotation(ReactModule.class);
+          for (Class<? extends NativeModule> moduleClass : moduleList) {
+            ReactModule reactModule = moduleClass.getAnnotation(ReactModule.class);
 
-          reactModuleInfoMap.put(
-              reactModule.name(),
-              new ReactModuleInfo(
-                  reactModule.name(),
-                  moduleClass.getName(),
-                  reactModule.canOverrideExistingModule(),
-                  reactModule.needsEagerInit(),
-                  reactModule.hasConstants(),
-                  reactModule.isCxxModule(),
-                  TurboModule.class.isAssignableFrom(moduleClass)));
+            reactModuleInfoMap.put(
+                reactModule.name(),
+                new ReactModuleInfo(
+                    reactModule.name(),
+                    moduleClass.getName(),
+                    reactModule.canOverrideExistingModule(),
+                    reactModule.needsEagerInit(),
+                    reactModule.hasConstants(),
+                    reactModule.isCxxModule(),
+                    TurboModule.class.isAssignableFrom(moduleClass)));
+          }
+
+          return reactModuleInfoMap;
         }
-
-        return reactModuleInfoMap;
       };
     } catch (InstantiationException | IllegalAccessException e) {
       throw new RuntimeException(

--- a/android/src/main/java/com/horcrux/svg/SvgViewManager.java
+++ b/android/src/main/java/com/horcrux/svg/SvgViewManager.java
@@ -8,10 +8,11 @@
 
 package com.horcrux.svg;
 
+import android.graphics.Rect;
 import android.util.SparseArray;
 import com.facebook.react.bridge.Dynamic;
-import com.facebook.react.bridge.DynamicFromObject;
 import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.uimanager.PixelUtil;
 import com.facebook.react.uimanager.PointerEvents;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.ViewManagerDelegate;
@@ -302,8 +303,25 @@ class SvgViewManager extends ReactViewManager
   }
 
   @Override
-  public void setHitSlop(SvgView view, @Nullable ReadableMap value) {
-    super.setHitSlop(view, new DynamicFromObject(value));
+  public void setHitSlop(SvgView view, @Nullable ReadableMap hitSlopMap) {
+    // we don't call super here since its signature changed in RN 0.69 and we want backwards
+    // compatibility
+    if (hitSlopMap != null) {
+      view.setHitSlopRect(
+          new Rect(
+              hitSlopMap.hasKey("left")
+                  ? (int) PixelUtil.toPixelFromDIP(hitSlopMap.getDouble("left"))
+                  : 0,
+              hitSlopMap.hasKey("top")
+                  ? (int) PixelUtil.toPixelFromDIP(hitSlopMap.getDouble("top"))
+                  : 0,
+              hitSlopMap.hasKey("right")
+                  ? (int) PixelUtil.toPixelFromDIP(hitSlopMap.getDouble("right"))
+                  : 0,
+              hitSlopMap.hasKey("bottom")
+                  ? (int) PixelUtil.toPixelFromDIP(hitSlopMap.getDouble("bottom"))
+                  : 0));
+    }
   }
 
   @Override

--- a/apple/RNSVGRenderableModule.mm
+++ b/apple/RNSVGRenderableModule.mm
@@ -20,7 +20,10 @@
 
 RCT_EXPORT_MODULE()
 
+#ifdef RN_FABRIC_ENABLED
 @synthesize viewRegistry_DEPRECATED = _viewRegistry_DEPRECATED;
+#endif // RN_FABRIC_ENABLED
+@synthesize bridge = _bridge;
 
 RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(isPointInFill : (nonnull NSNumber *)reactTag options : (NSDictionary *)options)
 {
@@ -193,9 +196,15 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(getScreenCTM : (nonnull NSNumber *)reactT
 - (RNSVGPlatformView *)getRenderableView:(NSNumber *)reactTag
 {
   __block RNSVGPlatformView *view;
+#ifdef RN_FABRIC_ENABLED
   dispatch_sync(dispatch_get_main_queue(), ^{
     view = [self.viewRegistry_DEPRECATED viewForReactTag:reactTag];
   });
+#else
+  dispatch_sync(dispatch_get_main_queue(), ^{
+    view = [self.bridge.uiManager viewForReactTag:reactTag];
+  });
+#endif // RN_FABRIC_ENABLED
   return view;
 }
 

--- a/apple/RNSVGSvgViewModule.mm
+++ b/apple/RNSVGSvgViewModule.mm
@@ -16,7 +16,9 @@
 
 RCT_EXPORT_MODULE()
 
+#ifdef RN_FABRIC_ENABLED
 @synthesize viewRegistry_DEPRECATED = _viewRegistry_DEPRECATED;
+#endif // RN_FABRIC_ENABLED
 @synthesize bridge = _bridge;
 
 - (void)toDataURL:(nonnull NSNumber *)reactTag
@@ -25,8 +27,14 @@ RCT_EXPORT_MODULE()
           attempt:(int)attempt
 {
   void (^block)(void) = ^{
+#ifdef RN_FABRIC_ENABLED
     [self.viewRegistry_DEPRECATED addUIBlock:^(RCTViewRegistry *viewRegistry) {
       __kindof RNSVGPlatformView *view = [viewRegistry viewForReactTag:reactTag];
+#else
+    [self.bridge.uiManager
+        addUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber *, RNSVGPlatformView *> *viewRegistry) {
+          __kindof RNSVGPlatformView *view = [uiManager viewForReactTag:reactTag];
+#endif // RN_FABRIC_ENABLED
       NSString *b64;
       if ([view isKindOfClass:[RNSVGSvgView class]]) {
         RNSVGSvgView *svg = view;


### PR DESCRIPTION
PR restoring backwards compatibility due to braking changes in method signatures of `getViewManagerNames` and `setHitSlop`, lambda expression being available for RN > 0.64(?). Since `viewRegistry_DEPRECATED` is available from RN 0.65, and its `addUIBlock` method is available from RN 0.69, and both those things are only really needed on new architecture, we use them only there and stick to the old impl for old arch.