### PR TITLE
chore: bump supported RN version for Fabric

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,8 @@ expo install react-native-svg
 
 | react-native-svg | react-native |
 | ---------------- | ------------ |
-| 13.0.0+          | 0.69.0+      |
+| >=13.0.0         | 0.69.0+      |
+| >=13.6.0         | 0.70.0+      |
 
 ## Troubleshooting
 


### PR DESCRIPTION
PR bumping supported RN version for Fabric since it changed due to https://github.com/software-mansion/react-native-svg/pull/1847 having custom cpp state with linking working only from RN `0.70`