### PR TITLE
fix: Call onLoad prop in SvgCssUri

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ react-native run-android
 #### Pre RN 0.68
 
 4. Scroll to the bottom until you find:
+
    ```xml
    <ImportGroup Label="ExtensionTargets">
    ```

--- a/USAGE.md
+++ b/USAGE.md
@@ -92,7 +92,7 @@ If remote SVG file contains CSS in `<style>` element, use `SvgCssUri`:
 ```jsx
 import * as React from 'react';
 import { ActivityIndicator, View, StyleSheet } from 'react-native';
-import { SvgUri } from 'react-native-svg';
+import { SvgCssUri } from 'react-native-svg';
 export default function TestComponent() {
   const [loading, setLoading] = React.useState(true);
   const onError = (e: Error) => {
@@ -105,7 +105,7 @@ export default function TestComponent() {
   };
   return (
     <>
-      <SvgUri
+      <SvgCssUri
         width="100"
         height="100"
         uri="https://dev.w3.org/SVG/tools/svgweb/samples/svg-files/ruby.svg"

--- a/src/css.tsx
+++ b/src/css.tsx
@@ -695,11 +695,18 @@ export function SvgCss(props: XmlProps) {
 }
 
 export function SvgCssUri(props: UriProps) {
-  const { uri, onError = err } = props;
+  const { uri, onError = err, onLoad } = props;
   const [xml, setXml] = useState<string | null>(null);
   useEffect(() => {
-    uri ? fetchText(uri).then(setXml).catch(onError) : setXml(null);
-  }, [onError, uri]);
+    uri
+      ? fetchText(uri)
+          .then((data) => {
+            setXml(data);
+            onLoad?.();
+          })
+          .catch(onError)
+      : setXml(null);
+  }, [onError, uri, onLoad]);
   return <SvgCss xml={xml} override={props} />;
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Addresses issue #1893.
SvgCssUri calls `onLoad` if it's passed, just like in PR #1817 (with SvgUri).
Fixed mistake in `USAGE.md`.
Change in `README.md` caused by running `yarn format-js` (prettier).

## Test Plan

Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

### What's required for testing (prerequisites)?
N/A

### What are the steps to reproduce (after prerequisites)?
N/A

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [ ] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
