### PR TITLE
fix: fill/stroke setters and implement currentColor on Windows

### DIFF
--- a/windows/RNSVG/RenderableView.h
+++ b/windows/RNSVG/RenderableView.h
@@ -89,6 +89,8 @@ struct RenderableView : RenderableViewT<RenderableView> {
       Microsoft::Graphics::Canvas::Geometry::CanvasLineJoin::Miter};
   Microsoft::Graphics::Canvas::Geometry::CanvasFilledRegionDetermination m_fillRule{
       Microsoft::Graphics::Canvas::Geometry::CanvasFilledRegionDetermination::Winding};
+
+  void SetColor(const Microsoft::ReactNative::JSValueObject &propValue, Windows::UI::Color fallbackColor, std::string propName);
 };
 } // namespace winrt::RNSVG::implementation
 

--- a/windows/RNSVG/SvgView.cpp
+++ b/windows/RNSVG/SvgView.cpp
@@ -81,6 +81,8 @@ void SvgView::UpdateProperties(IJSValueReader const &reader, bool forceUpdate, b
         m_align = Utils::JSValueAsString(propertyValue);
       } else if (propertyName == "meetOrSlice") {
         m_meetOrSlice = Utils::GetMeetOrSlice(propertyValue);
+      } else if (propertyName == "color") {
+        m_currentColor = Utils::JSValueAsColor(propertyValue);
       }
     }
 

--- a/windows/RNSVG/SvgView.h
+++ b/windows/RNSVG/SvgView.h
@@ -22,6 +22,8 @@ struct SvgView : SvgViewT<SvgView> {
 
   float SvgScale() { return m_scale; }
 
+  Windows::UI::Color CurrentColor() { return m_currentColor; }
+
   Windows::Foundation::Collections::IMap<hstring, RNSVG::IRenderable> Templates() {
     return m_templates;
   }
@@ -78,6 +80,7 @@ struct SvgView : SvgViewT<SvgView> {
   RNSVG::SVGLength m_height{};
   std::string m_align{""};
   RNSVG::MeetOrSlice m_meetOrSlice{RNSVG::MeetOrSlice::Meet};
+  Windows::UI::Color m_currentColor{Windows::UI::Colors::Black()};
 
   Windows::Foundation::Collections::IMap<hstring, RNSVG::IRenderable> m_templates{
       winrt::single_threaded_map<hstring, RNSVG::IRenderable>()};

--- a/windows/RNSVG/SvgViewManager.cpp
+++ b/windows/RNSVG/SvgViewManager.cpp
@@ -43,6 +43,7 @@ IMapView<hstring, ViewManagerPropertyType> SvgViewManager::NativeProps() {
 
   nativeProps.Insert(L"height", ViewManagerPropertyType::Number);
   nativeProps.Insert(L"width", ViewManagerPropertyType::Number);
+  nativeProps.Insert(L"color", ViewManagerPropertyType::Color);
 
   // viewBox
   nativeProps.Insert(L"minX", ViewManagerPropertyType::Number);

--- a/windows/RNSVG/Utils.h
+++ b/windows/RNSVG/Utils.h
@@ -325,7 +325,9 @@ struct Utils {
       ICanvasResourceCreator const &resourceCreator) {
     Brushes::ICanvasBrush brush{nullptr};
     if (root && brushId != L"") {
-      if (auto const &brushView{root.Brushes().TryLookup(brushId)}) {
+      if (brushId == L"currentColor") {
+        brush = Brushes::CanvasSolidColorBrush(resourceCreator, root.CurrentColor());
+      } else if (auto const &brushView{root.Brushes().TryLookup(brushId)}) {
         brushView.SetBounds(geometry.ComputeBounds());
         brush = brushView.Brush();
       }

--- a/windows/RNSVG/Views.idl
+++ b/windows/RNSVG/Views.idl
@@ -26,6 +26,7 @@ namespace RNSVG
 
     Single SvgScale{ get; };
     GroupView Group;
+    Windows.UI.Color CurrentColor{ get; };
     Microsoft.Graphics.Canvas.UI.Xaml.CanvasControl Canvas{ get; };
     Windows.Foundation.Collections.IMap<String, IRenderable> Templates{ get; };
     Windows.Foundation.Collections.IMap<String, BrushView> Brushes{ get; };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Starting in v13, the switch to Fabric changed the color prop values sent to the native side, so all colors on Windows were defaulting to black. Updated the property setters to handle that change and also added support for the SVG color prop / "currentColor". 

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ❌     |
| Windows |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [ ] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
