### PR TITLE
refactor: remove circular dependency

### DIFF
--- a/src/elements/Circle.tsx
+++ b/src/elements/Circle.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { extract, stringifyPropsForFabric } from '../lib/extract/extractProps';
 import { CommonPathProps, NumberProp } from '../lib/extract/types';
 import Shape from './Shape';
-import { RNSVGCircle } from '../ReactNativeSVG';
+import RNSVGCircle from '../fabric/CircleNativeComponent';
 import { NativeMethods } from 'react-native';
 
 export interface CircleProps extends CommonPathProps {

--- a/src/elements/ClipPath.tsx
+++ b/src/elements/ClipPath.tsx
@@ -1,7 +1,7 @@
 import React, { ReactNode } from 'react';
 import { extract } from '../lib/extract/extractProps';
 import Shape from './Shape';
-import { RNSVGClipPath } from '../ReactNativeSVG';
+import RNSVGClipPath from '../fabric/ClipPathNativeComponent';
 
 export interface ClipPathProps {
   children?: ReactNode;

--- a/src/elements/Defs.tsx
+++ b/src/elements/Defs.tsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { RNSVGDefs } from '../ReactNativeSVG';
+import RNSVGDefs from '../fabric/DefsNativeComponent';
 
 export default class Defs extends Component<React.PropsWithChildren<{}>> {
   static displayName = 'Defs';

--- a/src/elements/Ellipse.tsx
+++ b/src/elements/Ellipse.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { extract, stringifyPropsForFabric } from '../lib/extract/extractProps';
 import { CommonPathProps, NumberProp } from '../lib/extract/types';
 import Shape from './Shape';
-import { RNSVGEllipse } from '../ReactNativeSVG';
+import RNSVGEllipse from '../fabric/EllipseNativeComponent';
 import { NativeMethods } from 'react-native';
 
 export interface EllipseProps extends CommonPathProps {

--- a/src/elements/ForeignObject.tsx
+++ b/src/elements/ForeignObject.tsx
@@ -5,7 +5,7 @@ import {
 } from '../lib/extract/extractProps';
 import { NumberProp } from '../lib/extract/types';
 import G from './G';
-import { RNSVGForeignObject } from '../ReactNativeSVG';
+import RNSVGForeignObject from '../fabric/ForeignObjectNativeComponent';
 import { NativeMethods } from 'react-native';
 
 export interface ForeignObjectProps {

--- a/src/elements/G.tsx
+++ b/src/elements/G.tsx
@@ -9,7 +9,7 @@ import {
   TransformProps,
 } from '../lib/extract/types';
 import Shape from './Shape';
-import { RNSVGGroup } from '../ReactNativeSVG';
+import RNSVGGroup from '../fabric/GroupNativeComponent';
 import { NativeMethods } from 'react-native';
 
 export interface GProps extends CommonPathProps, FontProps {

--- a/src/elements/Image.tsx
+++ b/src/elements/Image.tsx
@@ -14,7 +14,7 @@ import {
   TouchableProps,
 } from '../lib/extract/types';
 import Shape from './Shape';
-import { RNSVGImage } from '../ReactNativeSVG';
+import RNSVGImage from '../fabric/ImageNativeComponent';
 
 const spacesRegExp = /\s+/;
 

--- a/src/elements/Line.tsx
+++ b/src/elements/Line.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { extract, stringifyPropsForFabric } from '../lib/extract/extractProps';
 import { CommonPathProps, NumberProp } from '../lib/extract/types';
 import Shape from './Shape';
-import { RNSVGLine } from '../ReactNativeSVG';
+import RNSVGLine from '../fabric/LineNativeComponent';
 import { NativeMethods } from 'react-native';
 
 export interface LineProps extends CommonPathProps {

--- a/src/elements/LinearGradient.tsx
+++ b/src/elements/LinearGradient.tsx
@@ -2,7 +2,7 @@ import React, { ReactElement } from 'react';
 import extractGradient from '../lib/extract/extractGradient';
 import { NumberProp, TransformProps, Units } from '../lib/extract/types';
 import Shape from './Shape';
-import { RNSVGLinearGradient } from '../ReactNativeSVG';
+import RNSVGLinearGradient from '../fabric/LinearGradientNativeComponent';
 import { stringifyPropsForFabric } from '../lib/extract/extractProps';
 import { NativeMethods } from 'react-native';
 

--- a/src/elements/Marker.tsx
+++ b/src/elements/Marker.tsx
@@ -2,7 +2,7 @@ import React, { ReactNode } from 'react';
 import extractViewBox from '../lib/extract/extractViewBox';
 import { NumberProp } from '../lib/extract/types';
 import Shape from './Shape';
-import { RNSVGMarker } from '../ReactNativeSVG';
+import RNSVGMarker from '../fabric/MarkerNativeComponent';
 import { stringifyPropsForFabric } from '../lib/extract/extractProps';
 import { NativeMethods } from 'react-native';
 

--- a/src/elements/Mask.tsx
+++ b/src/elements/Mask.tsx
@@ -6,7 +6,7 @@ import {
 import { CommonPathProps, NumberProp } from '../lib/extract/types';
 import units from '../lib/units';
 import Shape from './Shape';
-import { RNSVGMask } from '../ReactNativeSVG';
+import RNSVGMask from '../fabric/MaskNativeComponent';
 import { NativeMethods } from 'react-native';
 
 export type TMaskUnits = 'userSpaceOnUse' | 'objectBoundingBox';

--- a/src/elements/Path.tsx
+++ b/src/elements/Path.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { extract } from '../lib/extract/extractProps';
 import Shape from './Shape';
-import { RNSVGPath } from '../ReactNativeSVG';
+import RNSVGPath from '../fabric/PathNativeComponent';
 import { CommonPathProps, NumberProp } from '../lib/extract/types';
 import { NativeMethods } from 'react-native';
 

--- a/src/elements/Pattern.tsx
+++ b/src/elements/Pattern.tsx
@@ -4,7 +4,7 @@ import extractViewBox from '../lib/extract/extractViewBox';
 import { NumberProp, TransformProps, Units } from '../lib/extract/types';
 import units from '../lib/units';
 import Shape from './Shape';
-import { RNSVGPattern } from '../ReactNativeSVG';
+import RNSVGPattern from '../fabric/PatternNativeComponent';
 import { stringifyPropsForFabric } from '../lib/extract/extractProps';
 import { NativeMethods } from 'react-native';
 

--- a/src/elements/RadialGradient.tsx
+++ b/src/elements/RadialGradient.tsx
@@ -2,7 +2,7 @@ import React, { ReactElement } from 'react';
 import extractGradient from '../lib/extract/extractGradient';
 import { NumberProp, TransformProps, Units } from '../lib/extract/types';
 import Shape from './Shape';
-import { RNSVGRadialGradient } from '../ReactNativeSVG';
+import RNSVGRadialGradient from '../fabric/RadialGradientNativeComponent';
 import { stringifyPropsForFabric } from '../lib/extract/extractProps';
 import { NativeMethods } from 'react-native';
 

--- a/src/elements/Rect.tsx
+++ b/src/elements/Rect.tsx
@@ -5,7 +5,7 @@ import {
 } from '../lib/extract/extractProps';
 import { CommonPathProps, NumberProp } from '../lib/extract/types';
 import Shape from './Shape';
-import { RNSVGRect } from '../ReactNativeSVG';
+import RNSVGRect from '../fabric/RectNativeComponent';
 import { NativeMethods } from 'react-native';
 
 export interface RectProps extends CommonPathProps {

--- a/src/elements/Svg.tsx
+++ b/src/elements/Svg.tsx
@@ -21,7 +21,8 @@ import extractResponder from '../lib/extract/extractResponder';
 import extractViewBox from '../lib/extract/extractViewBox';
 import Shape from './Shape';
 import G, { GProps } from './G';
-import { RNSVGSvgAndroid, RNSVGSvgIOS } from '../ReactNativeSVG';
+import RNSVGSvgAndroid from '../fabric/AndroidSvgViewNativeComponent';
+import RNSVGSvgIOS from '../fabric/IOSSvgViewNativeComponent';
 import type { Spec } from '../fabric/NativeSvgViewModule';
 
 const styles = StyleSheet.create({

--- a/src/elements/Symbol.tsx
+++ b/src/elements/Symbol.tsx
@@ -1,7 +1,7 @@
 import React, { ReactNode } from 'react';
 import extractViewBox from '../lib/extract/extractViewBox';
 import Shape from './Shape';
-import { RNSVGSymbol } from '../ReactNativeSVG';
+import RNSVGSymbol from '../fabric/SymbolNativeComponent';
 import { NumberProp } from '../lib/extract/types';
 import { NativeMethods } from 'react-native';
 

--- a/src/elements/TSpan.tsx
+++ b/src/elements/TSpan.tsx
@@ -12,7 +12,7 @@ import {
   NumberProp,
   TransformProps,
 } from '../lib/extract/types';
-import { RNSVGTSpan } from '../ReactNativeSVG';
+import RNSVGTSpan from '../fabric/TSpanNativeComponent';
 
 export interface TSpanProps extends CommonPathProps, FontProps {
   children?: TextChild;

--- a/src/elements/Text.tsx
+++ b/src/elements/Text.tsx
@@ -12,7 +12,7 @@ import {
 import { pickNotNil } from '../lib/util';
 import Shape from './Shape';
 import './TSpan';
-import { RNSVGText } from '../ReactNativeSVG';
+import RNSVGText from '../fabric/TextNativeComponent';
 
 export interface TextProps extends TextSpecificProps {
   children?: ReactNode;

--- a/src/elements/TextPath.tsx
+++ b/src/elements/TextPath.tsx
@@ -14,7 +14,7 @@ import extractText, { TextChild } from '../lib/extract/extractText';
 import { idPattern, pickNotNil } from '../lib/util';
 import Shape from './Shape';
 import TSpan from './TSpan';
-import { RNSVGTextPath } from '../ReactNativeSVG';
+import RNSVGTextPath from '../fabric/TextPathNativeComponent';
 
 export interface TextPathProps extends TextSpecificProps {
   children?: TextChild;

--- a/src/elements/Use.tsx
+++ b/src/elements/Use.tsx
@@ -6,7 +6,7 @@ import {
 import { CommonPathProps, NumberProp } from '../lib/extract/types';
 import { idPattern } from '../lib/util';
 import Shape from './Shape';
-import { RNSVGUse } from '../ReactNativeSVG';
+import RNSVGUse from '../fabric/UseNativeComponent';
 import { NativeMethods } from 'react-native';
 
 export interface UseProps extends CommonPathProps {


### PR DESCRIPTION
# Summary

When importing the library we have a lot of React Native warning about circular dependency. This PR aims to fix those warnings.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

- [x] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [ ] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
