### PR TITLE
feat(windows): add clipPath and touch events

### DIFF
--- a/windows/RNSVG/BrushView.cpp
+++ b/windows/RNSVG/BrushView.cpp
@@ -16,9 +16,11 @@ void BrushView::SetBounds(Windows::Foundation::Rect const &rect) {
 }
 
 void BrushView::Unload() {
-  m_brush.Close();
-  m_brush = nullptr;
-
+  if (m_brush) {
+    m_brush.Close();
+    m_brush = nullptr;
+  }
+  
   __super::Unload();
 }
 } // namespace winrt::RNSVG::implementation

--- a/windows/RNSVG/ClipPathView.cpp
+++ b/windows/RNSVG/ClipPathView.cpp
@@ -2,23 +2,9 @@
 #include "ClipPathView.h"
 #include "ClipPathView.g.cpp"
 
-#include "Utils.h"
-
 using namespace winrt;
 using namespace Microsoft::Graphics::Canvas;
 using namespace Microsoft::ReactNative;
 
 namespace winrt::RNSVG::implementation {
-void ClipPathView::UpdateProperties(IJSValueReader const &reader, bool forceUpdate, bool invalidate) {
-  const JSValueObject &propertyMap{JSValue::ReadObjectFrom(reader)};
-
-  for (auto const &pair : propertyMap) {
-    auto const &propertyName{pair.first};
-    auto const &propertyValue{pair.second};
-
-  }
-
-  __super::UpdateProperties(reader, forceUpdate, invalidate);
-}
-
 } // namespace winrt::RNSVG::implementation

--- a/windows/RNSVG/ClipPathView.cpp
+++ b/windows/RNSVG/ClipPathView.cpp
@@ -1,0 +1,24 @@
+#include "pch.h"
+#include "ClipPathView.h"
+#include "ClipPathView.g.cpp"
+
+#include "Utils.h"
+
+using namespace winrt;
+using namespace Microsoft::Graphics::Canvas;
+using namespace Microsoft::ReactNative;
+
+namespace winrt::RNSVG::implementation {
+void ClipPathView::UpdateProperties(IJSValueReader const &reader, bool forceUpdate, bool invalidate) {
+  const JSValueObject &propertyMap{JSValue::ReadObjectFrom(reader)};
+
+  for (auto const &pair : propertyMap) {
+    auto const &propertyName{pair.first};
+    auto const &propertyValue{pair.second};
+
+  }
+
+  __super::UpdateProperties(reader, forceUpdate, invalidate);
+}
+
+} // namespace winrt::RNSVG::implementation

--- a/windows/RNSVG/ClipPathView.h
+++ b/windows/RNSVG/ClipPathView.h
@@ -1,0 +1,20 @@
+#pragma once
+#include "ClipPathView.g.h"
+#include "GroupView.h"
+
+namespace winrt::RNSVG::implementation {
+struct ClipPathView : ClipPathViewT<ClipPathView, RNSVG::implementation::GroupView> {
+ public:
+  ClipPathView() = default;
+
+  // RenderableView
+  void UpdateProperties(Microsoft::ReactNative::IJSValueReader const &reader, bool forceUpdate, bool invalidate);
+  void Render(
+      Microsoft::Graphics::Canvas::UI::Xaml::CanvasControl const & /*canvas*/,
+      Microsoft::Graphics::Canvas::CanvasDrawingSession const & /*session*/){};
+};
+} // namespace winrt::RNSVG::implementation
+
+namespace winrt::RNSVG::factory_implementation {
+struct ClipPathView : ClipPathViewT<ClipPathView, implementation::ClipPathView> {};
+} // namespace winrt::RNSVG::factory_implementation

--- a/windows/RNSVG/ClipPathView.h
+++ b/windows/RNSVG/ClipPathView.h
@@ -8,7 +8,6 @@ struct ClipPathView : ClipPathViewT<ClipPathView, RNSVG::implementation::GroupVi
   ClipPathView() = default;
 
   // RenderableView
-  void UpdateProperties(Microsoft::ReactNative::IJSValueReader const &reader, bool forceUpdate, bool invalidate);
   void Render(
       Microsoft::Graphics::Canvas::UI::Xaml::CanvasControl const & /*canvas*/,
       Microsoft::Graphics::Canvas::CanvasDrawingSession const & /*session*/){};

--- a/windows/RNSVG/ClipPathViewManager.cpp
+++ b/windows/RNSVG/ClipPathViewManager.cpp
@@ -19,9 +19,6 @@ IMapView<hstring, ViewManagerPropertyType> ClipPathViewManager::NativeProps() {
     nativeProps.Insert(prop.Key(), prop.Value());
   }
 
-  nativeProps.Insert(L"x", ViewManagerPropertyType::String);
-  nativeProps.Insert(L"y", ViewManagerPropertyType::String);
-
   return nativeProps.GetView();
 }
 } // namespace winrt::RNSVG::implementation

--- a/windows/RNSVG/ClipPathViewManager.cpp
+++ b/windows/RNSVG/ClipPathViewManager.cpp
@@ -1,0 +1,27 @@
+#include "pch.h"
+#include "ClipPathViewManager.h"
+#include "ClipPathViewManager.g.cpp"
+
+using namespace winrt;
+using namespace Microsoft::ReactNative;
+
+namespace winrt::RNSVG::implementation {
+ClipPathViewManager::ClipPathViewManager() {
+  m_class = RNSVG::SVGClass::RNSVGClipPath;
+  m_name = L"RNSVGClipPath";
+}
+
+IMapView<hstring, ViewManagerPropertyType> ClipPathViewManager::NativeProps() {
+  auto const &parentProps{__super::NativeProps()};
+  auto const &nativeProps{winrt::single_threaded_map<hstring, ViewManagerPropertyType>()};
+
+  for (auto const &prop : parentProps) {
+    nativeProps.Insert(prop.Key(), prop.Value());
+  }
+
+  nativeProps.Insert(L"x", ViewManagerPropertyType::String);
+  nativeProps.Insert(L"y", ViewManagerPropertyType::String);
+
+  return nativeProps.GetView();
+}
+} // namespace winrt::RNSVG::implementation

--- a/windows/RNSVG/ClipPathViewManager.h
+++ b/windows/RNSVG/ClipPathViewManager.h
@@ -1,0 +1,16 @@
+#pragma once
+#include "ClipPathViewManager.g.h"
+#include "GroupViewManager.h"
+
+namespace winrt::RNSVG::implementation {
+struct ClipPathViewManager : ClipPathViewManagerT<ClipPathViewManager, RNSVG::implementation::GroupViewManager> {
+  ClipPathViewManager();
+
+  // IViewManagerWithNativeProperties
+  Windows::Foundation::Collections::IMapView<hstring, Microsoft::ReactNative::ViewManagerPropertyType> NativeProps();
+};
+} // namespace winrt::RNSVG::implementation
+
+namespace winrt::RNSVG::factory_implementation {
+struct ClipPathViewManager : ClipPathViewManagerT<ClipPathViewManager, implementation::ClipPathViewManager> {};
+} // namespace winrt::RNSVG::factory_implementation

--- a/windows/RNSVG/GroupView.cpp
+++ b/windows/RNSVG/GroupView.cpp
@@ -174,4 +174,31 @@ void GroupView::Unload() {
 
   __super::Unload();
 }
+
+winrt::RNSVG::IRenderable GroupView::HitTest(Windows::Foundation::Point const &point) {
+  RNSVG::IRenderable renderable{nullptr};
+  if (IsResponsible()) {
+    for (auto const &child : Children()) {
+      if (auto const &hit{child.HitTest(point)}) {
+        renderable = hit;
+      }
+    }
+    if (renderable && !renderable.IsResponsible()) {
+      renderable = *this;
+    } else if (!renderable){
+      if (!Geometry()) {
+        if (auto const &svgRoot{SvgRoot()}) {
+          CreateGeometry(svgRoot.Canvas());
+        }
+      }
+      if (Geometry()) {
+        auto const &bounds{Geometry().ComputeBounds()};
+        if (Windows::UI::Xaml::RectHelper::Contains(bounds, point)) {
+          renderable = *this;
+        }
+      }
+    }
+  }
+  return renderable;
+}
 } // namespace winrt::RNSVG::implementation

--- a/windows/RNSVG/GroupView.cpp
+++ b/windows/RNSVG/GroupView.cpp
@@ -105,6 +105,9 @@ void GroupView::CreateGeometry(UI::Xaml::CanvasControl const &canvas) {
   auto const &resourceCreator{canvas.try_as<ICanvasResourceCreator>()};
   std::vector<Geometry::CanvasGeometry> geometries;
   for (auto const &child : Children()) {
+    if (!child.Geometry()) {
+      child.CreateGeometry(canvas);
+    }
     geometries.push_back(child.Geometry());
   }
 
@@ -134,7 +137,9 @@ void GroupView::Render(UI::Xaml::CanvasControl const &canvas, CanvasDrawingSessi
     session.Transform(transform * SvgTransform());
   }
 
-  if (auto const &opacityLayer{session.CreateLayer(m_opacity)}) {
+  auto const &clipPathGeometry{ClipPathGeometry()};
+
+  if (auto const &opacityLayer{clipPathGeometry ? session.CreateLayer(m_opacity, clipPathGeometry) : session.CreateLayer(m_opacity)}) {
     if (Children().Size() == 0) {
       __super::Render(canvas, session);
     } else {

--- a/windows/RNSVG/GroupView.h
+++ b/windows/RNSVG/GroupView.h
@@ -40,6 +40,8 @@ struct GroupView : GroupViewT<GroupView, RNSVG::implementation::RenderableView> 
 
   virtual void Unload();
 
+  virtual RNSVG::IRenderable HitTest(Windows::Foundation::Point const &point);
+
  private:
   Microsoft::ReactNative::IReactContext m_reactContext{nullptr};
   Windows::Foundation::Collections::IVector<RNSVG::IRenderable> m_children{

--- a/windows/RNSVG/GroupViewManager.cpp
+++ b/windows/RNSVG/GroupViewManager.cpp
@@ -43,6 +43,10 @@ void GroupViewManager::AddView(FrameworkElement const &parent, UIElement const &
       groupView.Children().Append(childView);
       childView.MergeProperties(groupView);
 
+      if (childView.IsResponsible() && !groupView.IsResponsible()) {
+        groupView.IsResponsible(true);
+      }
+
       if (auto const &root{groupView.SvgRoot()}) {
         root.InvalidateCanvas();
       }

--- a/windows/RNSVG/ImageView.cpp
+++ b/windows/RNSVG/ImageView.cpp
@@ -104,7 +104,9 @@ void ImageView::Render(UI::Xaml::CanvasControl const &canvas, CanvasDrawingSessi
     transformEffect.TransformMatrix(Utils::GetViewBoxTransform(vbRect, elRect, m_align, m_meetOrSlice));
   }
 
-  if (auto const &opacityLayer{session.CreateLayer(m_opacity)}) {
+  auto const &clipPathGeometry{ClipPathGeometry()};
+
+  if (auto const &opacityLayer{clipPathGeometry ? session.CreateLayer(m_opacity, clipPathGeometry) : session.CreateLayer(m_opacity)}) {
     if (m_source.format == ImageSourceFormat::Bitmap && m_bitmap) {
       auto const &transform{session.Transform()};
       if (m_propSetMap[RNSVG::BaseProp::Matrix]) {

--- a/windows/RNSVG/PathView.cpp
+++ b/windows/RNSVG/PathView.cpp
@@ -41,7 +41,7 @@ void PathView::CreateGeometry(UI::Xaml::CanvasControl const &canvas) {
   auto const &resourceCreator{canvas.try_as<ICanvasResourceCreator>()};
   Svg::CanvasSvgDocument doc{resourceCreator};
   auto const &path{doc.CreatePathAttribute(m_segmentData, m_commands)};
-  Geometry(path.CreatePathGeometry());
+  Geometry(path.CreatePathGeometry(FillRule()));
 }
 
 void PathView::ParsePath() {

--- a/windows/RNSVG/RNSVG.vcxproj
+++ b/windows/RNSVG/RNSVG.vcxproj
@@ -122,12 +122,14 @@
     <ClInclude Include="BrushView.h" />
     <ClInclude Include="CircleView.h" />
     <ClInclude Include="CircleViewManager.h" />
+    <ClInclude Include="ClipPathView.h" />
     <ClInclude Include="DefsView.h" />
     <ClInclude Include="DefsViewManager.h" />
     <ClInclude Include="EllipseView.h" />
     <ClInclude Include="EllipseViewManager.h" />
     <ClInclude Include="GroupView.h" />
     <ClInclude Include="GroupViewManager.h" />
+    <ClInclude Include="ClipPathViewManager.h" />
     <ClInclude Include="ImageView.h" />
     <ClInclude Include="ImageViewManager.h" />
     <ClInclude Include="LinearGradientView.h" />
@@ -166,6 +168,8 @@
     <ClCompile Include="BrushView.cpp" />
     <ClCompile Include="CircleView.cpp" />
     <ClCompile Include="CircleViewManager.cpp" />
+    <ClCompile Include="ClipPathView.cpp" />
+    <ClCompile Include="ClipPathViewManager.cpp" />
     <ClCompile Include="DefsView.cpp" />
     <ClCompile Include="DefsViewManager.cpp" />
     <ClCompile Include="EllipseView.cpp" />

--- a/windows/RNSVG/RNSVG.vcxproj.filters
+++ b/windows/RNSVG/RNSVG.vcxproj.filters
@@ -124,6 +124,12 @@
     <ClCompile Include="RadialGradientViewManager.cpp">
       <Filter>ViewManagers\GroupViewManagers</Filter>
     </ClCompile>
+    <ClCompile Include="ClipPathViewManager.cpp">
+      <Filter>ViewManagers\GroupViewManagers</Filter>
+    </ClCompile>
+    <ClCompile Include="ClipPathView.cpp">
+      <Filter>Views\GroupViews</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h" />
@@ -239,6 +245,12 @@
     </ClInclude>
     <ClInclude Include="RadialGradientViewManager.h">
       <Filter>ViewManagers\GroupViewManagers</Filter>
+    </ClInclude>
+    <ClInclude Include="ClipPathViewManager.h">
+      <Filter>ViewManagers\GroupViewManagers</Filter>
+    </ClInclude>
+    <ClInclude Include="ClipPathView.h">
+      <Filter>Views\GroupViews</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/windows/RNSVG/ReactPackageProvider.cpp
+++ b/windows/RNSVG/ReactPackageProvider.cpp
@@ -21,6 +21,7 @@
 #include "LinearGradientViewManager.h"
 #include "RadialGradientViewManager.h"
 #include "PatternViewManager.h"
+#include "ClipPathViewManager.h"
 
 using namespace winrt::Microsoft::ReactNative;
 
@@ -45,6 +46,7 @@ namespace winrt::RNSVG::implementation
     packageBuilder.AddViewManager(L"LinearGradientViewManager", []() { return winrt::make<LinearGradientViewManager>(); });
     packageBuilder.AddViewManager(L"RadialGradientViewManager", []() { return winrt::make<RadialGradientViewManager>(); });
     packageBuilder.AddViewManager(L"PatternViewManager", []() { return winrt::make<PatternViewManager>(); });
+    packageBuilder.AddViewManager(L"ClipPathViewManager", []() { return winrt::make<ClipPathViewManager>(); });
   }
 
 } // namespace winrt::RNSVG::implementation

--- a/windows/RNSVG/RenderableView.cpp
+++ b/windows/RNSVG/RenderableView.cpp
@@ -189,6 +189,8 @@ void RenderableView::UpdateProperties(IJSValueReader const &reader, bool forceUp
       m_opacity = Utils::JSValueAsFloat(propertyValue, 1.0f);
     } else if (propertyName == "clipPath") {
       m_clipPathId = to_hstring(Utils::JSValueAsString(propertyValue));
+    }  else if (propertyName == "responsible") {
+      m_isResponsible = propertyValue.AsBoolean();
     }
 
     // forceUpdate = true means the property is being set on an element
@@ -352,6 +354,21 @@ void RenderableView::Unload() {
   m_propList.clear();
   m_propSetMap.clear();
   m_strokeDashArray.Clear();
+}
+
+RNSVG::IRenderable RenderableView::HitTest(Point const &point) {
+  if (m_geometry) {
+    bool strokeContainsPoint{false};
+    if (auto const &svgRoot{SvgRoot()}) {
+      float canvasDiagonal{Utils::GetCanvasDiagonal(svgRoot.Canvas().Size())};
+      float strokeWidth{Utils::GetAbsoluteLength(StrokeWidth(), canvasDiagonal)};
+      strokeContainsPoint = m_geometry.StrokeContainsPoint(point, strokeWidth);
+    }
+    if (m_geometry.FillContainsPoint(point) || strokeContainsPoint) {
+      return *this;
+    }
+  }
+  return nullptr;
 }
 
 void RenderableView::SetColor(const JSValueObject& propValue, Windows::UI::Color fallbackColor, std::string propName) {

--- a/windows/RNSVG/RenderableView.h
+++ b/windows/RNSVG/RenderableView.h
@@ -20,6 +20,9 @@ struct RenderableView : RenderableViewT<RenderableView> {
   hstring Id() { return m_id; }
   Numerics::float3x2 SvgTransform() { return m_transformMatrix; }
 
+  bool IsResponsible() { return m_isResponsible; }
+  void IsResponsible(bool isResponsible) { m_isResponsible = isResponsible; }
+
   hstring FillBrushId() { return m_fillBrushId; }
   Windows::UI::Color Fill() { return m_fill; }
   float FillOpacity() { return m_fillOpacity; }
@@ -46,6 +49,7 @@ struct RenderableView : RenderableViewT<RenderableView> {
   virtual void CreateResources(
       Microsoft::Graphics::Canvas::ICanvasResourceCreator const & /*resourceCreator*/,
       Microsoft::Graphics::Canvas::UI::CanvasCreateResourcesEventArgs const & /*args*/) { }
+  virtual RNSVG::IRenderable HitTest(Windows::Foundation::Point const &point);
 
  protected:
   float m_opacity{1.0f};
@@ -70,7 +74,8 @@ struct RenderableView : RenderableViewT<RenderableView> {
   Windows::UI::Xaml::FrameworkElement m_parent{nullptr};
   Microsoft::Graphics::Canvas::Geometry::CanvasGeometry m_geometry{nullptr};
   bool m_recreateResources{true};
-
+  bool m_isResponsible{false};
+  
   hstring m_id{L""};
   hstring m_clipPathId{L""};
   Numerics::float3x2 m_transformMatrix{Numerics::make_float3x2_rotation(0)};

--- a/windows/RNSVG/RenderableView.h
+++ b/windows/RNSVG/RenderableView.h
@@ -33,6 +33,7 @@ struct RenderableView : RenderableViewT<RenderableView> {
   Microsoft::Graphics::Canvas::Geometry::CanvasCapStyle StrokeLineCap() { return m_strokeLineCap; }
   Microsoft::Graphics::Canvas::Geometry::CanvasLineJoin StrokeLineJoin() { return m_strokeLineJoin; }
   Microsoft::Graphics::Canvas::Geometry::CanvasFilledRegionDetermination FillRule() { return m_fillRule; }
+  Microsoft::Graphics::Canvas::Geometry::CanvasGeometry ClipPathGeometry();
 
   virtual void UpdateProperties(Microsoft::ReactNative::IJSValueReader const &reader, bool forceUpdate = true, bool invalidate = true);
   virtual void CreateGeometry(Microsoft::Graphics::Canvas::UI::Xaml::CanvasControl const & /*canvas*/) {}
@@ -71,6 +72,7 @@ struct RenderableView : RenderableViewT<RenderableView> {
   bool m_recreateResources{true};
 
   hstring m_id{L""};
+  hstring m_clipPathId{L""};
   Numerics::float3x2 m_transformMatrix{Numerics::make_float3x2_rotation(0)};
   Windows::UI::Color m_fill{Windows::UI::Colors::Black()};
   Windows::UI::Color m_stroke{Windows::UI::Colors::Transparent()};

--- a/windows/RNSVG/RenderableViewManager.cpp
+++ b/windows/RNSVG/RenderableViewManager.cpp
@@ -66,6 +66,7 @@ IMapView<hstring, ViewManagerPropertyType> RenderableViewManager::NativeProps() 
   nativeProps.Insert(L"matrix", ViewManagerPropertyType::Array);
   nativeProps.Insert(L"opacity", ViewManagerPropertyType::Number);
   nativeProps.Insert(L"propList", ViewManagerPropertyType::Array);
+  nativeProps.Insert(L"clipPath", ViewManagerPropertyType::String);
 
   return nativeProps.GetView();
 }

--- a/windows/RNSVG/RenderableViewManager.cpp
+++ b/windows/RNSVG/RenderableViewManager.cpp
@@ -40,6 +40,8 @@ Windows::UI::Xaml::FrameworkElement RenderableViewManager::CreateView() {
       return winrt::RNSVG::RadialGradientView();
     case RNSVG::SVGClass::RNSVGPattern:
       return winrt::RNSVG::PatternView();
+    case RNSVG::SVGClass::RNSVGClipPath:
+      return winrt::RNSVG::ClipPathView();
   }
 
   throw hresult_not_implemented();

--- a/windows/RNSVG/RenderableViewManager.cpp
+++ b/windows/RNSVG/RenderableViewManager.cpp
@@ -67,6 +67,7 @@ IMapView<hstring, ViewManagerPropertyType> RenderableViewManager::NativeProps() 
   nativeProps.Insert(L"opacity", ViewManagerPropertyType::Number);
   nativeProps.Insert(L"propList", ViewManagerPropertyType::Array);
   nativeProps.Insert(L"clipPath", ViewManagerPropertyType::String);
+  nativeProps.Insert(L"responsible", ViewManagerPropertyType::Boolean);
 
   return nativeProps.GetView();
 }

--- a/windows/RNSVG/SvgView.cpp
+++ b/windows/RNSVG/SvgView.cpp
@@ -157,6 +157,12 @@ void SvgView::CreateResources(ICanvasResourceCreator const &resourceCreator, UI:
   }
 }
 
+void SvgView::CreateGeometry(UI::Xaml::CanvasControl const& canvas) {
+  if (m_group) {
+    m_group.CreateGeometry(canvas);
+  }
+}
+
 void SvgView::Canvas_CreateResources(UI::Xaml::CanvasControl const &sender, UI::CanvasCreateResourcesEventArgs const &args) {
   CreateResources(sender, args);
 }

--- a/windows/RNSVG/SvgView.cpp
+++ b/windows/RNSVG/SvgView.cpp
@@ -83,6 +83,8 @@ void SvgView::UpdateProperties(IJSValueReader const &reader, bool forceUpdate, b
         m_meetOrSlice = Utils::GetMeetOrSlice(propertyValue);
       } else if (propertyName == "color") {
         m_currentColor = Utils::JSValueAsColor(propertyValue);
+      } else if (propertyName == "responsible") {
+        m_isResponsible = propertyValue.AsBoolean();
       }
     }
 

--- a/windows/RNSVG/SvgView.h
+++ b/windows/RNSVG/SvgView.h
@@ -42,6 +42,7 @@ struct SvgView : SvgViewT<SvgView> {
   void CreateResources(
       Microsoft::Graphics::Canvas::ICanvasResourceCreator const &resourceCreator,
       Microsoft::Graphics::Canvas::UI::CanvasCreateResourcesEventArgs const &args);
+  void CreateGeometry(Microsoft::Graphics::Canvas::UI::Xaml::CanvasControl const &canvas);
 
   // Overrides
   Windows::Foundation::Size MeasureOverride(Windows::Foundation::Size availableSize);

--- a/windows/RNSVG/SvgView.h
+++ b/windows/RNSVG/SvgView.h
@@ -24,6 +24,9 @@ struct SvgView : SvgViewT<SvgView> {
 
   Windows::UI::Color CurrentColor() { return m_currentColor; }
 
+  bool IsResponsible() { return m_isResponsible; }
+  void IsResponsible(bool isResponsible) { m_isResponsible = isResponsible; }
+
   Windows::Foundation::Collections::IMap<hstring, RNSVG::IRenderable> Templates() {
     return m_templates;
   }
@@ -43,6 +46,7 @@ struct SvgView : SvgViewT<SvgView> {
       Microsoft::Graphics::Canvas::ICanvasResourceCreator const &resourceCreator,
       Microsoft::Graphics::Canvas::UI::CanvasCreateResourcesEventArgs const &args);
   void CreateGeometry(Microsoft::Graphics::Canvas::UI::Xaml::CanvasControl const &canvas);
+  RNSVG::IRenderable HitTest(Windows::Foundation::Point const & /*point*/) { return nullptr; }
 
   // Overrides
   Windows::Foundation::Size MeasureOverride(Windows::Foundation::Size availableSize);
@@ -65,6 +69,7 @@ struct SvgView : SvgViewT<SvgView> {
 
  private:
   bool m_hasRendered{false};
+  bool m_isResponsible{false};
   Microsoft::ReactNative::IReactContext m_reactContext{nullptr};
   Microsoft::Graphics::Canvas::UI::Xaml::CanvasControl m_canvas{};
   Windows::UI::Xaml::FrameworkElement m_parent{nullptr};

--- a/windows/RNSVG/SvgViewManager.cpp
+++ b/windows/RNSVG/SvgViewManager.cpp
@@ -112,13 +112,10 @@ void SvgViewManager::ReplaceChild(
 }
 
 void SvgViewManager::OnPointerEvent(IInspectable const& view, ReactPointerEventArgs const& args) {
-  auto const kind{args.Kind()};
-  auto const move{winrt::Microsoft::ReactNative::PointerEventKind::Move};
-  bool debug{kind != move};
   if (auto const &svgView{view.try_as<RNSVG::SvgView>()}) {
-    auto const& point{args.Args().GetCurrentPoint(svgView).Position()};
     auto const &group{svgView.Group()};
-    if (group.IsResponsible() && debug) {
+    if (group.IsResponsible()) {
+      auto const& point{args.Args().GetCurrentPoint(svgView).Position()};
       for (auto const &child : group.Children()) {
         if (auto const &target{child.HitTest(point)}) {
           args.Target(target);

--- a/windows/RNSVG/SvgViewManager.cpp
+++ b/windows/RNSVG/SvgViewManager.cpp
@@ -4,6 +4,8 @@
 #include "SvgViewManager.g.cpp"
 #endif
 
+#include <winrt/Windows.UI.Input.h>
+#include <winrt/Windows.UI.Xaml.Input.h>
 #include <winrt/Windows.UI.Xaml.Media.h>
 #include <winrt/Windows.UI.Xaml.Shapes.h>
 
@@ -11,6 +13,7 @@
 #include "SvgView.h"
 
 namespace winrt {
+using namespace Windows::Foundation;
 using namespace Windows::Foundation::Collections;
 using namespace Microsoft::Graphics::Canvas::UI::Xaml;
 using namespace Microsoft::ReactNative;
@@ -44,6 +47,7 @@ IMapView<hstring, ViewManagerPropertyType> SvgViewManager::NativeProps() {
   nativeProps.Insert(L"height", ViewManagerPropertyType::Number);
   nativeProps.Insert(L"width", ViewManagerPropertyType::Number);
   nativeProps.Insert(L"color", ViewManagerPropertyType::Color);
+  nativeProps.Insert(L"responsible", ViewManagerPropertyType::Boolean);
 
   // viewBox
   nativeProps.Insert(L"minX", ViewManagerPropertyType::Number);
@@ -104,6 +108,23 @@ void SvgViewManager::ReplaceChild(
     oldGroup.Unload();
     newGroup.SvgParent(parent);
     svgView.Group(newGroup);
+  }
+}
+
+void SvgViewManager::OnPointerEvent(IInspectable const& view, ReactPointerEventArgs const& args) {
+  auto const kind{args.Kind()};
+  auto const move{winrt::Microsoft::ReactNative::PointerEventKind::Move};
+  bool debug{kind != move};
+  if (auto const &svgView{view.try_as<RNSVG::SvgView>()}) {
+    auto const& point{args.Args().GetCurrentPoint(svgView).Position()};
+    auto const &group{svgView.Group()};
+    if (group.IsResponsible() && debug) {
+      for (auto const &child : group.Children()) {
+        if (auto const &target{child.HitTest(point)}) {
+          args.Target(target);
+        }
+      }
+    }
   }
 }
 } // namespace winrt::RNSVG::implementation

--- a/windows/RNSVG/SvgViewManager.h
+++ b/windows/RNSVG/SvgViewManager.h
@@ -30,6 +30,11 @@ struct SvgViewManager : SvgViewManagerT<SvgViewManager> {
       Windows::UI::Xaml::UIElement const &oldChild,
       Windows::UI::Xaml::UIElement const &newChild);
 
+  // IViewManagerWithPointerEvents
+  void OnPointerEvent(
+      Windows::Foundation::IInspectable const &view,
+      Microsoft::ReactNative::ReactPointerEventArgs const &args);
+
  private:
   Microsoft::ReactNative::IReactContext m_reactContext{nullptr};
 };

--- a/windows/RNSVG/ViewManagers.idl
+++ b/windows/RNSVG/ViewManagers.idl
@@ -102,6 +102,12 @@ namespace RNSVG
   };
 
   [default_interface]
+  runtimeclass ClipPathViewManager : GroupViewManager
+  {
+    ClipPathViewManager();
+  };
+
+  [default_interface]
   unsealed runtimeclass TextViewManager : GroupViewManager
   {
     TextViewManager();

--- a/windows/RNSVG/ViewManagers.idl
+++ b/windows/RNSVG/ViewManagers.idl
@@ -8,6 +8,7 @@ namespace RNSVG
     , Microsoft.ReactNative.IViewManagerWithReactContext
     , Microsoft.ReactNative.IViewManagerWithNativeProperties
     , Microsoft.ReactNative.IViewManagerWithChildren
+    , Microsoft.ReactNative.IViewManagerWithPointerEvents
   {
     SvgViewManager();
   };

--- a/windows/RNSVG/Views.idl
+++ b/windows/RNSVG/Views.idl
@@ -6,6 +6,7 @@ namespace RNSVG
   {
     Windows.UI.Xaml.FrameworkElement SvgParent;
     Microsoft.Graphics.Canvas.Geometry.CanvasGeometry Geometry;
+    Boolean IsResponsible;
 
     void CreateResources(
       Microsoft.Graphics.Canvas.ICanvasResourceCreator resourceCreator,
@@ -18,6 +19,7 @@ namespace RNSVG
     void SaveDefinition();
     void Unload();
     void CreateGeometry(Microsoft.Graphics.Canvas.UI.Xaml.CanvasControl canvas);
+    IRenderable HitTest(Windows.Foundation.Point point);
   };
 
   [default_interface]

--- a/windows/RNSVG/Views.idl
+++ b/windows/RNSVG/Views.idl
@@ -153,6 +153,12 @@ namespace RNSVG
   };
 
   [default_interface]
+  runtimeclass ClipPathView : GroupView
+  {
+    ClipPathView();
+  };
+
+  [default_interface]
   unsealed runtimeclass BrushView : GroupView
   {
     BrushView();

--- a/windows/RNSVG/Views.idl
+++ b/windows/RNSVG/Views.idl
@@ -17,6 +17,7 @@ namespace RNSVG
     void MergeProperties(RenderableView other);
     void SaveDefinition();
     void Unload();
+    void CreateGeometry(Microsoft.Graphics.Canvas.UI.Xaml.CanvasControl canvas);
   };
 
   [default_interface]
@@ -55,8 +56,7 @@ namespace RNSVG
     Microsoft.Graphics.Canvas.Geometry.CanvasCapStyle StrokeLineCap{ get; };
     Microsoft.Graphics.Canvas.Geometry.CanvasLineJoin StrokeLineJoin{ get; };
     Microsoft.Graphics.Canvas.Geometry.CanvasFilledRegionDetermination FillRule{ get; };
-
-    void CreateGeometry(Microsoft.Graphics.Canvas.UI.Xaml.CanvasControl canvas);
+    Microsoft.Graphics.Canvas.Geometry.CanvasGeometry ClipPathGeometry { get; };
   };
 
   [default_interface]


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
Adding support for clipPath and touch events. (Closes marlenecota/react-native-svg#6)

## Test Plan


https://user-images.githubusercontent.com/1422161/206369981-cd31ea1c-a5f1-4a76-b8c6-6b0e120123d9.mp4



## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ❌     |
| Windows |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [ ] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
