### PR TITLE
fix: pass reference in nested svgView

### DIFF
--- a/apple/Elements/RNSVGSvgView.mm
+++ b/apple/Elements/RNSVGSvgView.mm
@@ -252,6 +252,17 @@ using namespace facebook::react;
 
 - (void)drawToContext:(CGContextRef)context withRect:(CGRect)rect
 {
+  for (RNSVGPlatformView *node in self.subviews) {
+    if ([node isKindOfClass:[RNSVGNode class]]) {
+      RNSVGNode *svg = (RNSVGNode *)node;
+      if (svg.responsible && !self.responsible) {
+        self.responsible = YES;
+      }
+
+      [svg parseReference];
+    }
+  }
+
   rendered = true;
   self.initialCTM = CGContextGetCTM(context);
   self.invInitialCTM = CGAffineTransformInvert(self.initialCTM);
@@ -287,17 +298,6 @@ using namespace facebook::react;
   _painters = nil;
   _boundingBox = rect;
   CGContextRef context = UIGraphicsGetCurrentContext();
-
-  for (RNSVGPlatformView *node in self.subviews) {
-    if ([node isKindOfClass:[RNSVGNode class]]) {
-      RNSVGNode *svg = (RNSVGNode *)node;
-      if (svg.responsible && !self.responsible) {
-        self.responsible = YES;
-      }
-
-      [svg parseReference];
-    }
-  }
 
   [self drawToContext:context withRect:rect];
 }

--- a/apple/Elements/RNSVGSvgView.mm
+++ b/apple/Elements/RNSVGSvgView.mm
@@ -252,6 +252,11 @@ using namespace facebook::react;
 
 - (void)drawToContext:(CGContextRef)context withRect:(CGRect)rect
 {
+  _clipPaths = nil;
+  _templates = nil;
+  _painters = nil;
+  _boundingBox = rect;
+
   for (RNSVGPlatformView *node in self.subviews) {
     if ([node isKindOfClass:[RNSVGNode class]]) {
       RNSVGNode *svg = (RNSVGNode *)node;
@@ -292,11 +297,9 @@ using namespace facebook::react;
   if ([parent isKindOfClass:[RNSVGNode class]]) {
     return;
   }
+
   rendered = true;
-  _clipPaths = nil;
-  _templates = nil;
-  _painters = nil;
-  _boundingBox = rect;
+
   CGContextRef context = UIGraphicsGetCurrentContext();
 
   [self drawToContext:context withRect:rect];


### PR DESCRIPTION
PR moving passing reference code to `- (void)drawToContext:(CGContextRef)context withRect:(CGRect)rect` method from `- (void)drawRect:(CGRect)rect` since this way passing reference is called in both the parent and the nested Svg. Should fix #1930.