### PR TITLE
fix: restore black as a default color for svgs

### DIFF
--- a/src/lib/extract/extractFill.ts
+++ b/src/lib/extract/extractFill.ts
@@ -20,6 +20,9 @@ export default function extractFill(
     inherited.push('fill');
     o.fill =
       !fill && typeof fill !== 'number' ? defaultFill : extractBrush(fill);
+  } else {
+    // we want the default value of fill to be black to match the spec
+    o.fill = defaultFill;
   }
   if (fillOpacity != null) {
     inherited.push('fillOpacity');


### PR DESCRIPTION
PR fixing setting of fill color to black when none is provided to the svg. Regression was most probably introduced in https://github.com/software-mansion/react-native-svg/commit/279c3fcf84540ba12b18dd2056e3189af75c29b4#diff-c9a7ab35811344ee98570618a27ce925792981d9fee1fb77c227b72129363aa6