### PR TITLE
fix: accept comas in viewbox

### DIFF
--- a/src/lib/extract/extractViewBox.ts
+++ b/src/lib/extract/extractViewBox.ts
@@ -37,7 +37,9 @@ export default function extractViewBox(props: {
   }
 
   const params = (
-    Array.isArray(viewBox) ? viewBox : viewBox.trim().split(spacesRegExp)
+    Array.isArray(viewBox)
+      ? viewBox
+      : viewBox.trim().replace(/,/g, ' ').split(spacesRegExp)
   ).map(Number);
 
   if (params.length !== 4 || params.some(isNaN)) {


### PR DESCRIPTION
PR adding support for comas in viewbox property, replacing them with `space`. Based on work by @HSalaila and @gp3gp3gp3 in https://github.com/software-mansion/react-native-svg/issues/1555. Fixes https://github.com/software-mansion/react-native-svg/issues/1363, fixes https://github.com/software-mansion/react-native-svg/issues/1555.