### PR TITLE
Fix: WithLocalSvg + data uri is not shown well in Android

### DIFF
--- a/src/LocalSvg.tsx
+++ b/src/LocalSvg.tsx
@@ -34,8 +34,42 @@ export async function loadAndroidRawResource(uri: string) {
   }
 }
 
+// copy from https://www.npmjs.com/package/data-uri-to-buffer
+export function dataUriToXml(uri) {
+  if (!/^data:/i.test(uri)) {
+    throw new TypeError('`uri` does not appear to be a Data URI (must begin with "data:")');
+  }
+  // strip newlines
+  uri = uri.replace(/\r?\n/g, '');
+  // split the URI up into the "metadata" and the "data" portions
+  const firstComma = uri.indexOf(',');
+  if (firstComma === -1 || firstComma <= 4) {
+    throw new TypeError('malformed data: URI');
+  }
+  // remove the "data:" scheme and parse the metadata
+  const meta = uri.substring(5, firstComma).split(';');
+  let base64 = false;
+  for (let i = 1; i < meta.length; i++) {
+    if (meta[i] === 'base64') {
+      base64 = true;
+    }
+  }
+
+  // get the encoded data portion and decode URI-encoded chars
+  const data = unescape(uri.substring(firstComma + 1));
+  if (!base64) {
+    return data;
+  }
+  return Base64.decode(data);
+}
+
 export function loadLocalRawResourceAndroid(source: ImageSourcePropType) {
   const uri = getUriFromSource(source);
+  if (uri.startsWith('data:')) {
+    return new Promise((resolve) => {
+      resolve(dataUriToXml(uri));
+    });
+  }
   if (isUriAnAndroidResourceIdentifier(uri)) {
     return loadAndroidRawResource(uri);
   } else {


### PR DESCRIPTION
Related issue: https://github.com/software-mansion/react-native-svg/issues/1318#issuecomment-665846082

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Sometime we will convert the svg into base64 format, and render it as a image.
WithLocalSvg is work well in iOS, but in Android it will throw an Error "Network request failed", because the LocalSvg.tsx wont check the file url format, and fetch it as a network url.

This PR will check the data uri format in loadLocalRawResourceAndroid, and if it is a data uri, it will parse and return the correct xml data, then the android will display the svg correctly.

## Test Plan

Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [ ] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
