### PR TITLE
Fix use of undeclared identifier 'RNSVGImageShadowNode' on Fabric

### DIFF
--- a/apple/Elements/RNSVGImage.mm
+++ b/apple/Elements/RNSVGImage.mm
@@ -37,8 +37,9 @@
 #import <rnsvg/RNSVGImageComponentDescriptor.h>
 #import "RNSVGFabricConversions.h"
 
-using namespace facebook::react;
 #endif // RN_FABRIC_ENABLED
+
+using namespace facebook::react;
 
 @implementation RNSVGImage {
   CGImageRef _image;

--- a/apple/Elements/RNSVGImage.mm
+++ b/apple/Elements/RNSVGImage.mm
@@ -51,17 +51,14 @@ using namespace facebook::react;
   RCTImageResponseObserverProxy _imageResponseObserverProxy;
 #endif // RN_FABRIC_ENABLED
 }
-#ifdef RN_FABRIC_ENABLED
 
+#ifdef RN_FABRIC_ENABLED
 - (instancetype)initWithFrame:(CGRect)frame
 {
   if (self = [super initWithFrame:frame]) {
     static const auto defaultProps = std::make_shared<const RNSVGImageProps>();
     _props = defaultProps;
-
-#ifdef RN_FABRIC_ENABLED
     _imageResponseObserverProxy = RCTImageResponseObserverProxy(self);
-#endif
   }
   return self;
 }


### PR DESCRIPTION
# Summary

This PR resolves the following error when building RN 0.71.0 app with Fabric enabled for iOS:

<img width="1255" alt="Zrzut ekranu 2023-01-19 o 09 13 11" src="https://user-images.githubusercontent.com/20516055/213390336-1cafc137-21d6-48cd-8488-92acfab1e9dc.png">
