### PR TITLE
chore: ensure consistent use of `import type`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,12 @@
 module.exports = {
   extends: '@react-native-community',
-  rules: { 'no-bitwise': 0, '@typescript-eslint/no-explicit-any': 2 },
+  parserOptions: {
+    project: ["./tsconfig.json"],
+  },
+  rules: {
+    'no-bitwise': 'off',
+    '@typescript-eslint/consistent-type-exports': 'error',
+    '@typescript-eslint/consistent-type-imports': 'error',
+    '@typescript-eslint/no-explicit-any': 'error',
+  },
 };

--- a/src/LocalSvg.tsx
+++ b/src/LocalSvg.tsx
@@ -1,9 +1,10 @@
 import React, { useState, useEffect, Component } from 'react';
-import { Platform, Image, ImageSourcePropType } from 'react-native';
+import type { ImageSourcePropType } from 'react-native';
+import { Platform, Image } from 'react-native';
 
 import { fetchText } from './xml';
 import { SvgCss, SvgWithCss } from './css';
-import { SvgProps } from './elements/Svg';
+import type { SvgProps } from './elements/Svg';
 import type { Spec } from './fabric/NativeSvgRenderableModule';
 
 export function getUriFromSource(source: ImageSourcePropType) {

--- a/src/ReactNativeSVG.web.ts
+++ b/src/ReactNativeSVG.web.ts
@@ -1,12 +1,15 @@
 import * as React from 'react';
+import type { GestureResponderEvent, TransformsStyle } from 'react-native';
 import {
-  GestureResponderEvent,
   // @ts-ignore
   unstable_createElement as ucE,
   createElement as cE,
-  TransformsStyle,
 } from 'react-native';
-import { NumberArray, NumberProp, TransformProps } from './lib/extract/types';
+import type {
+  NumberArray,
+  NumberProp,
+  TransformProps,
+} from './lib/extract/types';
 import SvgTouchableMixin from './lib/SvgTouchableMixin';
 import { resolve } from './lib/resolve';
 import { transformsArrayToProps } from './lib/extract/extractTransform';

--- a/src/css.tsx
+++ b/src/css.tsx
@@ -1,33 +1,30 @@
 import React, { Component, useEffect, useMemo, useState } from 'react';
-import {
-  camelCase,
-  err,
-  fetchText,
+import type {
   JsxAST,
   Middleware,
-  parse,
   Styles,
-  SvgAst,
   UriProps,
   UriState,
   XmlAST,
   XmlProps,
   XmlState,
 } from './xml';
-import csstree, {
+import { camelCase, err, fetchText, parse, SvgAst } from './xml';
+import type {
   Atrule,
   AtrulePrelude,
   CssNode,
   Declaration,
   DeclarationList,
-  List,
   ListItem,
   PseudoClassSelector,
   Rule,
   Selector,
   SelectorList,
 } from 'css-tree';
-import cssSelect, { Options } from 'css-select';
+import csstree, { List } from 'css-tree';
+import type { Options } from 'css-select';
+import cssSelect from 'css-select';
 
 /*
  * Style element inlining experiment based on SVGO

--- a/src/elements/Circle.tsx
+++ b/src/elements/Circle.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { extract, stringifyPropsForFabric } from '../lib/extract/extractProps';
-import { CommonPathProps, NumberProp } from '../lib/extract/types';
+import type { CommonPathProps, NumberProp } from '../lib/extract/types';
 import Shape from './Shape';
 import RNSVGCircle from '../fabric/CircleNativeComponent';
-import { NativeMethods } from 'react-native';
+import type { NativeMethods } from 'react-native';
 
 export interface CircleProps extends CommonPathProps {
   cx?: NumberProp;

--- a/src/elements/ClipPath.tsx
+++ b/src/elements/ClipPath.tsx
@@ -1,4 +1,5 @@
-import React, { ReactNode } from 'react';
+import type { ReactNode } from 'react';
+import React from 'react';
 import { extract } from '../lib/extract/extractProps';
 import Shape from './Shape';
 import RNSVGClipPath from '../fabric/ClipPathNativeComponent';

--- a/src/elements/Ellipse.tsx
+++ b/src/elements/Ellipse.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { extract, stringifyPropsForFabric } from '../lib/extract/extractProps';
-import { CommonPathProps, NumberProp } from '../lib/extract/types';
+import type { CommonPathProps, NumberProp } from '../lib/extract/types';
 import Shape from './Shape';
 import RNSVGEllipse from '../fabric/EllipseNativeComponent';
-import { NativeMethods } from 'react-native';
+import type { NativeMethods } from 'react-native';
 
 export interface EllipseProps extends CommonPathProps {
   cx?: NumberProp;

--- a/src/elements/ForeignObject.tsx
+++ b/src/elements/ForeignObject.tsx
@@ -1,12 +1,13 @@
-import React, { ReactNode } from 'react';
+import type { ReactNode } from 'react';
+import React from 'react';
 import {
   withoutXY,
   stringifyPropsForFabric,
 } from '../lib/extract/extractProps';
-import { NumberProp } from '../lib/extract/types';
+import type { NumberProp } from '../lib/extract/types';
 import G from './G';
 import RNSVGForeignObject from '../fabric/ForeignObjectNativeComponent';
-import { NativeMethods } from 'react-native';
+import type { NativeMethods } from 'react-native';
 
 export interface ForeignObjectProps {
   children?: ReactNode;

--- a/src/elements/G.tsx
+++ b/src/elements/G.tsx
@@ -1,8 +1,9 @@
-import React, { ReactNode } from 'react';
+import type { ReactNode } from 'react';
+import React from 'react';
 import extractProps, { propsAndStyles } from '../lib/extract/extractProps';
 import { extractFont } from '../lib/extract/extractText';
 import extractTransform from '../lib/extract/extractTransform';
-import {
+import type {
   CommonPathProps,
   FontProps,
   NumberProp,
@@ -10,7 +11,7 @@ import {
 } from '../lib/extract/types';
 import Shape from './Shape';
 import RNSVGGroup from '../fabric/GroupNativeComponent';
-import { NativeMethods } from 'react-native';
+import type { NativeMethods } from 'react-native';
 
 export interface GProps extends CommonPathProps, FontProps {
   children?: ReactNode;

--- a/src/elements/Image.tsx
+++ b/src/elements/Image.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
-import { Image, ImageProps as RNImageProps, NativeMethods } from 'react-native';
+import type { ImageProps as RNImageProps, NativeMethods } from 'react-native';
+import { Image } from 'react-native';
 import { alignEnum, meetOrSliceTypes } from '../lib/extract/extractViewBox';
 import {
   stringifyPropsForFabric,
   withoutXY,
 } from '../lib/extract/extractProps';
-import {
+import type {
   ClipProps,
   CommonMaskProps,
   NativeProps,

--- a/src/elements/Line.tsx
+++ b/src/elements/Line.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { extract, stringifyPropsForFabric } from '../lib/extract/extractProps';
-import { CommonPathProps, NumberProp } from '../lib/extract/types';
+import type { CommonPathProps, NumberProp } from '../lib/extract/types';
 import Shape from './Shape';
 import RNSVGLine from '../fabric/LineNativeComponent';
-import { NativeMethods } from 'react-native';
+import type { NativeMethods } from 'react-native';
 
 export interface LineProps extends CommonPathProps {
   opacity?: NumberProp;

--- a/src/elements/LinearGradient.tsx
+++ b/src/elements/LinearGradient.tsx
@@ -1,10 +1,11 @@
-import React, { ReactElement } from 'react';
+import type { ReactElement } from 'react';
+import React from 'react';
 import extractGradient from '../lib/extract/extractGradient';
-import { NumberProp, TransformProps, Units } from '../lib/extract/types';
+import type { NumberProp, TransformProps, Units } from '../lib/extract/types';
 import Shape from './Shape';
 import RNSVGLinearGradient from '../fabric/LinearGradientNativeComponent';
 import { stringifyPropsForFabric } from '../lib/extract/extractProps';
-import { NativeMethods } from 'react-native';
+import type { NativeMethods } from 'react-native';
 
 export interface LinearGradientProps {
   children?: ReactElement[];

--- a/src/elements/Marker.tsx
+++ b/src/elements/Marker.tsx
@@ -1,10 +1,11 @@
-import React, { ReactNode } from 'react';
+import type { ReactNode } from 'react';
+import React from 'react';
 import extractViewBox from '../lib/extract/extractViewBox';
-import { NumberProp } from '../lib/extract/types';
+import type { NumberProp } from '../lib/extract/types';
 import Shape from './Shape';
 import RNSVGMarker from '../fabric/MarkerNativeComponent';
 import { stringifyPropsForFabric } from '../lib/extract/extractProps';
-import { NativeMethods } from 'react-native';
+import type { NativeMethods } from 'react-native';
 
 export type MarkerUnits = 'strokeWidth' | 'userSpaceOnUse';
 

--- a/src/elements/Mask.tsx
+++ b/src/elements/Mask.tsx
@@ -1,13 +1,14 @@
-import React, { ReactNode } from 'react';
+import type { ReactNode } from 'react';
+import React from 'react';
 import {
   stringifyPropsForFabric,
   withoutXY,
 } from '../lib/extract/extractProps';
-import { CommonPathProps, NumberProp } from '../lib/extract/types';
+import type { CommonPathProps, NumberProp } from '../lib/extract/types';
 import units from '../lib/units';
 import Shape from './Shape';
 import RNSVGMask from '../fabric/MaskNativeComponent';
-import { NativeMethods } from 'react-native';
+import type { NativeMethods } from 'react-native';
 
 export type TMaskUnits = 'userSpaceOnUse' | 'objectBoundingBox';
 

--- a/src/elements/Path.tsx
+++ b/src/elements/Path.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import { extract } from '../lib/extract/extractProps';
 import Shape from './Shape';
 import RNSVGPath from '../fabric/PathNativeComponent';
-import { CommonPathProps, NumberProp } from '../lib/extract/types';
-import { NativeMethods } from 'react-native';
+import type { CommonPathProps, NumberProp } from '../lib/extract/types';
+import type { NativeMethods } from 'react-native';
 
 export interface PathProps extends CommonPathProps {
   d?: string;

--- a/src/elements/Pattern.tsx
+++ b/src/elements/Pattern.tsx
@@ -1,12 +1,13 @@
-import React, { ReactNode } from 'react';
+import type { ReactNode } from 'react';
+import React from 'react';
 import extractTransform from '../lib/extract/extractTransform';
 import extractViewBox from '../lib/extract/extractViewBox';
-import { NumberProp, TransformProps, Units } from '../lib/extract/types';
+import type { NumberProp, TransformProps, Units } from '../lib/extract/types';
 import units from '../lib/units';
 import Shape from './Shape';
 import RNSVGPattern from '../fabric/PatternNativeComponent';
 import { stringifyPropsForFabric } from '../lib/extract/extractProps';
-import { NativeMethods } from 'react-native';
+import type { NativeMethods } from 'react-native';
 
 export interface PatternProps extends TransformProps {
   children?: ReactNode;

--- a/src/elements/Polygon.tsx
+++ b/src/elements/Polygon.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Path from './Path';
 import Shape from './Shape';
-import { CommonPathProps, NumberProp } from '../lib/extract/types';
+import type { CommonPathProps, NumberProp } from '../lib/extract/types';
 import extractPolyPoints from '../lib/extract/extractPolyPoints';
 
 export interface PolygonProps extends CommonPathProps {

--- a/src/elements/Polyline.tsx
+++ b/src/elements/Polyline.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Path from './Path';
 import Shape from './Shape';
-import { CommonPathProps, NumberProp } from '../lib/extract/types';
+import type { CommonPathProps, NumberProp } from '../lib/extract/types';
 import extractPolyPoints from '../lib/extract/extractPolyPoints';
 
 export interface PolylineProps extends CommonPathProps {

--- a/src/elements/RadialGradient.tsx
+++ b/src/elements/RadialGradient.tsx
@@ -1,10 +1,11 @@
-import React, { ReactElement } from 'react';
+import type { ReactElement } from 'react';
+import React from 'react';
 import extractGradient from '../lib/extract/extractGradient';
-import { NumberProp, TransformProps, Units } from '../lib/extract/types';
+import type { NumberProp, TransformProps, Units } from '../lib/extract/types';
 import Shape from './Shape';
 import RNSVGRadialGradient from '../fabric/RadialGradientNativeComponent';
 import { stringifyPropsForFabric } from '../lib/extract/extractProps';
-import { NativeMethods } from 'react-native';
+import type { NativeMethods } from 'react-native';
 
 export interface RadialGradientProps {
   children?: ReactElement[];

--- a/src/elements/Rect.tsx
+++ b/src/elements/Rect.tsx
@@ -3,10 +3,10 @@ import {
   stringifyPropsForFabric,
   withoutXY,
 } from '../lib/extract/extractProps';
-import { CommonPathProps, NumberProp } from '../lib/extract/types';
+import type { CommonPathProps, NumberProp } from '../lib/extract/types';
 import Shape from './Shape';
 import RNSVGRect from '../fabric/RectNativeComponent';
-import { NativeMethods } from 'react-native';
+import type { NativeMethods } from 'react-native';
 
 export interface RectProps extends CommonPathProps {
   x?: NumberProp;

--- a/src/elements/Shape.tsx
+++ b/src/elements/Shape.tsx
@@ -1,8 +1,9 @@
 import { Component } from 'react';
 import SvgTouchableMixin from '../lib/SvgTouchableMixin';
 import extractBrush from '../lib/extract/extractBrush';
-import { ColorValue, findNodeHandle, NativeMethods } from 'react-native';
-import {
+import type { ColorValue, NativeMethods } from 'react-native';
+import { findNodeHandle } from 'react-native';
+import type {
   ColumnMajorTransformMatrix,
   TransformProps,
 } from '../lib/extract/types';

--- a/src/elements/Stop.tsx
+++ b/src/elements/Stop.tsx
@@ -1,6 +1,6 @@
 import { Component } from 'react';
-import { ColorValue } from 'react-native';
-import { NumberProp } from '../lib/extract/types';
+import type { ColorValue } from 'react-native';
+import type { NumberProp } from '../lib/extract/types';
 
 export interface StopProps {
   stopColor?: ColorValue;

--- a/src/elements/Svg.tsx
+++ b/src/elements/Svg.tsx
@@ -1,18 +1,17 @@
-import React, { Component } from 'react';
-import {
+import type { Component } from 'react';
+import React from 'react';
+import type {
   ColorValue,
-  findNodeHandle,
   MeasureInWindowOnSuccessCallback,
   MeasureLayoutOnSuccessCallback,
   MeasureOnSuccessCallback,
   NativeMethods,
-  Platform,
   StyleProp,
-  StyleSheet,
   ViewProps,
   ViewStyle,
 } from 'react-native';
-import {
+import { findNodeHandle, Platform, StyleSheet } from 'react-native';
+import type {
   extractedProps,
   NumberProp,
   ResponderInstanceProps,
@@ -20,7 +19,8 @@ import {
 import extractResponder from '../lib/extract/extractResponder';
 import extractViewBox from '../lib/extract/extractViewBox';
 import Shape from './Shape';
-import G, { GProps } from './G';
+import type { GProps } from './G';
+import G from './G';
 import RNSVGSvgAndroid from '../fabric/AndroidSvgViewNativeComponent';
 import RNSVGSvgIOS from '../fabric/IOSSvgViewNativeComponent';
 import type { Spec } from '../fabric/NativeSvgViewModule';

--- a/src/elements/Symbol.tsx
+++ b/src/elements/Symbol.tsx
@@ -1,9 +1,10 @@
-import React, { ReactNode } from 'react';
+import type { ReactNode } from 'react';
+import React from 'react';
 import extractViewBox from '../lib/extract/extractViewBox';
 import Shape from './Shape';
 import RNSVGSymbol from '../fabric/SymbolNativeComponent';
-import { NumberProp } from '../lib/extract/types';
-import { NativeMethods } from 'react-native';
+import type { NumberProp } from '../lib/extract/types';
+import type { NativeMethods } from 'react-native';
 
 export interface SymbolProps {
   children?: ReactNode;

--- a/src/elements/TSpan.tsx
+++ b/src/elements/TSpan.tsx
@@ -1,10 +1,12 @@
-import React, { Component } from 'react';
+import type { Component } from 'react';
+import React from 'react';
 import extractProps, { propsAndStyles } from '../lib/extract/extractProps';
 import extractTransform from '../lib/extract/extractTransform';
-import extractText, { setTSpan, TextChild } from '../lib/extract/extractText';
+import type { TextChild } from '../lib/extract/extractText';
+import extractText, { setTSpan } from '../lib/extract/extractText';
 import { pickNotNil } from '../lib/util';
 import Shape from './Shape';
-import {
+import type {
   ColumnMajorTransformMatrix,
   CommonPathProps,
   FontProps,

--- a/src/elements/Text.tsx
+++ b/src/elements/Text.tsx
@@ -1,8 +1,9 @@
-import React, { Component, ReactNode } from 'react';
+import type { Component, ReactNode } from 'react';
+import React from 'react';
 import extractText from '../lib/extract/extractText';
 import extractProps, { propsAndStyles } from '../lib/extract/extractProps';
 import extractTransform from '../lib/extract/extractTransform';
-import {
+import type {
   ColumnMajorTransformMatrix,
   NumberArray,
   NumberProp,

--- a/src/elements/TextPath.tsx
+++ b/src/elements/TextPath.tsx
@@ -1,7 +1,8 @@
-import React, { Component } from 'react';
+import type { Component } from 'react';
+import React from 'react';
 import extractTransform from '../lib/extract/extractTransform';
 import { withoutXY } from '../lib/extract/extractProps';
-import {
+import type {
   ColumnMajorTransformMatrix,
   NumberProp,
   TextPathMethod,
@@ -10,7 +11,8 @@ import {
   TextSpecificProps,
   TransformProps,
 } from '../lib/extract/types';
-import extractText, { TextChild } from '../lib/extract/extractText';
+import type { TextChild } from '../lib/extract/extractText';
+import extractText from '../lib/extract/extractText';
 import { idPattern, pickNotNil } from '../lib/util';
 import Shape from './Shape';
 import TSpan from './TSpan';

--- a/src/elements/Use.tsx
+++ b/src/elements/Use.tsx
@@ -1,13 +1,14 @@
-import React, { ReactNode } from 'react';
+import type { ReactNode } from 'react';
+import React from 'react';
 import {
   stringifyPropsForFabric,
   withoutXY,
 } from '../lib/extract/extractProps';
-import { CommonPathProps, NumberProp } from '../lib/extract/types';
+import type { CommonPathProps, NumberProp } from '../lib/extract/types';
 import { idPattern } from '../lib/util';
 import Shape from './Shape';
 import RNSVGUse from '../fabric/UseNativeComponent';
-import { NativeMethods } from 'react-native';
+import type { NativeMethods } from 'react-native';
 
 export interface UseProps extends CommonPathProps {
   children?: ReactNode;

--- a/src/fabric/DefsNativeComponent.ts
+++ b/src/fabric/DefsNativeComponent.ts
@@ -1,5 +1,5 @@
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
-import {
+import type {
   Float,
   Int32,
   WithDefault,

--- a/src/fabric/NativeSvgRenderableModule.ts
+++ b/src/fabric/NativeSvgRenderableModule.ts
@@ -1,5 +1,6 @@
-import { TurboModuleRegistry, TurboModule } from 'react-native';
-import { Int32, Float } from 'react-native/Libraries/Types/CodegenTypes';
+import type { TurboModule } from 'react-native';
+import { TurboModuleRegistry } from 'react-native';
+import type { Int32, Float } from 'react-native/Libraries/Types/CodegenTypes';
 
 type Rect = {
   x: Float;

--- a/src/fabric/NativeSvgViewModule.ts
+++ b/src/fabric/NativeSvgViewModule.ts
@@ -1,5 +1,6 @@
-import { TurboModuleRegistry, TurboModule } from 'react-native';
-import { Int32 } from 'react-native/Libraries/Types/CodegenTypes';
+import type { TurboModule } from 'react-native';
+import { TurboModuleRegistry } from 'react-native';
+import type { Int32 } from 'react-native/Libraries/Types/CodegenTypes';
 
 export interface Spec extends TurboModule {
   toDataURL(

--- a/src/lib/SvgTouchableMixin.ts
+++ b/src/lib/SvgTouchableMixin.ts
@@ -1,5 +1,6 @@
 // @ts-ignore
-import { Touchable, GestureResponderEvent } from 'react-native';
+import type { GestureResponderEvent } from 'react-native';
+import { Touchable } from 'react-native';
 const PRESS_RETENTION_OFFSET = { top: 20, left: 20, right: 20, bottom: 30 };
 // @ts-ignore
 const { Mixin } = Touchable;

--- a/src/lib/extract/extractBrush.ts
+++ b/src/lib/extract/extractBrush.ts
@@ -1,4 +1,5 @@
-import { ColorValue, processColor } from 'react-native';
+import type { ColorValue } from 'react-native';
+import { processColor } from 'react-native';
 
 const urlIdPattern = /^url\(#(.+)\)$/;
 

--- a/src/lib/extract/extractFill.ts
+++ b/src/lib/extract/extractFill.ts
@@ -1,6 +1,6 @@
 import extractBrush from './extractBrush';
 import extractOpacity from './extractOpacity';
-import { extractedProps, FillProps } from './types';
+import type { extractedProps, FillProps } from './types';
 import { processColor } from 'react-native';
 
 const fillRules: { evenodd: number; nonzero: number } = {

--- a/src/lib/extract/extractGradient.ts
+++ b/src/lib/extract/extractGradient.ts
@@ -1,9 +1,10 @@
-import React, { Children, ReactElement } from 'react';
+import type { ReactElement } from 'react';
+import React, { Children } from 'react';
 import { processColor } from 'react-native';
 
 import extractOpacity from './extractOpacity';
 import extractTransform from './extractTransform';
-import { TransformProps } from './types';
+import type { TransformProps } from './types';
 import units from '../units';
 
 const percentReg = /^([+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)(%?)$/;

--- a/src/lib/extract/extractLengthList.ts
+++ b/src/lib/extract/extractLengthList.ts
@@ -1,4 +1,4 @@
-import { NumberProp } from './types';
+import type { NumberProp } from './types';
 
 const spaceReg = /\s+/;
 const commaReg = /,/g;

--- a/src/lib/extract/extractOpacity.ts
+++ b/src/lib/extract/extractOpacity.ts
@@ -1,4 +1,4 @@
-import { NumberProp } from './types';
+import type { NumberProp } from './types';
 
 export default function extractOpacity(opacity: NumberProp | void) {
   const value = +opacity;

--- a/src/lib/extract/extractPolyPoints.ts
+++ b/src/lib/extract/extractPolyPoints.ts
@@ -1,4 +1,4 @@
-import { NumberProp } from './types';
+import type { NumberProp } from './types';
 
 export default function extractPolyPoints(
   points: string | readonly NumberProp[],

--- a/src/lib/extract/extractProps.ts
+++ b/src/lib/extract/extractProps.ts
@@ -4,7 +4,7 @@ import extractTransform from './extractTransform';
 import extractResponder from './extractResponder';
 import extractOpacity from './extractOpacity';
 import { idPattern } from '../util';
-import {
+import type {
   ClipProps,
   extractedProps,
   FillProps,

--- a/src/lib/extract/extractProps.windows.ts
+++ b/src/lib/extract/extractProps.windows.ts
@@ -4,7 +4,7 @@ import extractTransform from './extractTransform';
 import extractResponder from './extractResponder';
 import extractOpacity from './extractOpacity';
 import { idPattern } from '../util';
-import {
+import type {
   ClipProps,
   extractedProps,
   FillProps,

--- a/src/lib/extract/extractResponder.ts
+++ b/src/lib/extract/extractResponder.ts
@@ -1,5 +1,5 @@
 import { PanResponder } from 'react-native';
-import {
+import type {
   extractedProps,
   ResponderInstanceProps,
   ResponderProps,

--- a/src/lib/extract/extractStroke.ts
+++ b/src/lib/extract/extractStroke.ts
@@ -1,7 +1,7 @@
 import extractBrush from './extractBrush';
 import extractOpacity from './extractOpacity';
 import extractLengthList from './extractLengthList';
-import { extractedProps, StrokeProps } from './types';
+import type { extractedProps, StrokeProps } from './types';
 
 const caps = {
   butt: 0,

--- a/src/lib/extract/extractText.tsx
+++ b/src/lib/extract/extractText.tsx
@@ -1,7 +1,8 @@
-import React, { Children, ComponentType } from 'react';
+import type { ComponentType } from 'react';
+import React, { Children } from 'react';
 import extractLengthList from './extractLengthList';
 import { pickNotNil } from '../util';
-import { NumberArray, NumberProp } from './types';
+import type { NumberArray, NumberProp } from './types';
 import { stringifyPropsForFabric } from './extractProps';
 
 const fontRegExp =

--- a/src/lib/extract/extractTransform.ts
+++ b/src/lib/extract/extractTransform.ts
@@ -1,7 +1,7 @@
-import { TransformsStyle } from 'react-native';
+import type { TransformsStyle } from 'react-native';
 import { append, appendTransform, identity, reset, toArray } from '../Matrix2D';
 import { parse } from './transform';
-import {
+import type {
   ColumnMajorTransformMatrix,
   NumberProp,
   TransformedProps,

--- a/src/lib/extract/extractViewBox.ts
+++ b/src/lib/extract/extractViewBox.ts
@@ -1,4 +1,4 @@
-import { NumberProp } from './types';
+import type { NumberProp } from './types';
 
 export const meetOrSliceTypes: {
   [meetOrSlice: string]: number;

--- a/src/lib/extract/types.ts
+++ b/src/lib/extract/types.ts
@@ -1,10 +1,10 @@
-import {
+import type {
   ColorValue,
   GestureResponderEvent,
   GestureResponderHandlers,
   LayoutChangeEvent,
 } from 'react-native';
-import React from 'react';
+import type React from 'react';
 import type { TransformsStyle } from 'react-native';
 
 export type NumberProp = string | number;

--- a/src/xml.tsx
+++ b/src/xml.tsx
@@ -1,17 +1,13 @@
-import React, {
-  Component,
-  ComponentType,
-  useEffect,
-  useMemo,
-  useState,
-} from 'react';
+import type { ComponentType } from 'react';
+import React, { Component, useEffect, useMemo, useState } from 'react';
 import Rect from './elements/Rect';
 import Circle from './elements/Circle';
 import Ellipse from './elements/Ellipse';
 import Polygon from './elements/Polygon';
 import Polyline from './elements/Polyline';
 import Line from './elements/Line';
-import Svg, { SvgProps } from './elements/Svg';
+import type { SvgProps } from './elements/Svg';
+import Svg from './elements/Svg';
 import Path from './elements/Path';
 import G from './elements/G';
 import Text from './elements/Text';


### PR DESCRIPTION
# Summary

We hit issues when building react-native-svg because of inconsistent use of `import type`. This change adds ESLint result to ensure consistency. I also ran `yarn lint --fix` to fix up the code.

Related to https://github.com/software-mansion/react-native-svg/pull/1874.

## Test Plan

`yarn lint` should succeed.

### What's required for testing (prerequisites)?

n/a

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [x] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
