### PR TITLE
fix: mask render on android

### DIFF
--- a/android/src/main/java/com/horcrux/svg/RenderableView.java
+++ b/android/src/main/java/com/horcrux/svg/RenderableView.java
@@ -366,7 +366,7 @@ public abstract class RenderableView extends VirtualView implements ReactHitSlop
       float maskY = (float) relativeOnHeight(mask.mY);
       float maskWidth = (float) relativeOnWidth(mask.mW);
       float maskHeight = (float) relativeOnHeight(mask.mH);
-      maskCanvas.clipRect(maskX, maskY, maskWidth, maskHeight);
+      maskCanvas.clipRect(maskX, maskY, maskWidth + maskX, maskHeight + maskY);
 
       Paint maskPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
       mask.draw(maskCanvas, maskPaint, 1);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Currently, there is a bug, that lead to incorrect svg render on android devices. That PR fixes this bug on android.
SVG on android:
![image](https://user-images.githubusercontent.com/9139860/216385439-14cd239c-efc7-4d72-82b2-b2de958cd30f.png)
SVG on ios and web:
![image](https://user-images.githubusercontent.com/9139860/216386643-826898dd-bb99-4552-bd7f-ab061091bde5.png)

## Test Plan
Example component that render incorrectly:
````
import * as React from 'react';
import { SvgXml } from 'react-native-svg';

const xml = `
<svg width="190" height="172" viewBox="0 0 190 172" fill="none" xmlns="http://www.w3.org/2000/svg"><circle cx="96" cy="86" r="79" fill="#FF891D"/><mask id="a" mask-type="alpha" maskUnits="userSpaceOnUse" x="17" y="7" width="158" height="158"><circle cx="96" cy="86" r="79" fill="#fff"/></mask><g mask="url(#a)"><rect x="-13" y="6" width="71" height="32" rx="4" fill="#FFAF65"/><rect x="-13" y="87" width="71" height="32" rx="4" fill="#FFAF65"/><rect x="26" y="46" width="71" height="32" rx="4" fill="#FFAF65"/><rect x="26" y="127" width="71" height="32" rx="4" fill="#FFAF65"/><rect x="66" y="6" width="71" height="32" rx="4" fill="#FFAF65"/><rect x="66" y="87" width="71" height="32" rx="4" fill="#FFAF65"/><rect x="105" y="46" width="71" height="32" rx="4" fill="#FFAF65"/><rect x="105" y="127" width="71" height="32" rx="4" fill="#FFAF65"/><rect x="145" y="6" width="71" height="32" rx="4" fill="#FFAF65"/><rect x="145" y="87" width="71" height="32" rx="4" fill="#FFAF65"/></g></svg>
`;

export default () => <SvgXml xml={xml} width="100%" height="100%" />;
````

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    Already worked correctly    |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [ ] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
