### PR TITLE
Don't set `self.opaque = false` on macOS

### DIFF
--- a/apple/Elements/RNSVGSvgView.mm
+++ b/apple/Elements/RNSVGSvgView.mm
@@ -45,8 +45,10 @@ using namespace facebook::react;
 #ifdef RCT_NEW_ARCH_ENABLED
     static const auto defaultProps = std::make_shared<const RNSVGSvgViewProps>();
     _props = defaultProps;
+#if !TARGET_OS_OSX // On macOS, views are transparent by default
     // TODO: think if we can do it better
     self.opaque = NO;
+#endif // TARGET_OS_OSX
 #endif // RCT_NEW_ARCH_ENABLED
   }
   return self;

--- a/apple/RNSVGNode.mm
+++ b/apple/RNSVGNode.mm
@@ -34,7 +34,9 @@ CGFloat const RNSVG_DEFAULT_FONT_SIZE = 12;
 {
   if (self = [super init]) {
     self.opacity = 1;
+#if !TARGET_OS_OSX // On macOS, views are transparent by default
     self.opaque = false;
+#endif
     self.matrix = CGAffineTransformIdentity;
     self.transforms = CGAffineTransformIdentity;
     self.invTransform = CGAffineTransformIdentity;
@@ -596,7 +598,9 @@ CGFloat const RNSVG_DEFAULT_FONT_SIZE = 12;
   [super prepareForRecycle];
 
   self.opacity = 1;
+#if !TARGET_OS_OSX // On macOS, views are transparent by default
   self.opaque = false;
+#endif
   self.matrix = CGAffineTransformIdentity;
   self.transforms = CGAffineTransformIdentity;
   self.invTransform = CGAffineTransformIdentity;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Hi, guys. In recent react-native-macos versions, react-native-svg is broken.
The reason for this is because https://github.com/microsoft/react-native-macos/pull/1612 addressed some of the compiler warnings they were having, one of the being not redefining `opaque` for `NSView`.

Now I see that you have a couple of `#ifdefs` to deal with this already, but the check is not everywhere.
This PR fixes this.

## Test Plan

Test latest react-native-macos master with react-native-svg and it will complain that `opaque` is `readonly`.
With this PR, the issue is fixed.


### What are the steps to reproduce (after prerequisites)?

Just using react-native-svg.