### PR TITLE
Fix SVG parsing when the closing tags include whitespace

### DIFF
--- a/src/xml.tsx
+++ b/src/xml.tsx
@@ -429,6 +429,7 @@ export function parse(source: string, middleware?: Middleware): JsxAST | null {
       );
     }
 
+    allowSpaces();
     if (source[i] !== '>') {
       error('Expected >');
     }


### PR DESCRIPTION
# Summary

Fixes https://github.com/software-mansion/react-native-svg/issues/2011

Allows whitespace to be used in the closing tag

## Test Plan

Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

### What's required for testing (prerequisites)?
See original issue

### What are the steps to reproduce (after prerequisites)?
See original issue

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [ ] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
