### PR TITLE
fix: read svg file on android

### DIFF
--- a/src/xml.tsx
+++ b/src/xml.tsx
@@ -122,7 +122,7 @@ export function SvgXml(props: XmlProps) {
 
 export async function fetchText(uri: string) {
   const response = await fetch(uri);
-  if (response.ok) {
+  if (response.ok  || response['_bodyBlob']) {
     return await response.text();
   }
   throw new Error(`Fetching ${uri} failed with status ${response.status}`);


### PR DESCRIPTION
Fixes #2002.

I used the [repo](https://github.com/Balintataw/android-filesystem-svg) provided by @Balintataw to test this fix.

The problem is `response.ok` is `true` for iOS and `false` for Android. Not sure why.

Here's the response I got,

iOS:
```
{
  "type": "default",
  "status": 200,
  "ok": true,
  "statusText": "",
  "headers": {
    "map": {
      "content-type": "image/svg+xml"
    }
  },
  "url": "file:///Users/ganapathy/Library/Developer/CoreSimulator/Devices/489FCC72-D532-4391-A87E-660EB64C358B/data/Containers/Data/Application/DEFD8517-5A39-4278-9A71-88DE00618B8C/Documents/icon.svg",
  "bodyUsed": false,
  "_bodyInit": {
    "_data": {
      "size": 1221,
      "offset": 0,
      "blobId": "54A00EA9-F868-40D3-B330-24986404443D",
      "type": "image/svg+xml",
      "name": "icon.svg",
      "__collector": {}
    }
  },
  "_bodyBlob": {
    "_data": {
      "size": 1221,
      "offset": 0,
      "blobId": "54A00EA9-F868-40D3-B330-24986404443D",
      "type": "image/svg+xml",
      "name": "icon.svg",
      "__collector": {}
    }
  }
}
```

Android:
```
{
  "type": "default",
  "status": 0,
  "ok": false,
  "statusText": "",
  "headers": {
    "map": {
      "content-type": "image/svg+xml"
    }
  },
  "url": "",
  "bodyUsed": false,
  "_bodyInit": {
    "_data": {
      "lastModified": 0,
      "name": "icon.svg",
      "size": 1221,
      "offset": 0,
      "type": "image/svg+xml",
      "blobId": "6c643b8f-eb09-410a-beb5-8e6c8251b467",
      "__collector": {}
    }
  },
  "_bodyBlob": {
    "_data": {
      "lastModified": 0,
      "name": "icon.svg",
      "size": 1221,
      "offset": 0,
      "type": "image/svg+xml",
      "blobId": "6c643b8f-eb09-410a-beb5-8e6c8251b467",
      "__collector": {}
    }
  }
}
```

- [x] I have tested this on a simulator
- [ ] ~~I added documentation in `README.md`~~
- [ ] ~~I updated the typed files (typescript)~~
- [ ] I added a test for the API in the `__tests__` folder
