### PR TITLE
fix: remove deprecated import from react-native-web

### DIFF
--- a/src/ReactNativeSVG.web.ts
+++ b/src/ReactNativeSVG.web.ts
@@ -2,8 +2,7 @@ import * as React from 'react';
 import type { GestureResponderEvent, TransformsStyle } from 'react-native';
 import {
   // @ts-ignore
-  unstable_createElement as ucE,
-  createElement as cE,
+  unstable_createElement as createElement,
 } from 'react-native';
 import type {
   NumberArray,
@@ -13,8 +12,6 @@ import type {
 import SvgTouchableMixin from './lib/SvgTouchableMixin';
 import { resolve } from './lib/resolve';
 import { transformsArrayToProps } from './lib/extract/extractTransform';
-
-const createElement = cE || ucE;
 
 type BlurEvent = Object;
 type FocusEvent = Object;


### PR DESCRIPTION
# Summary

Since v13.9.0 `react-native-svg` no longer ships with imports transpiled down to CommonJS. Building a web app with Webpack will now result in this error:

```
ERROR in ./node_modules/react-native-svg/lib/module/ReactNativeSVG.web.js 8:22-24

export 'createElement' (imported as 'cE') was not found in 'react-native' (possible exports: AccessibilityInfo, ActivityIndicator, Alert, Animated, AppRegistry, AppState, Appearance, BackHandler, Button, CheckBox, Clipboard, DeviceEventEmitter, Dimensions, Easing, FlatList, I18nManager, Image, ImageBackground, InteractionManager, Keyboard, KeyboardAvoidingView, LayoutAnimation, Linking, LogBox, Modal, NativeEventEmitter, NativeModules, PanResponder, Picker, PixelRatio, Platform, Pressable, ProgressBar, RefreshControl, SafeAreaView, ScrollView, SectionList, Share, StatusBar, StyleSheet, Switch, Text, TextInput, Touchable, TouchableHighlight, TouchableNativeFeedback, TouchableOpacity, TouchableWithoutFeedback, UIManager, Vibration, View, VirtualizedList, YellowBox, findNodeHandle, processColor, render, unmountComponentAtNode, unstable_createElement, useColorScheme, useLocaleContext, useWindowDimensions)
```

I'm guessing both variants were imported to increase compatibility, but `createElement` was renamed to `unstable_createElement` in [React Native Web v0.12.0](https://github.com/necolas/react-native-web/releases/tag/0.12.0), which was released 3 years ago. It's probably time to get rid of the old one.

Related issue: #2020

## Test Plan

### What's required for testing (prerequisites)?

A web project with React Native Web 0.12+ and Webpack 5

### What are the steps to reproduce (after prerequisites)?

Starting the project will result in this non-fatal error