### PR TITLE
Fix importing createElement from React Native instead of React

### DIFF
--- a/src/ReactNativeSVG.web.ts
+++ b/src/ReactNativeSVG.web.ts
@@ -1,10 +1,5 @@
 import * as React from 'react';
 import type { GestureResponderEvent, TransformsStyle } from 'react-native';
-import {
-  // @ts-ignore
-  unstable_createElement as ucE,
-  createElement as cE,
-} from 'react-native';
 import type {
   NumberArray,
   NumberProp,
@@ -14,7 +9,7 @@ import SvgTouchableMixin from './lib/SvgTouchableMixin';
 import { resolve } from './lib/resolve';
 import { transformsArrayToProps } from './lib/extract/extractTransform';
 
-const createElement = cE || ucE;
+const createElement = React.createElement || React.unstable_createElement;
 
 type BlurEvent = Object;
 type FocusEvent = Object;


### PR DESCRIPTION
# Summary

Explain the **motivation** for making this change: here are some points to help you:

When bundling a React Native project with ESBuild, I noticed it complaining about how:

```ts
import {
// @ts-ignore
unstable_createElement as ucE, createElement as cE } from 'react-native';
```

This code struck me as curious, as `createElement` should be coming from React first-of-all, and secondly I was wondering if the `@ts-ignore` is masking the underlying issue

I'm creating this PR to hopefully highlight the root of the issue, whether the code herein is the solution or not

🙏 Apologies for the lack of reproduction and/or accompanying tests. Do let me know how to best support moving this forward should those be necessary

## Test Plan

Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

### What's required for testing (prerequisites)?

If the existing tests pass, I'd consider this an equivalent change

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ❌     |
| Web |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator - I have tested this via my ESBuild script
- [ ] I added documentation in `README.md`
- [ ] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
