### PR TITLE
fix: Updating iOS version #2038

### DIFF
--- a/RNSVG.podspec
+++ b/RNSVG.podspec
@@ -23,7 +23,7 @@ Pod::Spec.new do |s|
       'HEADER_SEARCH_PATHS' => '"$(PODS_ROOT)/boost" "$(PODS_ROOT)/boost-for-react-native"  "$(PODS_ROOT)/RCT-Folly"',
       "CLANG_CXX_LANGUAGE_STANDARD" => "c++17",
     }
-    s.platforms       = { ios: '11.0', tvos: '11.0' }
+    s.platforms       = { ios: '12.4', tvos: '11.0' }
     s.compiler_flags  = folly_compiler_flags + ' -DRCT_NEW_ARCH_ENABLED'
     s.source_files    = 'apple/**/*.{h,m,mm,cpp}'
     s.ios.exclude_files = '**/*.macos.{h,m,mm,cpp}'


### PR DESCRIPTION
# Summary

Fix for #2038. Increased iOS Version which fixes the build. 

## Test Plan

Checked the change locally. Also ran `yarn test` without issues. 

### What's required for testing (prerequisites)?
Xcode 14.3 is needed for testing.

### What are the steps to reproduce (after prerequisites)?
Build any project using this library. 

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

Only iOS is affected.

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [ ] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
