### PR TITLE
Fix compilation errors on Windows

### DIFF
--- a/windows/RNSVG/GroupView.cpp
+++ b/windows/RNSVG/GroupView.cpp
@@ -184,7 +184,7 @@ winrt::RNSVG::IRenderable GroupView::HitTest(Windows::Foundation::Point const &p
       }
     }
     if (renderable && !renderable.IsResponsible()) {
-      renderable = *this;
+      return *this;
     } else if (!renderable){
       if (!Geometry()) {
         if (auto const &svgRoot{SvgRoot()}) {
@@ -194,7 +194,7 @@ winrt::RNSVG::IRenderable GroupView::HitTest(Windows::Foundation::Point const &p
       if (Geometry()) {
         auto const &bounds{Geometry().ComputeBounds()};
         if (Windows::UI::Xaml::RectHelper::Contains(bounds, point)) {
-          renderable = *this;
+          return *this;
         }
       }
     }

--- a/windows/RNSVG/PathView.cpp
+++ b/windows/RNSVG/PathView.cpp
@@ -5,6 +5,7 @@
 #endif
 
 #include <winrt/Microsoft.Graphics.Canvas.Svg.h>
+#include <cctype>
 
 #include "JSValueXaml.h"
 #include "Utils.h"


### PR DESCRIPTION
# Summary

I am seeing compile errors on Windows with clang 12.0.1 such as
```
stderr: node_modules\react-native-svg\windows\RNSVG\PathView.cpp:188:10: error: no member named 'isdigit' in namespace 'std'; did you mean simply 'isdigit'?
  return std::isdigit(static_cast<unsigned char>(c));
         ^~~~~~~~~~~~
         isdigit
C:\open\fbsource\third-party\toolchains\windows10sdk\10.0.18362.0\Include\10.0.18362.0/ucrt\ctype.h:35:56: note: 'isdigit' declared here
_Check_return_ _CRT_JIT_INTRINSIC _ACRTIMP int __cdecl isdigit(_In_ int _C);
                                                       ^
node_modules\react-native-svg\windows\RNSVG\PathView.cpp:192:10: error: no member named 'isupper' in namespace 'std'; did you mean simply 'isupper'?
  return std::isupper(static_cast<unsigned char>(c));
         ^~~~~~~~~~~~
         isupper
C:\open\fbsource\third-party\toolchains\windows10sdk\10.0.18362.0\Include\10.0.18362.0/ucrt\ctype.h:29:56: note: 'isupper' declared here
_Check_return_ _CRT_JIT_INTRINSIC _ACRTIMP int __cdecl isupper(_In_ int _C);
                                                       ^
node_modules\react-native-svg\windows\RNSVG\PathView.cpp:196:10: error: no member named 'isspace' in namespace 'std'; did you mean simply 'isspace'?
  return std::isspace(static_cast<unsigned char>(c));
```

Here we are missing a https://en.cppreference.com/w/cpp/header/cctype import

And
```
third-party\microsoft-fork-of-react-native\public\node_modules\react-native-svg\windows\RNSVG\GroupView.cpp:197:24: error: no viable conversion from 'winrt::RNSVG::implementation::GroupView' to 'winrt::RNSVG::IRenderable'
          renderable = *this;
```
Here we either return or need to static_cast

## Test Plan

Is there a build job validation the Windows build?

I am not quite sure how to test this project on windows as even w/o my changes I am hitting compilation errors in VS 2022 (after a fresh clone and after running `yarn install`)

### What's required for testing (prerequisites)?

Windows + clang

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Fixed |
| ------- | :---------: |
| Windows     |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [ ] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
