### PR TITLE
Fix setNativeProps type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "13.8.0",
+  "version": "13.9.0",
   "name": "react-native-svg",
   "description": "SVG library for react-native",
   "homepage": "https://github.com/react-native-community/react-native-svg",

--- a/src/elements/G.tsx
+++ b/src/elements/G.tsx
@@ -7,7 +7,6 @@ import type {
   CommonPathProps,
   FontProps,
   NumberProp,
-  TransformProps,
 } from '../lib/extract/types';
 import Shape from './Shape';
 import RNSVGGroup from '../fabric/GroupNativeComponent';
@@ -22,9 +21,10 @@ export default class G<P> extends Shape<GProps & P> {
   static displayName = 'G';
 
   setNativeProps = (
-    props: Object & {
-      matrix?: number[];
-    } & TransformProps,
+    props: GProps &
+      P & {
+        matrix?: number[];
+      },
   ) => {
     const matrix = !props.matrix && extractTransform(props);
     if (matrix) {

--- a/src/elements/Polygon.tsx
+++ b/src/elements/Polygon.tsx
@@ -17,8 +17,7 @@ export default class Polygon extends Shape<PolygonProps> {
   };
 
   setNativeProps = (
-    props: Object & {
-      points?: string | NumberProp[];
+    props: PolygonProps & {
       d?: string;
     },
   ) => {

--- a/src/elements/Polyline.tsx
+++ b/src/elements/Polyline.tsx
@@ -17,8 +17,7 @@ export default class Polyline extends Shape<PolylineProps> {
   };
 
   setNativeProps = (
-    props: Object & {
-      points?: string | NumberProp[];
+    props: PolylineProps & {
       d?: string;
     },
   ) => {

--- a/src/elements/Shape.tsx
+++ b/src/elements/Shape.tsx
@@ -249,7 +249,7 @@ export default class Shape<P> extends Component<P> {
     return this.root;
   }
   setNativeProps = (
-    props: Object & {
+    props: P & {
       matrix?: ColumnMajorTransformMatrix;
       fill?: ColorValue;
     } & TransformProps,

--- a/src/elements/Svg.tsx
+++ b/src/elements/Svg.tsx
@@ -69,9 +69,7 @@ export default class Svg extends Shape<SvgProps> {
   };
 
   setNativeProps = (
-    props: Object & {
-      width?: NumberProp;
-      height?: NumberProp;
+    props: SvgProps & {
       bbWidth?: NumberProp;
       bbHeight?: NumberProp;
     },

--- a/src/elements/TSpan.tsx
+++ b/src/elements/TSpan.tsx
@@ -12,7 +12,6 @@ import type {
   FontProps,
   NumberArray,
   NumberProp,
-  TransformProps,
 } from '../lib/extract/types';
 import RNSVGTSpan from '../fabric/TSpanNativeComponent';
 
@@ -30,10 +29,10 @@ export default class TSpan extends Shape<TSpanProps> {
   static displayName = 'TSpan';
 
   setNativeProps = (
-    props: Object & {
+    props: TSpanProps & {
       matrix?: ColumnMajorTransformMatrix;
       style?: [] | {};
-    } & TransformProps,
+    },
   ) => {
     const matrix = !props.matrix && extractTransform(props);
     if (matrix) {

--- a/src/elements/Text.tsx
+++ b/src/elements/Text.tsx
@@ -8,7 +8,6 @@ import type {
   NumberArray,
   NumberProp,
   TextSpecificProps,
-  TransformProps,
 } from '../lib/extract/types';
 import { pickNotNil } from '../lib/util';
 import Shape from './Shape';
@@ -30,10 +29,10 @@ export default class Text extends Shape<TextProps> {
   static displayName = 'Text';
 
   setNativeProps = (
-    props: Object & {
+    props: TextProps & {
       matrix?: ColumnMajorTransformMatrix;
       style?: [] | {};
-    } & TransformProps,
+    },
   ) => {
     const matrix = props && !props.matrix && extractTransform(props);
     if (matrix) {


### PR DESCRIPTION
# Summary

Setting Object to the props type does not allow passing any object to the method. So in TypeScript when using the method for example with Path, you will get an error when passing the d:

```typescript
this.pathComponent?.setNativeProps({ d })
```

```typescript
Argument of type '{ d: string; }' is not assignable to parameter of type 'Object & { matrix?: ColumnMajorTransformMatrix | undefined; fill?: ColorValue | undefined; } & TransformProps'.
  Object literal may only specify known properties, and 'd' does not exist in type 'Object & { matrix?: ColumnMajorTransformMatrix | undefined; fill?: ColorValue | undefined; } & TransformProps'
.ts(2345)
```

Instead ob Object, you should use at least P so it allows the original props of the component you are using.

## Test Plan

Only Type checking is modified, so it does not affect the functionality.

## Compatibility

Not aplicable

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [x ] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
