### PR TITLE
docs: Update deprecated expo install instructions to `npx expo install´

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,14 @@
 
 ## Installation
 
-### With expo-cli
+### With expo
 
 > ✅ The [Expo client app](https://expo.io/tools) comes with the native code installed!
 
 Install the JavaScript with:
 
 ```bash
-expo install react-native-svg
+npx expo install react-native-svg
 ```
 
 📚 See the [**Expo docs**](https://docs.expo.io/versions/latest/sdk/svg/) for more info or jump ahead to [Usage](#usage).


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Update Readme

Changed expo install react-native-svg to npx expo install react-native-svg, because global expo-cli is deprecated [docs-expo-cli](https://docs.expo.dev/archive/expo-cli/)

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [x] I added documentation in `README.md`
- [ ] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
