### PR TITLE
feat: SvgFromUri/SvgFromXml add props onError execution

### DIFF
--- a/src/xml.tsx
+++ b/src/xml.tsx
@@ -174,6 +174,7 @@ export class SvgFromXml extends Component<XmlProps, XmlState> {
     try {
       this.setState({ ast: xml ? parse(xml) : null });
     } catch (e) {
+      this.props.onError?.(e);
       console.error(e);
     }
   }
@@ -204,6 +205,7 @@ export class SvgFromUri extends Component<UriProps, UriState> {
     try {
       this.setState({ xml: uri ? await fetchText(uri) : null });
     } catch (e) {
+      this.props.onError?.(e);
       console.error(e);
     }
   }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

The `onError` function of the `SvgFromUri` / `SvgFromXml` component does not work.
According to the current code, there is no way to track if an error occurs in the component rendering.

## Test Plan

### What's required for testing (prerequisites)?
`uri` fetch fails.

### What are the steps to reproduce (after prerequisites)?
Pass the `onError` function as props to test whether it is executed.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [ ] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
