### PR TITLE
[macOS][Xcode 15] Avoid using dirtyRect in `drawRect:`

### DIFF
--- a/apple/Elements/RNSVGSvgView.mm
+++ b/apple/Elements/RNSVGSvgView.mm
@@ -293,7 +293,7 @@ using namespace facebook::react;
   _boundingBox = rect;
   CGContextRef context = UIGraphicsGetCurrentContext();
 
-  [self drawToContext:context withRect:rect];
+  [self drawToContext:context withRect:[self bounds]];
 }
 
 - (RNSVGPlatformView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event


### PR DESCRIPTION
# Summary

Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?

See: 
- https://github.com/expo/orbit/issues/30 
- https://indiestack.com/2023/06/view-clipping-sonoma/
- https://developer.apple.com/documentation/macos-release-notes/appkit-release-notes-for-macos-14#NSView
Apple made a breaking change in Xcode 15 / macOS Sonoma which breaks usages of `drawRect:`. You can no longer trust that the OS will provide you a dirtyRect will be within the bounds of your view. Specifically (from the appkit release notes):
> Filling the dirty rect of a view inside of -drawRect. A fairly common pattern is to simply rect fill the dirty rect passed into an override of NSView.draw(). The dirty rect can now extend outside of your view’s bounds. This pattern can be adjusted by filling the bounds instead of the dirty rect, or by setting clipsToBounds = true.

This led to an unfortunate bug where _any_ SVG drawn took up the full width/height of your window. Let's follow Apple's advice and draw using `[self bounds]` instead of `dirtyRect`.

## Test Plan

I built our [FluentUI React Native test app](https://github.com/microsoft/fluentui-react-native/tree/main/apps/fluent-tester) with and without the one line change on Xcode 15. Notice how without the change, the chevron that is otherwise in the top right dropdown takes up the whole window.

Before:
 ![Screenshot 2023-09-15 at 1 37 32 PM](https://github.com/software-mansion/react-native-svg/assets/6722175/95a862ec-4a64-476b-b11c-631640c58dd7)
 
 After:
 ![Screenshot 2023-09-15 at 1 47 25 PM](https://github.com/software-mansion/react-native-svg/assets/6722175/2c61066d-61ea-46c3-a58f-e849a0b6567f)



## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [ ] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
