### PR TITLE
fix: error for transform on web

### DIFF
--- a/src/ReactNativeSVG.web.ts
+++ b/src/ReactNativeSVG.web.ts
@@ -223,9 +223,19 @@ const prepare = <T extends BaseProps>(
     clean['transform-origin'] = `${originX || 0} ${originY || 0}`;
   }
 
-  clean.transform = parseTransformProp(transform, props);
-  clean.gradientTransform = parseTransformProp(gradientTransform);
-  clean.patternTransform = parseTransformProp(patternTransform);
+  // we do it like this because setting transform as undefined causes error in web
+  const parsedTransform = parseTransformProp(transform, props);
+  if (parsedTransform) {
+    clean.transform = parsedTransform;
+  }
+  const parsedGradientTransform = parseTransformProp(gradientTransform);
+  if (parsedGradientTransform) {
+    clean.gradientTransform = parsedGradientTransform;
+  }
+  const parsedPatternTransform = parseTransformProp(patternTransform);
+  if (parsedPatternTransform) {
+    clean.patternTransform = parsedPatternTransform;
+  }
 
   clean.ref = (el: SVGElement | null) => {
     self.elementRef.current = el;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Setting `transform` prop of svg component as `undefined` in web causes the error, so we set it only if the parsed value is not `undefined`.

## Test Plan

Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅❌     |
| Android |    ✅❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [ ] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
