### PR TITLE
Build `renderer/components/rnsvg` with `-std=c++20`

### DIFF
--- a/RNSVG.podspec
+++ b/RNSVG.podspec
@@ -20,8 +20,6 @@ Pod::Spec.new do |s|
 
   if fabric_enabled
     s.platforms = { :osx => "10.14", ios: '12.4', tvos: '11.0' }
-    s.pod_target_xcconfig = { "CLANG_CXX_LANGUAGE_STANDARD" => "c++20" }
-
     install_modules_dependencies(s)
 
     s.subspec "common" do |ss|

--- a/RNSVG.podspec
+++ b/RNSVG.podspec
@@ -20,6 +20,8 @@ Pod::Spec.new do |s|
 
   if fabric_enabled
     s.platforms = { :osx => "10.14", ios: '12.4', tvos: '11.0' }
+    s.pod_target_xcconfig = { "CLANG_CXX_LANGUAGE_STANDARD" => "c++20" }
+
     install_modules_dependencies(s)
 
     s.subspec "common" do |ss|
@@ -27,7 +29,7 @@ Pod::Spec.new do |s|
       ss.header_dir           = "rnsvg"
       ss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/common/cpp\"" }
     end
-  else 
+  else
     s.platforms         = { :osx => "10.14", :ios => "10.0", :tvos => "9.2" }
     s.exclude_files      = 'apple/Utils/RNSVGFabricConversions.h'
     s.dependency           'React-Core'

--- a/android/src/main/jni/CMakeLists.txt
+++ b/android/src/main/jni/CMakeLists.txt
@@ -10,7 +10,7 @@ set(RNS_GENERATED_REACT_DIR ${RNS_GENERATED_JNI_DIR}/react/renderer/components/r
 add_compile_options(
   -fexceptions
   -frtti
-  -std=c++17
+  -std=c++20
   -Wall
   -Wpedantic
   -Wno-gnu-zero-variadic-macro-arguments


### PR DESCRIPTION
# Summary

RN 0.73 adds the requirement that ComponentViews, ShadowNodws, etc, build using C++ 20. This adds the flags to do that when building for Android.

## Test Plan

Locally validated this does not prevent us from building earlier RN Fabric (at least 0.72), by changing the flags in CMakeLists.txt, then running `./gradlew assembleDebug` in `FabricExample`.

I think RN on iOS will set C++ version for you [during pod install](https://github.com/facebook/react-native/commit/ca8174e15f77cbeecb7ff7a5a583abb668817777).

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [ ] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
