### PR TITLE
enable buildConfig generation to better support AGP8

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -43,6 +43,11 @@ android {
     if (agpVersion.tokenize('.')[0].toInteger() >= 7) {
         namespace "com.horcrux.svg"
     }
+    if (agpVersion.tokenize('.')[0].toInteger() >= 8) {
+        buildFeatures {
+            buildConfig = true
+        }
+    }
     // Used to override the NDK path/version on internal CI or by allowing
     // users to customize the NDK path/version from their root project (e.g. for M1 support)
     if (rootProject.hasProperty("ndkPath")) {


### PR DESCRIPTION
So that consumer projects don't have to globally enable this themselves leading to performance impact

# Summary

Since AGP8 this flag is disabled by default. Consumer projects have to enable this flag in them **globally** if the library doesn't do this correctly itself, but uses custom buildConfig fields.

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
Solves Build Errors with default setup using AGP8+
* What is the feature? (if applicable)
No errors and better build performance than the workaround in consuming projects would be.
* How did you implement the solution?
* What areas of the library does it impact?

## Test Plan

Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    N/A     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ x ] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [ ] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
