### PR TITLE
perf: avoid unnecessary shared_ptr copies in Fabric components

### DIFF
--- a/apple/Elements/RNSVGClipPath.mm
+++ b/apple/Elements/RNSVGClipPath.mm
@@ -39,7 +39,7 @@ using namespace facebook::react;
 
 - (void)updateProps:(Props::Shared const &)props oldProps:(Props::Shared const &)oldProps
 {
-  const auto &newProps = *std::static_pointer_cast<const RNSVGClipPathProps>(props);
+  const auto &newProps = static_cast<const RNSVGClipPathProps &>(*props);
   setCommonNodeProps(newProps, self);
   _props = std::static_pointer_cast<RNSVGClipPathProps const>(props);
 }

--- a/apple/Elements/RNSVGForeignObject.mm
+++ b/apple/Elements/RNSVGForeignObject.mm
@@ -41,7 +41,7 @@ using namespace facebook::react;
 
 - (void)updateProps:(Props::Shared const &)props oldProps:(Props::Shared const &)oldProps
 {
-  const auto &newProps = *std::static_pointer_cast<const RNSVGForeignObjectProps>(props);
+  const auto &newProps = static_cast<const RNSVGForeignObjectProps &>(*props);
 
   self.x = RCTNSStringFromStringNilIfEmpty(newProps.x)
       ? [RNSVGLength lengthWithString:RCTNSStringFromString(newProps.x)]

--- a/apple/Elements/RNSVGGroup.mm
+++ b/apple/Elements/RNSVGGroup.mm
@@ -43,7 +43,7 @@ using namespace facebook::react;
 
 - (void)updateProps:(Props::Shared const &)props oldProps:(Props::Shared const &)oldProps
 {
-  const auto &newProps = *std::static_pointer_cast<const RNSVGGroupProps>(props);
+  const auto &newProps = static_cast<const RNSVGGroupProps &>(*props);
 
   setCommonGroupProps(newProps, self);
   _props = std::static_pointer_cast<RNSVGGroupProps const>(props);

--- a/apple/Elements/RNSVGImage.mm
+++ b/apple/Elements/RNSVGImage.mm
@@ -72,7 +72,7 @@ using namespace facebook::react;
 
 - (void)updateProps:(Props::Shared const &)props oldProps:(Props::Shared const &)oldProps
 {
-  const auto &newProps = *std::static_pointer_cast<const RNSVGImageProps>(props);
+  const auto &newProps = static_cast<const RNSVGImageProps &>(*props);
 
   self.x = [RNSVGLength lengthWithString:RCTNSStringFromString(newProps.x)];
   self.y = [RNSVGLength lengthWithString:RCTNSStringFromString(newProps.y)];

--- a/apple/Elements/RNSVGLinearGradient.mm
+++ b/apple/Elements/RNSVGLinearGradient.mm
@@ -40,7 +40,7 @@ using namespace facebook::react;
 
 - (void)updateProps:(Props::Shared const &)props oldProps:(Props::Shared const &)oldProps
 {
-  const auto &newProps = *std::static_pointer_cast<const RNSVGLinearGradientProps>(props);
+  const auto &newProps = static_cast<const RNSVGLinearGradientProps &>(*props);
 
   self.x1 = [RNSVGLength lengthWithString:RCTNSStringFromString(newProps.x1)];
   self.y1 = [RNSVGLength lengthWithString:RCTNSStringFromString(newProps.y1)];

--- a/apple/Elements/RNSVGMarker.mm
+++ b/apple/Elements/RNSVGMarker.mm
@@ -42,7 +42,7 @@ using namespace facebook::react;
 
 - (void)updateProps:(Props::Shared const &)props oldProps:(Props::Shared const &)oldProps
 {
-  const auto &newProps = *std::static_pointer_cast<const RNSVGMarkerProps>(props);
+  const auto &newProps = static_cast<const RNSVGMarkerProps &>(*props);
 
   self.refX = [RNSVGLength lengthWithString:RCTNSStringFromString(newProps.refX)];
   self.refY = [RNSVGLength lengthWithString:RCTNSStringFromString(newProps.refY)];

--- a/apple/Elements/RNSVGMask.mm
+++ b/apple/Elements/RNSVGMask.mm
@@ -41,7 +41,7 @@ using namespace facebook::react;
 
 - (void)updateProps:(Props::Shared const &)props oldProps:(Props::Shared const &)oldProps
 {
-  const auto &newProps = *std::static_pointer_cast<const RNSVGMaskProps>(props);
+  const auto &newProps = static_cast<const RNSVGMaskProps &>(*props);
 
   self.x = [RNSVGLength lengthWithString:RCTNSStringFromString(newProps.x)];
   self.y = [RNSVGLength lengthWithString:RCTNSStringFromString(newProps.y)];

--- a/apple/Elements/RNSVGPath.mm
+++ b/apple/Elements/RNSVGPath.mm
@@ -41,7 +41,7 @@ using namespace facebook::react;
 
 - (void)updateProps:(Props::Shared const &)props oldProps:(Props::Shared const &)oldProps
 {
-  const auto &newProps = *std::static_pointer_cast<const RNSVGPathProps>(props);
+  const auto &newProps = static_cast<const RNSVGPathProps &>(*props);
   self.d = [[RNSVGPathParser alloc] initWithPathString:RCTNSStringFromString(newProps.d)];
 
   setCommonRenderableProps(newProps, self);

--- a/apple/Elements/RNSVGPattern.mm
+++ b/apple/Elements/RNSVGPattern.mm
@@ -41,7 +41,7 @@ using namespace facebook::react;
 
 - (void)updateProps:(Props::Shared const &)props oldProps:(Props::Shared const &)oldProps
 {
-  const auto &newProps = *std::static_pointer_cast<const RNSVGPatternProps>(props);
+  const auto &newProps = static_cast<const RNSVGPatternProps &>(*props);
 
   self.x = [RNSVGLength lengthWithString:RCTNSStringFromString(newProps.x)];
   self.y = [RNSVGLength lengthWithString:RCTNSStringFromString(newProps.y)];

--- a/apple/Elements/RNSVGRadialGradient.mm
+++ b/apple/Elements/RNSVGRadialGradient.mm
@@ -38,7 +38,7 @@ using namespace facebook::react;
 
 - (void)updateProps:(Props::Shared const &)props oldProps:(Props::Shared const &)oldProps
 {
-  const auto &newProps = *std::static_pointer_cast<const RNSVGRadialGradientProps>(props);
+  const auto &newProps = static_cast<const RNSVGRadialGradientProps &>(*props);
 
   self.fx = [RNSVGLength lengthWithString:RCTNSStringFromString(newProps.fx)];
   self.fy = [RNSVGLength lengthWithString:RCTNSStringFromString(newProps.fy)];

--- a/apple/Elements/RNSVGSvgView.mm
+++ b/apple/Elements/RNSVGSvgView.mm
@@ -64,7 +64,7 @@ using namespace facebook::react;
 
 - (void)updateProps:(Props::Shared const &)props oldProps:(Props::Shared const &)oldProps
 {
-  const auto &newProps = *std::static_pointer_cast<const RNSVGSvgViewProps>(props);
+  const auto &newProps = static_cast<const RNSVGSvgViewProps &>(*props);
 
   self.minX = newProps.minX;
   self.minY = newProps.minY;

--- a/apple/Elements/RNSVGSymbol.mm
+++ b/apple/Elements/RNSVGSymbol.mm
@@ -39,7 +39,7 @@ using namespace facebook::react;
 
 - (void)updateProps:(Props::Shared const &)props oldProps:(Props::Shared const &)oldProps
 {
-  const auto &newProps = *std::static_pointer_cast<const RNSVGSymbolProps>(props);
+  const auto &newProps = static_cast<const RNSVGSymbolProps &>(*props);
 
   self.minX = newProps.minX;
   self.minY = newProps.minY;

--- a/apple/Elements/RNSVGUse.mm
+++ b/apple/Elements/RNSVGUse.mm
@@ -40,7 +40,7 @@ using namespace facebook::react;
 
 - (void)updateProps:(Props::Shared const &)props oldProps:(Props::Shared const &)oldProps
 {
-  const auto &newProps = *std::static_pointer_cast<const RNSVGUseProps>(props);
+  const auto &newProps = static_cast<const RNSVGUseProps &>(*props);
 
   self.x = [RNSVGLength lengthWithString:RCTNSStringFromString(newProps.x)];
   self.y = [RNSVGLength lengthWithString:RCTNSStringFromString(newProps.y)];

--- a/apple/Shapes/RNSVGCircle.mm
+++ b/apple/Shapes/RNSVGCircle.mm
@@ -40,7 +40,7 @@ using namespace facebook::react;
 
 - (void)updateProps:(Props::Shared const &)props oldProps:(Props::Shared const &)oldProps
 {
-  const auto &newProps = *std::static_pointer_cast<const RNSVGCircleProps>(props);
+  const auto &newProps = static_cast<const RNSVGCircleProps &>(*props);
 
   self.cx = [RNSVGLength lengthWithString:RCTNSStringFromString(newProps.cx)];
   self.cy = [RNSVGLength lengthWithString:RCTNSStringFromString(newProps.cy)];

--- a/apple/Shapes/RNSVGEllipse.mm
+++ b/apple/Shapes/RNSVGEllipse.mm
@@ -40,7 +40,7 @@ using namespace facebook::react;
 
 - (void)updateProps:(Props::Shared const &)props oldProps:(Props::Shared const &)oldProps
 {
-  const auto &newProps = *std::static_pointer_cast<const RNSVGEllipseProps>(props);
+  const auto &newProps = static_cast<const RNSVGEllipseProps &>(*props);
 
   self.cx = [RNSVGLength lengthWithString:RCTNSStringFromString(newProps.cx)];
   self.cy = [RNSVGLength lengthWithString:RCTNSStringFromString(newProps.cy)];

--- a/apple/Shapes/RNSVGLine.mm
+++ b/apple/Shapes/RNSVGLine.mm
@@ -40,7 +40,7 @@ using namespace facebook::react;
 
 - (void)updateProps:(Props::Shared const &)props oldProps:(Props::Shared const &)oldProps
 {
-  const auto &newProps = *std::static_pointer_cast<const RNSVGLineProps>(props);
+  const auto &newProps = static_cast<const RNSVGLineProps &>(*props);
 
   self.x1 = [RNSVGLength lengthWithString:RCTNSStringFromString(newProps.x1)];
   self.y1 = [RNSVGLength lengthWithString:RCTNSStringFromString(newProps.y1)];

--- a/apple/Shapes/RNSVGRect.mm
+++ b/apple/Shapes/RNSVGRect.mm
@@ -40,7 +40,7 @@ using namespace facebook::react;
 
 - (void)updateProps:(Props::Shared const &)props oldProps:(Props::Shared const &)oldProps
 {
-  const auto &newProps = *std::static_pointer_cast<const RNSVGRectProps>(props);
+  const auto &newProps = static_cast<const RNSVGRectProps &>(*props);
 
   self.x = [RNSVGLength lengthWithString:RCTNSStringFromString(newProps.x)];
   self.y = [RNSVGLength lengthWithString:RCTNSStringFromString(newProps.y)];

--- a/apple/Text/RNSVGTSpan.mm
+++ b/apple/Text/RNSVGTSpan.mm
@@ -58,7 +58,7 @@ using namespace facebook::react;
 
 - (void)updateProps:(Props::Shared const &)props oldProps:(Props::Shared const &)oldProps
 {
-  const auto &newProps = *std::static_pointer_cast<const RNSVGTSpanProps>(props);
+  const auto &newProps = static_cast<const RNSVGTSpanProps &>(*props);
 
   self.content = RCTNSStringFromStringNilIfEmpty(newProps.content);
 

--- a/apple/Text/RNSVGText.mm
+++ b/apple/Text/RNSVGText.mm
@@ -49,7 +49,7 @@ using namespace facebook::react;
 
 - (void)updateProps:(Props::Shared const &)props oldProps:(Props::Shared const &)oldProps
 {
-  const auto &newProps = *std::static_pointer_cast<const RNSVGTextProps>(props);
+  const auto &newProps = static_cast<const RNSVGTextProps &>(*props);
 
   setCommonTextProps(newProps, self);
   _props = std::static_pointer_cast<RNSVGTextProps const>(props);

--- a/apple/Text/RNSVGTextPath.mm
+++ b/apple/Text/RNSVGTextPath.mm
@@ -39,7 +39,7 @@ using namespace facebook::react;
 
 - (void)updateProps:(Props::Shared const &)props oldProps:(Props::Shared const &)oldProps
 {
-  const auto &newProps = *std::static_pointer_cast<const RNSVGTextPathProps>(props);
+  const auto &newProps = static_cast<const RNSVGTextPathProps &>(*props);
 
   self.href = RCTNSStringFromStringNilIfEmpty(newProps.href);
   self.side = RCTNSStringFromStringNilIfEmpty(newProps.side);

--- a/common/cpp/react/renderer/components/rnsvg/RNSVGImageComponentDescriptor.h
+++ b/common/cpp/react/renderer/components/rnsvg/RNSVGImageComponentDescriptor.h
@@ -29,12 +29,11 @@ class RNSVGImageComponentDescriptor final
   void adopt(ShadowNode::Unshared const &shadowNode) const override {
     ConcreteComponentDescriptor::adopt(shadowNode);
 
-    auto imageShadowNode =
-        std::static_pointer_cast<RNSVGImageShadowNode>(shadowNode);
+    auto &imageShadowNode = static_cast<RNSVGImageShadowNode &>(*shadowNode);
 
     // `RNSVGImageShadowNode` uses `ImageManager` to initiate image loading and
     // communicate the loading state and results to mounting layer.
-    imageShadowNode->setImageManager(imageManager_);
+    imageShadowNode.setImageManager(imageManager_);
   }
 
  private:


### PR DESCRIPTION
# Summary

Ports the upstream best-practice around props handling of shared_ptr in https://github.com/facebook/react-native/commit/a855013fc6c963aca2282b6b43aeeb621eeb88d7

## Test Plan

Build and run the sample app

## Checklist

- [x] I have tested this on a device and a simulator
- [NA] I added documentation in `README.md`
- [NA] I updated the typed files (typescript)
- [NA] I added a test for the API in the `__tests__` folder
