### PR TITLE
Minor fix to prevent crash when Loaded fires twice

### DIFF
--- a/windows/RNSVG/SvgView.cpp
+++ b/windows/RNSVG/SvgView.cpp
@@ -202,8 +202,10 @@ void SvgView::CreateResources() {
 
 void SvgView::Panel_Loaded(IInspectable const &sender, xaml::RoutedEventArgs const & /*args*/) {
   if (auto const &svgView{sender.try_as<RNSVG::SvgView>()}) {
-    m_loaded = true;
-    svgView.CreateResources();
+    if (!m_loaded) {
+      m_loaded = true;
+      svgView.CreateResources();
+    }
   }
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged

There are many reasons `Loaded` can fire twice. Usually, it will happen when the native SvgView component is moved, but it can also happen if an ancestor of SvgView is reparented. There is a crash that appears to occur when we attempt to call CreateResources twice. This resolves that crash.

* What areas of the library does it impact?
Windows

## Test Plan

Ran a sample that appears to cause the SvgView to load twice. Without this change, the app crashes. With this change, the app no longer crashes.

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [ ] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
