### PR TITLE
fix: allow to array style prop

### DIFF
--- a/src/elements/Svg.tsx
+++ b/src/elements/Svg.tsx
@@ -183,7 +183,7 @@ export default class Svg extends Shape<SvgProps> {
       props.onLayout = onLayout;
     }
 
-    const gStyle = Object.assign({}, style) as ViewStyle;
+    const gStyle = Object.assign({}, StyleSheet.flatten(style ?? {}));
     // if transform prop is of RN style's kind, we want `SvgView` to handle it
     // since it can be done here. Otherwise, if transform is of `svg` kind, e.g. string,
     // we want G element to parse it since `Svg` does not include parsing of those custom transforms.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
- Previously, styles in "Array" format were not being applied correctly.
- Therefore, now ensure that styles in "Array" format are correctly applied using `StyleSheet.flatten.`


**Before: The `opacity` attribute is not correctly applied in `gStyle`.** :x:
```tsx
const gStyle = Object.assign({}, [{ opacity: 0.5 }]);
/* { 0: {opacity: 0.5 }} */
```

**After: Now, the `opacity` attribute is correctly applied in `gStyle`.** ✅ 
```tsx
const gStyle = Object.assign({}, StyleSheet.flatten([{ opacity: 0.5 }]));
/* { opacity: 0.5 } */
```

```tsx
const gStyle = Object.assign({}, StyleSheet.flatten([{ opacity: 0.5 }, { backgroundColor: 'red' }]));
/* { opacity: 0.5, backgroundColor: 'red' } */
```

## Test Plan

`0` key is not allow to `ViewStyle`

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅❌     |
| Android |    ✅❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [ ] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
