### PR TITLE
feat: add visionOS support

### DIFF
--- a/RNSVG.podspec
+++ b/RNSVG.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
   s.requires_arc    = true
 
   if fabric_enabled
-    s.platforms = { :osx => "10.14", ios: '12.4', tvos: '11.0' }
+    s.platforms = { :osx => "10.14", ios => "12.4", tvos => "11.0", :visionos => "1.0" }
     install_modules_dependencies(s)
 
     s.subspec "common" do |ss|
@@ -28,7 +28,7 @@ Pod::Spec.new do |s|
       ss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/common/cpp\"" }
     end
   else
-    s.platforms         = { :osx => "10.14", :ios => "10.0", :tvos => "9.2" }
+    s.platforms         = { :osx => "10.14", :ios => "10.0", :tvos => "9.2", :visionos => "1.0" }
     s.exclude_files      = 'apple/Utils/RNSVGFabricConversions.h'
     s.dependency           'React-Core'
   end

--- a/RNSVG.podspec
+++ b/RNSVG.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
   s.requires_arc    = true
 
   if fabric_enabled
-    s.platforms = { :osx => "10.14", ios => "12.4", tvos => "11.0", :visionos => "1.0" }
+    s.platforms = { :osx => "10.14", :ios => "12.4", :tvos => "11.0", :visionos => "1.0" }
     install_modules_dependencies(s)
 
     s.subspec "common" do |ss|

--- a/apple/RNSVGRenderable.mm
+++ b/apple/RNSVGRenderable.mm
@@ -248,7 +248,7 @@ UInt32 saturate(CGFloat value)
 #if TARGET_OS_OSX
     CGFloat scale = [[NSScreen mainScreen] backingScaleFactor];
 #else
-    CGFloat scale = [[UIScreen mainScreen] scale];
+    CGFloat scale = [UITraitCollection currentTraitCollection].displayScale;
 #endif // TARGET_OS_OSX
     NSUInteger iheight = (NSUInteger)height;
     NSUInteger iwidth = (NSUInteger)width;

--- a/apple/RNSVGRenderable.mm
+++ b/apple/RNSVGRenderable.mm
@@ -245,10 +245,17 @@ UInt32 saturate(CGFloat value)
     CGSize boundsSize = bounds.size;
     CGFloat height = boundsSize.height;
     CGFloat width = boundsSize.width;
+    CGFloat scale = 0.0;
 #if TARGET_OS_OSX
-    CGFloat scale = [[NSScreen mainScreen] backingScaleFactor];
+    scale = [[NSScreen mainScreen] backingScaleFactor];
 #else
-    CGFloat scale = [UITraitCollection currentTraitCollection].displayScale;
+    if (@available(iOS 13.0, *)) {
+      scale = [UITraitCollection currentTraitCollection].displayScale;
+    } else {
+#if !TARGET_OS_VISION
+      scale = [[UIScreen mainScreen] scale];
+#endif
+    }
 #endif // TARGET_OS_OSX
     NSUInteger iheight = (NSUInteger)height;
     NSUInteger iwidth = (NSUInteger)width;


### PR DESCRIPTION
# Summary

This PR adds support for visionOS. I've migrated the `UIScreen` API to take `displayScale` from `currentTraitCollection` - same as I did in Core (https://github.com/facebook/react-native/pull/41214/files) 

![image](https://github.com/software-mansion/react-native-svg/assets/52801365/6f313979-c106-40c8-b76f-687571dd18a1)

## Test Plan

1. Init new app with `npx @callstack/react-native-visionos init TestApp` 
2. `yarn add react-native-svg`
3. Install pods
4. Check if the app compiles 

### What's required for testing (prerequisites)?

Xcode 15.1 Beta

### What are the steps to reproduce (after prerequisites)?

Build the app

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator (Only on simulator 😅)
- [ ] I added documentation in `README.md`
- [ ] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
