### PR TITLE
Fix crash when SVG is unloaded by XAML

### DIFF
--- a/windows/RNSVG/GroupViewManager.cpp
+++ b/windows/RNSVG/GroupViewManager.cpp
@@ -71,11 +71,13 @@ void GroupViewManager::RemoveAllChildren(FrameworkElement const &parent) {
 
 void GroupViewManager::RemoveChildAt(FrameworkElement const &parent, int64_t index) {
   if (auto const &groupView{parent.try_as<RNSVG::GroupView>()}) {
-    auto const &child{groupView.Children().GetAt(static_cast<uint32_t>(index))};
-    child.Unload();
-    child.SvgParent(nullptr);
+    if (!groupView.IsUnloaded()) {
+      auto const &child{groupView.Children().GetAt(static_cast<uint32_t>(index))};
+      child.Unload();
+      child.SvgParent(nullptr);
 
-    groupView.Children().RemoveAt(static_cast<uint32_t>(index));
+      groupView.Children().RemoveAt(static_cast<uint32_t>(index));
+    }
 
     if (auto const &root{groupView.SvgRoot()}) {
       root.Invalidate();

--- a/windows/RNSVG/RenderableView.cpp
+++ b/windows/RNSVG/RenderableView.cpp
@@ -358,6 +358,7 @@ void RenderableView::Unload() {
   m_propList.clear();
   m_propSetMap.clear();
   m_strokeDashArray.Clear();
+  m_isUnloaded = true;
 }
 
 RNSVG::IRenderable RenderableView::HitTest(Point const &point) {
@@ -370,7 +371,7 @@ RNSVG::IRenderable RenderableView::HitTest(Point const &point) {
     if (auto const &svgRoot{SvgRoot()}) {
       float canvasDiagonal{Utils::GetCanvasDiagonal(svgRoot.ActualSize())};
       float strokeWidth{Utils::GetAbsoluteLength(StrokeWidth(), canvasDiagonal)};
-      
+
       check_hresult(geometry->StrokeContainsPoint(pointD2D, strokeWidth, nullptr, nullptr, &strokeContainsPoint));
     }
 

--- a/windows/RNSVG/RenderableView.h
+++ b/windows/RNSVG/RenderableView.h
@@ -25,6 +25,8 @@ struct RenderableView : RenderableViewT<RenderableView> {
   bool IsResponsible() { return m_isResponsible; }
   void IsResponsible(bool isResponsible) { m_isResponsible = isResponsible; }
 
+  bool IsUnloaded() { return m_isUnloaded; }
+
   hstring FillBrushId() { return m_fillBrushId; }
   Windows::UI::Color Fill() { return m_fill; }
   float FillOpacity() { return m_fillOpacity; }
@@ -73,7 +75,8 @@ struct RenderableView : RenderableViewT<RenderableView> {
   RNSVG::D2DGeometry m_geometry{nullptr};
   bool m_recreateResources{true};
   bool m_isResponsible{false};
-  
+  bool m_isUnloaded{false};
+
   hstring m_id{L""};
   hstring m_clipPathId{L""};
   Numerics::float3x2 m_transformMatrix{Numerics::make_float3x2_rotation(0)};

--- a/windows/RNSVG/Views.idl
+++ b/windows/RNSVG/Views.idl
@@ -38,6 +38,7 @@ namespace RNSVG
   {
     RenderableView(Microsoft.ReactNative.IReactContext context);
     SvgView SvgRoot{ get; };
+    Boolean IsUnloaded { get; };
 
     String Id{ get; };
     Windows.Foundation.Numerics.Matrix3x2 SvgTransform{ get; };


### PR DESCRIPTION

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

XAML may unload the root SVG panel, which will trigger a recursive unload. For GroupView, this unload will clear the child collection. However, active operations on the SVG from the React Native UIManager may still be in flight, in which case we may attempt to remove a child that has already been cleared by the root unload.

## Test Plan

This wouldn't repro in any of the existing examples, but the crash no longer occurs in our app.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅❌     |
| Android |    ✅❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [ ] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
