### PR TITLE
Fix type exports and enable `isolatedModules` setting to catch it in `tsc`

### DIFF
--- a/src/ReactNativeSVG.ts
+++ b/src/ReactNativeSVG.ts
@@ -141,15 +141,6 @@ export {
   camelCase,
   err,
   fetchText,
-  JsxAST,
-  Middleware,
-  Styles,
-  UriProps,
-  UriState,
-  XmlAST,
-  XmlProps,
-  XmlState,
-  AstProps,
   Shape,
   RNSVGMarker,
   RNSVGMask,
@@ -173,6 +164,18 @@ export {
   RNSVGSvgAndroid,
   RNSVGSvgIOS,
   RNSVGForeignObject,
+};
+
+export type {
+  JsxAST,
+  Middleware,
+  Styles,
+  UriProps,
+  UriState,
+  XmlAST,
+  XmlProps,
+  XmlState,
+  AstProps,
 };
 
 export default Svg;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "declaration": true,
     "paths": {
       "react-native-svg": ["./src"],
-      "react-native-svg/css": ["./src/css/index.tsx"],
+      "react-native-svg/css": ["./src/css/index.tsx"]
     },
     "preserveSymlinks": true,
     "target": "es6",
@@ -17,7 +17,8 @@
     "esModuleInterop": true,
     "strict": true,
     "forceConsistentCasingInFileNames": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "isolatedModules": true
   },
   "include": ["src"]
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

This is the same issue as the one I fixed last year in #1874

To prevent this from occurring again, I enabled the `isolatedModules` Typescript option which will warn when you export non-value identifiers without using `export type`, which will break transpilation processes what work on a per-file basis. You can find a [more detailed explanation in Typescript's doc](https://www.typescriptlang.org/tsconfig#isolatedModules)

## Test Plan

I used this patch in my own app using [@rnx-kit/metro-serializer-esbuild](https://microsoft.github.io/rnx-kit/docs/tools/metro-serializer-esbuild) and it builds correctly. The preview version was already using `export type` without any reported issues.

## Compatibility

Not relevant

## Checklist

Not relevant
