### PR TITLE
fix: Fix combining of ClipPath child elements on Android

### DIFF
--- a/android/src/main/java/com/horcrux/svg/VirtualView.java
+++ b/android/src/main/java/com/horcrux/svg/VirtualView.java
@@ -355,10 +355,7 @@ public abstract class VirtualView extends ReactViewGroup {
       ClipPathView mClipNode = (ClipPathView) getSvgView().getDefinedClipPath(mClipPath);
 
       if (mClipNode != null) {
-        Path clipPath =
-            mClipRule == CLIP_RULE_EVENODD
-                ? mClipNode.getPath(canvas, paint)
-                : mClipNode.getPath(canvas, paint, Region.Op.UNION);
+        Path clipPath = mClipNode.getPath(canvas, paint, Region.Op.UNION);
         clipPath.transform(mClipNode.mMatrix);
         clipPath.transform(mClipNode.mTransform);
         switch (mClipRule) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Fixes combining of ClipPath child elements to match the spec and browsers, Inkscape, etc.
The problem affects both Android and iOS, but this PR currently only fixes it on Android
I started looking at the iOS code, but got a bit lost

Relevant issue: #1520

The code was conflating clipRules with how child elements need to be combined. These are unrelated. Children always need to be combined using UNION

From https://www.w3.org/TR/SVG11/masking.html#EstablishingANewClippingPath
> When the ‘clipPath’ element contains multiple child elements, the silhouettes of the child elements are logically OR'd together to create a single silhouette which is then used to restrict the region onto which paint can be applied.

### Related commits
766926f75874dedd7b13dadf65315f7030c4234a
a1097b85942c559ebcef6b93fa2ce601434d9c50

### Note

This is a breaking change and the ClipPath example image with need to be updated in USAGE.

## Test Plan

`yarn test` gave the following warning on the `main` branch (i.e. before my change. My fix is completely unrelated to this file):
```
/tmp/react-native-svg/src/css/LocalSvg.tsx
  26:34  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
```

After adding `// eslint-disable-next-line @typescript-eslint/no-explicit-any` on the previous line, everything is happy with my changes applied:

```console
% yarn test
yarn run v1.22.19
$ npm run lint && npm run tsc

> react-native-svg@14.1.0 lint
> eslint --ext .ts,.tsx src


> react-native-svg@14.1.0 tsc
> tsc --noEmit

✨  Done in 5.09s.
```

`yarn jest` failed before my change. I ran `yarn jest -u` on the `main` branch to update the snapshots.
After that, `yarn jest` passes on the branch containing my change.

```console
% git checkout wodin/fix-combining-of-clip-path-children
M	__tests__/__snapshots__/css.test.tsx.snap
M	src/css/LocalSvg.tsx
Switched to branch 'wodin/fix-combining-of-clip-path-children'
% yarn jest
yarn run v1.22.19
$ jest
 PASS  __tests__/css.test.tsx
  ✓ inlines styles (6 ms)
  ✓ supports CSS in style element (8 ms)

Test Suites: 1 passed, 1 total
Tests:       2 passed, 2 total
Snapshots:   2 passed, 2 total
Time:        0.737 s, estimated 1 s
Ran all test suites.
✨  Done in 2.72s.
```

### What's required for testing (prerequisites)?

N/A

### What are the steps to reproduce (after prerequisites)?

Code like this reproduces the problem and demonstrates that the fix works:
```javascript
    <Svg viewBox="0 0 250 234">
      <ClipPath id="clip">
        <Polygon points="31,0 31,234 170,234 250,0" />
        <Rect x="0" y="0" width="41" height="234" rx="8" ry="8" />
        <Rect x="0" y="112" width="250" height="10" />
      </ClipPath>
      <Rect x="0" y="0" width="250" height="234" fill="red" clipPath="url(#clip)" />
    </Svg>
```

Before the fix the result looks like this:
<img src="https://github.com/software-mansion/react-native-svg/assets/4579020/a42f8a10-9eab-45e0-ac14-abffb0c91af3" alt="Before" width="200px">

After the fix it looks like this:
<img src="https://github.com/software-mansion/react-native-svg/assets/4579020/3d74a3c5-9072-44e0-9a70-d8c056652eb4" alt="After" width="200px">

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [ ] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
