### PR TITLE
fixed @Deprecated warning in React Native 0.73: 'com.facebook.react.common.StandardCharsets' is deprecated and marked for removal

### DIFF
--- a/android/src/main/java/com/horcrux/svg/RNSVGRenderableManager.java
+++ b/android/src/main/java/com/horcrux/svg/RNSVGRenderableManager.java
@@ -8,7 +8,7 @@
 
 package com.horcrux.svg;
 
-import static com.facebook.react.common.StandardCharsets.UTF_8;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 import android.content.res.Resources;
 import android.graphics.Matrix;


### PR DESCRIPTION
# Summary

fixed warning in React Native 0.73: 'com.facebook.react.common.StandardCharsets' is deprecated and marked for removal

**com.facebook.react.common.StandardCharsets** was marked as `@Deprecated`, and says "Deprecated class since v0.73.0, please use java.nio.charset.StandardCharsets instead."

# Solution

RNSVGRenderableManager.java

```java
// react-native-svg/android/src/main/java/com/horcrux/svg/RNSVGRenderableManager.java

// replace this line 
import static com.facebook.react.common.StandardCharsets.UTF_8;
// with
import static java.nio.charset.StandardCharsets.UTF_8;
```

It doesn't make any break changes because they are the same value: `Charset.forName("UTF-8")`

![image](https://github.com/software-mansion/react-native-svg/assets/16949192/01f96684-d502-4ff4-ad22-f483cf1a12ae)
