### PR TITLE
fix: visionOS support

### DIFF
--- a/RNSVG.podspec
+++ b/RNSVG.podspec
@@ -15,6 +15,7 @@ Pod::Spec.new do |s|
   s.source_files    = 'apple/**/*.{h,m,mm}'
   s.ios.exclude_files = '**/*.macos.{h,m,mm}'
   s.tvos.exclude_files = '**/*.macos.{h,m,mm}'
+  s.visionos.exclude_files = '**/*.macos.{h,m,mm}'
   s.osx.exclude_files = '**/*.ios.{h,m,mm}'
   s.requires_arc    = true
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

This PR fixes the following errors when compiling for visionOS:

`Unknown type name 'NSColor'`

<img width="1624" alt="Screenshot 2024-02-04 at 00 54 02" src="https://github.com/software-mansion/react-native-svg/assets/20516055/a7ad2ceb-bb8d-4bfb-a529-b152ba484a89">

## Test Plan

<img width="1165" alt="Screenshot 2024-02-04 at 00 57 26" src="https://github.com/software-mansion/react-native-svg/assets/20516055/69248341-c21d-4e01-a2ba-c0c8db4cca60">

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [ ] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
