### PR TITLE
fix: Add missing nan value checks for bounds size

### DIFF
--- a/Example/ios/Podfile.lock
+++ b/Example/ios/Podfile.lock
@@ -1378,7 +1378,7 @@ SPEC CHECKSUMS:
   React-utils: debda2c206770ee2785bdebb7f16d8db9f18838a
   ReactCommon: ddb128564dcbfa0287d3d1a2d10f8c7457c971f6
   RNReanimated: 57f436e7aa3d277fbfed05e003230b43428157c0
-  RNSVG: bfabf2d466107f38d894f7e7a73bd73fafd1f52e
+  RNSVG: 4ddf4baa2fdd87abd32e5fdd2c5e10522c97b204
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   Yoga: 4f53dc50008d626fa679c7a1cb4bed898f8c0bde
 

--- a/Example/ios/Podfile.lock
+++ b/Example/ios/Podfile.lock
@@ -1378,7 +1378,7 @@ SPEC CHECKSUMS:
   React-utils: debda2c206770ee2785bdebb7f16d8db9f18838a
   ReactCommon: ddb128564dcbfa0287d3d1a2d10f8c7457c971f6
   RNReanimated: 57f436e7aa3d277fbfed05e003230b43428157c0
-  RNSVG: 4ddf4baa2fdd87abd32e5fdd2c5e10522c97b204
+  RNSVG: bfabf2d466107f38d894f7e7a73bd73fafd1f52e
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   Yoga: 4f53dc50008d626fa679c7a1cb4bed898f8c0bde
 

--- a/apple/RNSVGRenderable.mm
+++ b/apple/RNSVGRenderable.mm
@@ -475,7 +475,9 @@ UInt32 saturate(CGFloat value)
   CGPoint mid = CGPointMake(CGRectGetMidX(pathBounds), CGRectGetMidY(pathBounds));
   CGPoint center = CGPointApplyAffineTransform(mid, matrix);
 
-  self.bounds = bounds;
+  if (!isnan(bounds.size.width) && !isnan(bounds.size.height)) {
+    self.bounds = bounds;
+  }
   if (!isnan(center.x) && !isnan(center.y)) {
     self.center = center;
   }


### PR DESCRIPTION
# Summary

This PR adds missing checks whether SVG bounds size values are nan. This PR should fix [this](https://github.com/software-mansion/react-native-svg/issues/978) old issue that still happens sometimes.

## Test Plan

I was unable to reproduce the issue on my device but we got multiple issue reports on Sentry in the production environment. Here is the stacktrace based on which I implemented this fix.

<img width="1169" alt="image" src="https://github.com/software-mansion/react-native-svg/assets/52978053/672c411f-0786-4602-8ec0-796c65c8578c">

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [ ] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
