### PR TITLE
fix: typo on require statement (`WithLocalSvg`)

### DIFF
--- a/src/css/LocalSvg.tsx
+++ b/src/css/LocalSvg.tsx
@@ -26,7 +26,7 @@ export async function loadAndroidRawResource(uri: string) {
     const RNSVGRenderableModule: any =
       // neeeded for new arch
       // eslint-disable-next-line @typescript-eslint/no-var-requires
-      require('./fabric/NativeSvgRenderableModule').default;
+      require('../fabric/NativeSvgRenderableModule').default;
     return await RNSVGRenderableModule.getRawResource(uri);
   } catch (e) {
     console.error(


### PR DESCRIPTION
# Summary

Our sentry

![Screenshot 2024-02-14 at 12 18 38 AM](https://github.com/software-mansion/react-native-svg/assets/16035247/484589c1-18f6-422c-bcb5-32d093db03f8)

This PR fixes typo on require statement.
It makes `WithLocalSvg` function as expected without crash.

## Test Plan

`import { WithLocalSvg } from 'react-native-svg/css'`

### What's required for testing (prerequisites)?

Nothing

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [ ] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
