### PR TITLE
fix: Fix pod install not working with lower version of Cocoapods due to visionOS

### DIFF
--- a/RNSVG.podspec
+++ b/RNSVG.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.source_files    = 'apple/**/*.{h,m,mm}'
   s.ios.exclude_files = '**/*.macos.{h,m,mm}'
   s.tvos.exclude_files = '**/*.macos.{h,m,mm}'
-  s.visionos.exclude_files = '**/*.macos.{h,m,mm}'
+  s.visionos.exclude_files = '**/*.macos.{h,m,mm}' if s.respond_to?(:visionos)
   s.osx.exclude_files = '**/*.ios.{h,m,mm}'
   s.requires_arc    = true
   s.platforms         = { :osx => "10.14", :ios => "12.4", :tvos => "12.4", :visionos => "1.0" }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
On Cocoapods versions of lower than 1.14.3, pod install fails due to it not understanding the visionos field.
Our company cannot use a higher version of Cocoapods right now, so it would be beneficial if we or other similar people can use the latest version of react-native-svg without having to upgrade the Cocoapods version.

I was able to find this solution from https://github.com/getsentry/sentry-react-native/issues/3547#issuecomment-1907677879

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [ ] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
