### PR TITLE
fix: toDataUrl line breaks

### DIFF
--- a/TestsExample/App.js
+++ b/TestsExample/App.js
@@ -12,6 +12,7 @@ import Test2071 from './src/Test2071';
 import Test2089 from './src/Test2089';
 import Test2196 from './src/Test2196';
 import Test2266 from './src/Test2266';
+import Test1986 from './src/Test1986';
 
 export default function App() {
   return <ColorTest />;

--- a/TestsExample/src/Test1986.tsx
+++ b/TestsExample/src/Test1986.tsx
@@ -1,0 +1,29 @@
+import React, {useRef, useState} from 'react';
+import {Button, Image, View} from 'react-native';
+import {Circle, Svg} from 'react-native-svg';
+
+export default () => {
+  const ref = useRef<Svg>(null);
+  const [s, setS] = useState('');
+  return (
+    <View style={{flex: 1, paddingTop: 100}}>
+      <Button
+        onPress={() => {
+          ref.current?.toDataURL(source => {
+            setS(source);
+            console.log(source);
+          });
+        }}
+        title="log data url"
+      />
+      <Image
+        width={400}
+        height={300}
+        source={{uri: `data:image/png;base64,${s}`}}
+      />
+      <Svg width={400} height={300} ref={ref}>
+        <Circle cx={200} cy={150} r={100} fill="red" />
+      </Svg>
+    </View>
+  );
+};

--- a/android/src/main/java/com/horcrux/svg/SvgView.java
+++ b/android/src/main/java/com/horcrux/svg/SvgView.java
@@ -339,7 +339,7 @@ public class SvgView extends ReactViewGroup implements ReactCompoundView, ReactC
     bitmap.compress(Bitmap.CompressFormat.PNG, 100, stream);
     bitmap.recycle();
     byte[] bitmapBytes = stream.toByteArray();
-    return Base64.encodeToString(bitmapBytes, Base64.DEFAULT);
+    return Base64.encodeToString(bitmapBytes, Base64.NO_WRAP);
   }
 
   String toDataURL(int width, int height) {
@@ -353,7 +353,7 @@ public class SvgView extends ReactViewGroup implements ReactCompoundView, ReactC
     bitmap.compress(Bitmap.CompressFormat.PNG, 100, stream);
     bitmap.recycle();
     byte[] bitmapBytes = stream.toByteArray();
-    return Base64.encodeToString(bitmapBytes, Base64.DEFAULT);
+    return Base64.encodeToString(bitmapBytes, Base64.NO_WRAP);
   }
 
   void enableTouchEvents() {

--- a/apple/Elements/RNSVGSvgView.mm
+++ b/apple/Elements/RNSVGSvgView.mm
@@ -344,10 +344,10 @@ using namespace facebook::react;
 #endif
 #if !TARGET_OS_OSX // [macOS]
   NSData *imageData = UIImagePNGRepresentation(image);
-  NSString *base64 = [imageData base64EncodedStringWithOptions:NSDataBase64Encoding64CharacterLineLength];
+  NSString *base64 = [imageData base64EncodedStringWithOptions:NSDataBase64EncodingEndLineWithLineFeed];
 #else // [macOS
   NSData *imageData = UIImagePNGRepresentation(UIGraphicsGetImageFromCurrentImageContext());
-  NSString *base64 = [imageData base64EncodedStringWithOptions:NSDataBase64Encoding64CharacterLineLength];
+  NSString *base64 = [imageData base64EncodedStringWithOptions:NSDataBase64EncodingEndLineWithLineFeed];
   UIGraphicsEndImageContext();
 #endif // macOS]
   return base64;


### PR DESCRIPTION
# Summary

This PR removes the flag to include custom line breaks on `toDataUrl` method. Some software could not read base64 with additional line break characters, so it could lead to corrupting the image (like in react-native-share). Fixes #1986.

## Test Plan

`TestsExample` -> `Test1986`

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |