### PR TITLE
fix: Fix static view config validation for RNSVGSvgViewAndroid

### DIFF
--- a/android/src/main/java/com/horcrux/svg/SvgViewManager.java
+++ b/android/src/main/java/com/horcrux/svg/SvgViewManager.java
@@ -317,6 +317,21 @@ class SvgViewManager extends ReactViewManager
   }
 
   @Override
+  public void setBorderBlockColor(SvgView view, @Nullable Integer value) {
+    super.setBorderColor(view, 9, value);
+  }
+
+  @Override
+  public void setBorderBlockEndColor(SvgView view, @Nullable Integer value) {
+    super.setBorderColor(view, 10, value);
+  }
+
+  @Override
+  public void setBorderBlockStartColor(SvgView view, @Nullable Integer value) {
+    super.setBorderColor(view, 11, value);
+  }
+
+  @Override
   public void setBorderRadius(SvgView view, double value) {
     super.setBorderRadius(view, 0, (float) value);
   }
@@ -339,5 +354,25 @@ class SvgViewManager extends ReactViewManager
   @Override
   public void setBorderBottomLeftRadius(SvgView view, double value) {
     super.setBorderRadius(view, 4, (float) value);
+  }
+
+  @Override
+  public void setBorderEndEndRadius(SvgView view, double value) {
+    super.setBorderRadius(view, 9, (float) value);
+  }
+
+  @Override
+  public void setBorderEndStartRadius(SvgView view, double value) {
+    super.setBorderRadius(view, 10, (float) value);
+  }
+
+  @Override
+  public void setBorderStartEndRadius(SvgView view, double value) {
+    super.setBorderRadius(view, 11, (float) value);
+  }
+
+  @Override
+  public void setBorderStartStartRadius(SvgView view, double value) {
+    super.setBorderRadius(view, 12, (float) value);
   }
 }

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGSvgViewAndroidManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGSvgViewAndroidManagerDelegate.java
@@ -150,6 +150,27 @@ public class RNSVGSvgViewAndroidManagerDelegate<T extends View, U extends BaseVi
       case "borderTopLeftRadius":
         mViewManager.setBorderTopLeftRadius(view, value == null ? 0f : ((Double) value).doubleValue());
         break;
+      case "borderBlockColor":
+        mViewManager.setBorderBlockColor(view, ColorPropConverter.getColor(value, view.getContext()));
+        break;
+      case "borderBlockEndColor":
+        mViewManager.setBorderBlockEndColor(view, ColorPropConverter.getColor(value, view.getContext()));
+        break;
+      case "borderBlockStartColor":
+        mViewManager.setBorderBlockStartColor(view, ColorPropConverter.getColor(value, view.getContext()));
+        break;
+      case "borderEndEndRadius":
+        mViewManager.setBorderEndEndRadius(view, value == null ? 0f : ((Double) value).doubleValue());
+        break;
+      case "borderEndStartRadius":
+        mViewManager.setBorderEndStartRadius(view, value == null ? 0f : ((Double) value).doubleValue());
+        break;
+      case "borderStartEndRadius":
+        mViewManager.setBorderStartEndRadius(view, value == null ? 0f : ((Double) value).doubleValue());
+        break;
+      case "borderStartStartRadius":
+        mViewManager.setBorderStartStartRadius(view, value == null ? 0f : ((Double) value).doubleValue());
+        break;
       default:
         super.setProperty(view, propName, value);
     }

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGSvgViewAndroidManagerInterface.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGSvgViewAndroidManagerInterface.java
@@ -57,4 +57,11 @@ public interface RNSVGSvgViewAndroidManagerInterface<T extends View> {
   void setBorderRadius(T view, double value);
   void setBorderBottomLeftRadius(T view, double value);
   void setBorderTopLeftRadius(T view, double value);
+  void setBorderBlockColor(T view, @Nullable Integer value);
+  void setBorderBlockEndColor(T view, @Nullable Integer value);
+  void setBorderBlockStartColor(T view, @Nullable Integer value);
+  void setBorderEndEndRadius(T view, double value);
+  void setBorderEndStartRadius(T view, double value);
+  void setBorderStartEndRadius(T view, double value);
+  void setBorderStartStartRadius(T view, double value);
 }

--- a/src/fabric/AndroidSvgViewNativeComponent.ts
+++ b/src/fabric/AndroidSvgViewNativeComponent.ts
@@ -73,6 +73,13 @@ interface NativeProps extends ViewProps {
   borderRadius?: Double;
   borderBottomLeftRadius?: Double;
   borderTopLeftRadius?: Double;
+  borderBlockColor?: ColorValue;
+  borderBlockEndColor?: ColorValue;
+  borderBlockStartColor?: ColorValue;
+  borderEndEndRadius?: Double;
+  borderEndStartRadius?: Double;
+  borderStartEndRadius?: Double;
+  borderStartStartRadius?: Double;
 }
 
 export default codegenNativeComponent<NativeProps>('RNSVGSvgViewAndroid', {


### PR DESCRIPTION
# Summary

As per title, when running an app in bridgless mode the following redbox appears:

> StaticViewConfigValidator: Invalid static view config for 'RNSVGSvgViewAndroid'.
> 
> 'validAttributes.borderBlockColor' is missing.
> 'validAttributes.borderBlockEndColor' is missing.
> 'validAttributes.borderBlockStartColor' is missing.
> 'validAttributes.borderEndEndRadius' is missing.
> 'validAttributes.borderEndStartRadius' is missing.
> 'validAttributes.borderStartEndRadius' is missing.
> 'validAttributes.borderStartStartRadius' is missing.

## Test Plan

Tested that the redbox is gone.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    N/A     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [ ] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
