### PR TITLE
fix: error when building paper after fabric

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -74,7 +74,6 @@ android {
             if (!isNewArchitectureEnabled()) {
                 srcDirs += [
                     "src/paper/java",
-                    "build/generated/source/codegen/java"
                 ]
             }
         }


### PR DESCRIPTION
# Summary

We had similar config in react-native-screens. It caused problem when building Paper arch app after Fabric. Those changes help, so I'm moving them here as well. 
