### PR TITLE
feat: add basic React Server Component support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 export * from './ReactNativeSVG';
 
 export { default } from './ReactNativeSVG';


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Add basic support for React Server Components support. This package could surely be improved (at least on web) but there are a lot of class components (unsupported in RSC) which need to be rewritten to function components in order to compile down further. For now, I'm opting the entire package. 

Related PRs for more context:

- https://github.com/necolas/react-native-web/pull/2678
- https://github.com/th3rdwave/react-native-safe-area-context/pull/502
- I've added more support for mixing export types, but it isn't perfect https://github.com/expo/expo/pull/29426

## Test Plan

- It's kinda hard to test this E2E. I wrote a small jest runner in jest-expo which executes in RSC mode, but it requires React 19 to work. Here's where I tested this patch https://github.com/expo/expo/pull/29404