### PR TITLE
chore: TestsExample app fix reanimated and metro.config issues

### DIFF
--- a/TestsExample/metro.config.js
+++ b/TestsExample/metro.config.js
@@ -30,10 +30,13 @@ const config = {
       ),
     ),
 
-    extraNodeModules: modules.reduce((acc, name) => {
-      acc[name] = path.join(__dirname, 'node_modules', name);
-      return acc;
-    }, {}),
+    extraNodeModules: modules.reduce(
+      (acc, name) => {
+        acc[name] = path.join(__dirname, 'node_modules', name);
+        return acc;
+      },
+      {'react-native-svg': `${__dirname}/../`},
+    ),
   },
 
   transformer: {

--- a/TestsExample/package.json
+++ b/TestsExample/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "react": "18.2.0",
     "react-native": "0.73.1",
-    "react-native-reanimated": "3.6.1",
+    "react-native-reanimated": "3.7.0",
     "react-native-svg": "link:../"
   },
   "devDependencies": {

--- a/TestsExample/yarn.lock
+++ b/TestsExample/yarn.lock
@@ -5644,10 +5644,10 @@ react-is@^17.0.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
-react-native-reanimated@3.6.1:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-3.6.1.tgz#5add41efafac6d0befd9786e752e7f26dbe903b7"
-  integrity sha512-F4vG9Yf9PKmE3GaWtVGUpzj3SM6YY2cx1yRHCwiMd1uY7W0gU017LfcVUorboJnj0y5QZqEriEK1Usq2Y8YZqg==
+react-native-reanimated@3.7.0:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-3.7.0.tgz#ad36b86533c0aa5e64795b05588dfd656d490039"
+  integrity sha512-KM+MKa3CJWqsF4GlOLLKBxTR2NEcrg5/HP9J2b6Dfgvll1sjZPywCOEEIh967SboEU8N9LjYZuoVm2UoXGxp2Q==
   dependencies:
     "@babel/plugin-transform-object-assign" "^7.16.7"
     "@babel/preset-typescript" "^7.16.7"
@@ -5655,10 +5655,8 @@ react-native-reanimated@3.6.1:
     invariant "^2.2.4"
 
 "react-native-svg@link:..":
-  version "14.1.0"
-  dependencies:
-    css-select "^5.1.0"
-    css-tree "^1.1.3"
+  version "0.0.0"
+  uid ""
 
 react-native@0.73.1:
   version "0.73.1"


### PR DESCRIPTION
# Summary

We want to fix the TextExample app

- change version of react-native-reanimated.
- add to `metro.config.js` extraNodeModules: 
```
'react-native-svg': `${__dirname}/../`
```

## Test Plan

test manually.
