### PR TITLE
fixed pars on Android platform prop  strokeDasharray

### DIFF
--- a/TestsExample/App.js
+++ b/TestsExample/App.js
@@ -13,6 +13,7 @@ import Test2080 from './src/Test2080';
 import Test2089 from './src/Test2089';
 import Test2148 from './src/Test2148';
 import Test2196 from './src/Test2196';
+import Test2248 from './src/Test2248';
 import Test2266 from './src/Test2266';
 import Test2276 from './src/Test2276';
 

--- a/TestsExample/src/Test2248.tsx
+++ b/TestsExample/src/Test2248.tsx
@@ -1,0 +1,59 @@
+import React, {useEffect, useRef} from 'react';
+import {Path, Svg} from 'react-native-svg';
+import {Animated} from 'react-native';
+
+const AnimatedPath = Animated.createAnimatedComponent(Path as any);
+
+type Props = {
+  value: number;
+  color: string;
+};
+const Test2248 = ({value = 86, color = '#ED745F'}: Props) => {
+  const animationValue = useRef(new Animated.Value(0)).current;
+
+  useEffect(() => {
+    const animatePath = () => {
+      Animated.loop(
+        Animated.timing(animationValue, {
+          toValue: 1,
+          duration: 2000,
+          useNativeDriver: true,
+        }),
+      ).start();
+    };
+
+    animatePath();
+
+    return () => {
+      animationValue.setValue(0);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <Svg width="150" height="120" viewBox="0 0 100 80">
+      <Path
+        d="M22.37 60.987a30.3 30.3 0 0 1-2.357-11.76C20.013 32.54 33.44 19.012 50 19.012S79.987 32.54 79.987 49.226c0 4.172-.84 8.146-2.357 11.76"
+        fill="none"
+        strokeWidth={14}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        stroke="#3a393e"
+      />
+      <AnimatedPath
+        d="M22.37 60.987a30.3 30.3 0 0 1-2.357-11.76C20.013 32.54 33.44 19.012 50 19.012S79.987 32.54 79.987 49.226c0 4.172-.84 8.146-2.357 11.76"
+        strokeDasharray={animationValue.interpolate({
+          inputRange: [0, 0.5, 1],
+          outputRange: ['0 120', `${(120 * value) / 100} 120`, '0 120'],
+        })}
+        fill="none"
+        strokeWidth={14}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        stroke={color}
+      />
+    </Svg>
+  );
+};
+
+export default Test2248;

--- a/android/src/main/java/com/horcrux/svg/RenderableView.java
+++ b/android/src/main/java/com/horcrux/svg/RenderableView.java
@@ -254,15 +254,9 @@ public abstract class RenderableView extends VirtualView implements ReactHitSlop
   }
 
   public void setStrokeDasharray(Dynamic dynamicStrokeDasharray) {
-    if (!dynamicStrokeDasharray.isNull()) {
-      ReadableArray strokeDasharray = dynamicStrokeDasharray.asArray();
-      int fromSize = strokeDasharray.size();
-      this.strokeDasharray = new SVGLength[fromSize];
-      for (int i = 0; i < fromSize; i++) {
-        this.strokeDasharray[i] = SVGLength.from(strokeDasharray.getDynamic(i));
-      }
-    } else {
-      this.strokeDasharray = null;
+    ArrayList<SVGLength> arrayList = SVGLength.arrayFrom(dynamicStrokeDasharray);
+    if (arrayList != null) {
+      this.strokeDasharray = arrayList.toArray(new SVGLength[0]);
     }
     invalidate();
   }


### PR DESCRIPTION
# Summary
Closes #2248.
Add the ability to parse `strokeDasharray` string value on the Android platform

## Test Plan

Manually test both platforms.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |
