### PR TITLE
fix: handle onPress prop on web app

### DIFF
--- a/src/ReactNativeSVG.web.ts
+++ b/src/ReactNativeSVG.web.ts
@@ -195,6 +195,7 @@ const prepare = <T extends BaseProps>(
     onResponderRelease?: (e: GestureResponderEvent) => void;
     onResponderTerminate?: (e: GestureResponderEvent) => void;
     onResponderTerminationRequest?: (e: GestureResponderEvent) => boolean;
+    onClick?: (e: GestureResponderEvent) => void;
     transform?: string;
     gradientTransform?: string;
     patternTransform?: string;
@@ -266,7 +267,9 @@ const prepare = <T extends BaseProps>(
     styles.fontStyle = fontStyle;
   }
   clean.style = resolve(style, styles);
-
+  if (props.onPress != null) {
+    clean.onClick = props.onPress;
+  }
   return clean;
 };
 


### PR DESCRIPTION
# Summary
Closes #1483
Closes #1524

We want a handle `onPress` prop on the web version in SVG components.

## Test Plan

Check on `react-native` web version if prop onPress works.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| Web     |    ✅     |