### PR TITLE
fix: add default transform-origin value for web version

### DIFF
--- a/src/ReactNativeSVG.web.ts
+++ b/src/ReactNativeSVG.web.ts
@@ -228,14 +228,17 @@ const prepare = <T extends BaseProps>(
   const parsedTransform = parseTransformProp(transform, props);
   if (parsedTransform) {
     clean.transform = parsedTransform;
+    clean['transform-origin'] = '50% 50%';
   }
   const parsedGradientTransform = parseTransformProp(gradientTransform);
   if (parsedGradientTransform) {
     clean.gradientTransform = parsedGradientTransform;
+    clean['transform-origin'] = '50% 50%';
   }
   const parsedPatternTransform = parseTransformProp(patternTransform);
   if (parsedPatternTransform) {
     clean.patternTransform = parsedPatternTransform;
+    clean['transform-origin'] = '50% 50%';
   }
 
   clean.ref = (el: SVGElement | null) => {

--- a/src/ReactNativeSVG.web.ts
+++ b/src/ReactNativeSVG.web.ts
@@ -228,6 +228,7 @@ const prepare = <T extends BaseProps>(
   const parsedTransform = parseTransformProp(transform, props);
   if (parsedTransform) {
     clean.transform = parsedTransform;
+    // we set default value for transform-origin based in that documentation: https://drafts.csswg.org/css-transforms/#propdef-transform-origin
     clean['transform-origin'] = '50% 50%';
   }
   const parsedGradientTransform = parseTransformProp(gradientTransform);


### PR DESCRIPTION
# Summary
Closes #1566
Add default value for transform-origin web application.

## Test Plan
When we run our example, it should appear consistently across all platforms.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |  ✅    |
| Web |  ✅    |
