### PR TITLE
fix: behaviour of gradient-transform for web version

### DIFF
--- a/src/ReactNativeSVG.web.ts
+++ b/src/ReactNativeSVG.web.ts
@@ -197,7 +197,7 @@ const prepare = <T extends BaseProps>(
     onResponderTerminationRequest?: (e: GestureResponderEvent) => boolean;
     onClick?: (e: GestureResponderEvent) => void;
     transform?: string;
-    gradientTransform?: string;
+    'gradient-transform'?: string;
     patternTransform?: string;
     'transform-origin'?: string;
     style?: object;
@@ -231,7 +231,7 @@ const prepare = <T extends BaseProps>(
   }
   const parsedGradientTransform = parseTransformProp(gradientTransform);
   if (parsedGradientTransform) {
-    clean.gradientTransform = parsedGradientTransform;
+    clean['gradient-transform'] = parsedGradientTransform;
   }
   const parsedPatternTransform = parseTransformProp(patternTransform);
   if (parsedPatternTransform) {


### PR DESCRIPTION
Closes #1615

# Summary
We want to achieve the same behavior in the same platform when we use a gradient-transform prop.

## Test Plan

| OS | Before | After |
|--------|--------|--------|
| IOS | <img width="300" height="650" src="https://github.com/software-mansion/react-native-svg/assets/69891500/bd8197fe-05ce-442c-8281-e18730e32fda" /> | <img width="300" height="650" src="https://github.com/software-mansion/react-native-svg/assets/69891500/bd8197fe-05ce-442c-8281-e18730e32fda" /> |
| ANDROID | <img width="300" height="650" src="https://github.com/software-mansion/react-native-svg/assets/69891500/8dd23b52-a2b9-4821-9d9f-2dff4b484382" /> | <img width="300" height="650" src="https://github.com/software-mansion/react-native-svg/assets/69891500/8dd23b52-a2b9-4821-9d9f-2dff4b484382" /> |
| WEB | <img width="300" height="650" src="https://github.com/software-mansion/react-native-svg/assets/69891500/425c8866-6443-49f5-a2c3-d058c555c73f" /> | <img width="300" height="650" src="https://github.com/software-mansion/react-native-svg/assets/69891500/49e07044-6413-43bb-86a8-bd8eb0b00f30" /> | 

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅    |
| Web |    ✅    |