### PR TITLE
fix: android PathParser crash app if pass some wrong d prop

### DIFF
--- a/TestsExample/App.js
+++ b/TestsExample/App.js
@@ -10,6 +10,7 @@ import Test1845 from './src/Test1845';
 import Test1986 from './src/Test1986';
 import Test2071 from './src/Test2071';
 import Test2080 from './src/Test2080';
+import Test2086 from './src/Test2086';
 import Test2089 from './src/Test2089';
 import Test2148 from './src/Test2148';
 import Test2196 from './src/Test2196';

--- a/TestsExample/src/Test2086.tsx
+++ b/TestsExample/src/Test2086.tsx
@@ -1,0 +1,45 @@
+import React, {useState} from 'react';
+import Svg, {Path} from 'react-native-svg';
+import {StyleSheet, Text, View, Button} from 'react-native';
+
+export default function Test2086() {
+  const [display, setDisplay] = useState(false);
+  return (
+    <View style={styles.container}>
+      <View>
+        <Text>Click on the button to crash the app</Text>
+        <Button onPress={() => setDisplay(state => !state)} title="Run" />
+        <MySVG style={{width: 100, height: 100}} toggle={display} />
+      </View>
+    </View>
+  );
+}
+
+const MySVG = ({style, toggle}) => {
+  return (
+    <Svg viewBox="0 0 32 32" style={style}>
+      {toggle && (
+        <Path
+          d="M 16 16 m 16, 0 a 16,16 0 1,1 -32,0 a r,r 0 1,1 32,0"
+          stroke="#000"
+        />
+      )}
+      {!toggle && (
+        <Path
+          d="M 16 16 m 16, 0 a 16,16 0 1,1 -32,0 a 16,16 0 1,1 32,0"
+          stroke="#000"
+        />
+      )}
+    </Svg>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    paddingVertical: 200,
+    flex: 1,
+    backgroundColor: '#fff',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/android/src/main/java/com/horcrux/svg/PathParser.java
+++ b/android/src/main/java/com/horcrux/svg/PathParser.java
@@ -62,7 +62,7 @@ class PathParser {
 
       if (!has_prev_cmd && first_char != 'M' && first_char != 'm') {
         // The first segment must be a MoveTo.
-        throw new Error(String.format("Unexpected character '%c' (i=%d, s=%s)", first_char, i, s));
+        throw new IllegalArgumentException(String.format("Unexpected character '%c' (i=%d, s=%s)", first_char, i, s));
       }
 
       // TODO: simplify
@@ -75,7 +75,7 @@ class PathParser {
       } else if (is_number_start(first_char) && has_prev_cmd) {
         if (prev_cmd == 'Z' || prev_cmd == 'z') {
           // ClosePath cannot be followed by a number.
-          throw new Error(String.format("Unexpected number after 'z' (s=%s)", s));
+          throw new IllegalArgumentException(String.format("Unexpected number after 'z' (s=%s)", s));
         }
 
         if (prev_cmd == 'M' || prev_cmd == 'm') {
@@ -93,7 +93,7 @@ class PathParser {
           cmd = prev_cmd;
         }
       } else {
-        throw new Error(String.format("Unexpected character '%c' (i=%d, s=%s)", first_char, i, s));
+        throw new IllegalArgumentException(String.format("Unexpected character '%c' (i=%d, s=%s)", first_char, i, s));
       }
 
       boolean absolute = is_absolute(cmd);
@@ -226,7 +226,8 @@ class PathParser {
           }
         default:
           {
-            throw new Error(String.format("Unexpected comand '%c' (s=%s)", cmd, s));
+            throw new IllegalArgumentException(String.format("Unexpected comand '%c' (s=%s)", cmd, s));
+
           }
       }
 
@@ -623,8 +624,7 @@ class PathParser {
         c = s.charAt(i);
       }
     } else if (c != '.') {
-      throw new Error(
-          String.format("Invalid number formating character '%c' (i=%d, s=%s)", c, i, s));
+      throw new IllegalArgumentException(String.format("Invalid number formating character '%c' (i=%d, s=%s)", c, i, s));
     }
 
     // Consume fraction.
@@ -649,8 +649,7 @@ class PathParser {
         } else if (c >= '0' && c <= '9') {
           skip_digits();
         } else {
-          throw new Error(
-              String.format("Invalid number formating character '%c' (i=%d, s=%s)", c, i, s));
+          throw new IllegalArgumentException(String.format("Invalid number formating character '%c' (i=%d, s=%s)", c, i, s));
         }
       }
     }
@@ -660,8 +659,7 @@ class PathParser {
 
     // inf, nan, etc. are an error.
     if (Float.isInfinite(n) || Float.isNaN(n)) {
-      throw new Error(
-          String.format("Invalid number '%s' (start=%d, i=%d, s=%s)", num, start, i, s));
+      throw new IllegalArgumentException(String.format("Invalid number '%s' (start=%d, i=%d, s=%s)", num, start, i, s));
     }
 
     return n;


### PR DESCRIPTION
Closes #2086
# Summary

The application crashes if an error is thrown when something goes wrong during path parse.

## Test Plan
You can easily check in that component `Test2086` how it works after the fix.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅    |
