### PR TITLE
Correct return type of `getTotalLength` in RNSVGRenderableManager

### DIFF
--- a/android/src/main/java/com/horcrux/svg/RNSVGRenderableManager.java
+++ b/android/src/main/java/com/horcrux/svg/RNSVGRenderableManager.java
@@ -88,7 +88,7 @@ class RNSVGRenderableManager extends NativeSvgRenderableModuleSpec {
   @SuppressWarnings("unused")
   @ReactMethod(isBlockingSynchronousMethod = true)
   @Override
-  public double getTotalLength(Double tag) {
+  public float getTotalLength(Double tag) {
     RenderableView svg = RenderableViewManager.getRenderableViewByTag(tag.intValue());
     if (svg == null) {
       return 0;


### PR DESCRIPTION
# Summary

Opening this in draft as React Native 0.74.x comes with better support for Int32 & Float inside codegen (previously they would be converted to Double).

As I noticed you folks have this in your specs:
https://github.com/software-mansion/react-native-svg/blob/a36a676d4313225bbcec44120eb38ce871106d0a/src/fabric/NativeSvgRenderableModule.ts#L31

`react-native-svg` will stop working with the next patch RN (most likely 0.74.4).

To avoid this kind of problems in the future you folks can use `includesGeneratedCode` in the package.json:

https://github.com/facebook/react-native/blame/75451d5b89d7f6c33688df23b57bea521374c2dc/packages/react-native-test-library/package.json#L44

## Test Plan

This is sadly not easy to test as is. Once 0.74.4 will be out, I suspect `react-native-svg` will break. This PR will fix it and a patch release will be needed afterwards.