### PR TITLE
fix(svg-view): the hitSlop value should use float in android like in ios

### DIFF
--- a/android/src/main/java/com/horcrux/svg/SvgViewManager.java
+++ b/android/src/main/java/com/horcrux/svg/SvgViewManager.java
@@ -285,25 +285,30 @@ class SvgViewManager extends ReactViewManager
   }
 
   @Override
-  public void setHitSlop(SvgView view, @Nullable ReadableMap hitSlopMap) {
+  public void setHitSlop(SvgView view, ReadableMap hitSlopMap) {
     // we don't call super here since its signature changed in RN 0.69 and we want backwards
     // compatibility
-    if (hitSlopMap != null) {
-      view.setHitSlopRect(
-          new Rect(
-              hitSlopMap.hasKey("left")
-                  ? (int) PixelUtil.toPixelFromDIP(hitSlopMap.getDouble("left"))
-                  : 0,
-              hitSlopMap.hasKey("top")
-                  ? (int) PixelUtil.toPixelFromDIP(hitSlopMap.getDouble("top"))
-                  : 0,
-              hitSlopMap.hasKey("right")
-                  ? (int) PixelUtil.toPixelFromDIP(hitSlopMap.getDouble("right"))
-                  : 0,
-              hitSlopMap.hasKey("bottom")
-                  ? (int) PixelUtil.toPixelFromDIP(hitSlopMap.getDouble("bottom"))
-                  : 0));
-    }
+    view.setHitSlopRect(
+        new Rect(
+            hitSlopMap.hasKey("left")
+                ? (int) PixelUtil.toPixelFromDIP(hitSlopMap.getDouble("left"))
+                : 0,
+            hitSlopMap.hasKey("top")
+                ? (int) PixelUtil.toPixelFromDIP(hitSlopMap.getDouble("top"))
+                : 0,
+            hitSlopMap.hasKey("right")
+                ? (int) PixelUtil.toPixelFromDIP(hitSlopMap.getDouble("right"))
+                : 0,
+            hitSlopMap.hasKey("bottom")
+                ? (int) PixelUtil.toPixelFromDIP(hitSlopMap.getDouble("bottom"))
+                : 0)
+    );
+  }
+
+  @Override
+  public void setHitSlop(SvgView view, Double hitSlopValue) {
+    int pixelValue = (int) PixelUtil.toPixelFromDIP(hitSlopValue);
+    view.setHitSlopRect(new Rect(pixelValue, pixelValue, pixelValue, pixelValue));
   }
 
   @Override

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGSvgViewAndroidManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGSvgViewAndroidManagerDelegate.java
@@ -127,7 +127,11 @@ public class RNSVGSvgViewAndroidManagerDelegate<T extends View, U extends BaseVi
         mViewManager.setNeedsOffscreenAlphaCompositing(view, value == null ? false : (boolean) value);
         break;
       case "hitSlop":
-        mViewManager.setHitSlop(view, (ReadableMap) value);
+        if (value instanceof ReadableMap) {
+          mViewManager.setHitSlop(view, (ReadableMap) value);
+        } else if (value instanceof Double) {
+          mViewManager.setHitSlop(view, (Double) value);
+        }
         break;
       case "borderTopColor":
         mViewManager.setBorderTopColor(view, ColorPropConverter.getColor(value, view.getContext()));

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGSvgViewAndroidManagerInterface.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGSvgViewAndroidManagerInterface.java
@@ -49,7 +49,8 @@ public interface RNSVGSvgViewAndroidManagerInterface<T extends View> {
   void setBackfaceVisibility(T view, @Nullable String value);
   void setBorderStyle(T view, @Nullable String value);
   void setNeedsOffscreenAlphaCompositing(T view, boolean value);
-  void setHitSlop(T view, @Nullable ReadableMap value);
+  void setHitSlop(T view, ReadableMap value);
+  void setHitSlop(T view, Double value);
   void setBorderTopColor(T view, @Nullable Integer value);
   void setNextFocusLeft(T view, int value);
   void setBorderTopRightRadius(T view, double value);

--- a/src/fabric/AndroidSvgViewNativeComponent.ts
+++ b/src/fabric/AndroidSvgViewNativeComponent.ts
@@ -22,7 +22,7 @@ type HitSlop = Readonly<{
   top?: Float;
   right?: Float;
   bottom?: Float;
-}>;
+} | Float>;
 
 interface NativeProps extends ViewProps {
   bbWidth?: UnsafeMixed<NumberProp>;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

In IOS, the `hitSlop` attribute of `Svg` supports the direct use of `hitSlope={4}`, but it can cause crashes on Android.The native view is also compatible with this writing style, so I think we should add compatibility in this area, otherwise it may lead to hidden cross end compatibility issues.

## Test Plan

-  this will cause crash, and we need to prevent crash
```ts
<Svg hitSlop={4} />
```

### What's required for testing (prerequisites)?

Any Android device with sample programs.

### What are the steps to reproduce (after prerequisites)?

Check if there are no behavior changes between previous implementation and current

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [x] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
