### PR TITLE
fix: add check  in RNSVGImage for macos platform

### DIFF
--- a/apple/Elements/RNSVGImage.mm
+++ b/apple/Elements/RNSVGImage.mm
@@ -210,15 +210,20 @@ using namespace facebook::react;
                        dispatch_async(dispatch_get_main_queue(), ^{
                          self->_image = CGImageRetain(image.CGImage);
                          self->_imageSize = CGSizeMake(CGImageGetWidth(self->_image), CGImageGetHeight(self->_image));
-                         if (self->_onLoad) {
-                           RCTImageSource *sourceLoaded = [src imageSourceWithSize:image.size scale:image.scale];
-                             NSDictionary *dict = @{
-                               @"uri" : sourceLoaded.request.URL.absoluteString,
-                               @"width" : @(sourceLoaded.size.width),
-                               @"height" : @(sourceLoaded.size.height),
-                             };
-                             self->_onLoad(@{@"source" : dict});
-                         }
+                          if (self->_onLoad) {
+                            RCTImageSource *sourceLoaded;
+#if TARGET_OS_OSX // [macOS]
+                            sourceLoaded = [src imageSourceWithSize:image.size scale:1];
+#else
+                            sourceLoaded = [src imageSourceWithSize:image.size scale:image.scale];
+#endif
+                              NSDictionary *dict = @{
+                                @"uri" : sourceLoaded.request.URL.absoluteString,
+                                @"width" : @(sourceLoaded.size.width),
+                                @"height" : @(sourceLoaded.size.height),
+                              };
+                              self->_onLoad(@{@"source" : dict});
+                          }
                          [self invalidate];
                        });
                      }];


### PR DESCRIPTION
# Summary
We have to merge those changes to that [PR](https://github.com/software-mansion/react-native-svg/pull/2319) and check the pipeline in the macos platform.
