### PR TITLE
Add missing `#import <folly/dynamic.h>` on RN 0.75

### DIFF
--- a/common/cpp/react/renderer/components/rnsvg/RNSVGImageState.h
+++ b/common/cpp/react/renderer/components/rnsvg/RNSVGImageState.h
@@ -14,6 +14,7 @@
 #ifdef ANDROID
 #include <react/renderer/mapbuffer/MapBuffer.h>
 #include <react/renderer/mapbuffer/MapBufferBuilder.h>
+#include <folly/dynamic.h>
 #endif
 
 namespace facebook {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Currently, react-native-svg fails to compile on Android with `react-native@0.75.0-rc.4` and new architecture enabled due to an unknown identified `folly::dynamic`.

This PR adds the missing import so that the identifier has a declaration.

## Test Plan

I've already tested out this change in Reanimated's fabric-example app.

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [ ] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
