### PR TITLE
fix: remove using pattern matching in FilterView

### DIFF
--- a/android/src/main/java/com/horcrux/svg/FilterView.java
+++ b/android/src/main/java/com/horcrux/svg/FilterView.java
@@ -80,7 +80,8 @@ class FilterView extends DefinitionView {
 
     for (int i = 0; i < getChildCount(); i++) {
       View node = getChildAt(i);
-      if (node instanceof FilterPrimitiveView currentFilter) {
+      if (node instanceof FilterPrimitiveView) {
+        FilterPrimitiveView currentFilter = (FilterPrimitiveView) node;
         res = currentFilter.applyFilter(mResultsMap, res);
         String resultName = currentFilter.getResult();
         if (resultName != null) {


### PR DESCRIPTION
# Summary
Closes #2347
Fixed a problem with building an Android app, pattern matching threw an error when we tried to build an Android app.
[Repository](https://github.com/bohdanprog/react-native-svg-error-pattern-matching) to reproduce that error.
## Test Plan
We can easily check that build the app.

### What are the steps to reproduce (after prerequisites)?
build the app without that fix.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| Android |    ✅     |

