### PR TITLE
fix: cannot set property transform of undefined (gStyle)

### DIFF
--- a/src/elements/Svg.tsx
+++ b/src/elements/Svg.tsx
@@ -177,7 +177,7 @@ export default class Svg extends Shape<SvgProps> {
       props.onLayout = onLayout;
     }
 
-    const gStyle = StyleSheet.flatten(style);
+    const gStyle = Object.assign({}, StyleSheet.flatten(style));
     // if transform prop is of RN style's kind, we want `SvgView` to handle it
     // since it can be done here. Otherwise, if transform is of `svg` kind, e.g. string,
     // we want G element to parse it since `Svg` does not include parsing of those custom transforms.


### PR DESCRIPTION
# Summary

Fix bug introduced in #2189, 
if `style` is not provided, then `StyleSheet.flatten` returns `undefined`, and we're trying to access `transform` of it.

## Test Plan

Run `example` app