### PR TITLE
fix: color shift in FeColorMatrix on android

### DIFF
--- a/android/src/main/java/com/horcrux/svg/FeColorMatrixView.java
+++ b/android/src/main/java/com/horcrux/svg/FeColorMatrixView.java
@@ -44,7 +44,7 @@ class FeColorMatrixView extends FilterPrimitiveView {
         float[] rawMatrix = new float[mValues.size()];
 
         for (int i = 0; i < this.mValues.size(); i++) {
-          rawMatrix[i] = (float) this.mValues.getDouble(i);
+          rawMatrix[i] = (float) this.mValues.getDouble(i) * (i % 5 == 4 ? 255 : 1);
         }
 
         colorMatrix.set(rawMatrix);
@@ -88,8 +88,7 @@ class FeColorMatrixView extends FilterPrimitiveView {
       case LUMINANCE_TO_ALPHA:
         colorMatrix.set(
             new float[] {
-              0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0.2125f, 0.7154f, 0.0721f, 0, 0, 0, 0, 0,
-              0, 1
+              0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0.2125f, 0.7154f, 0.0721f, 0, 0,
             });
         break;
     }


### PR DESCRIPTION
# Summary

While debugging #2364 I've noticed that color shift in `FeColorMatrix` on Android is wrong.
On web, elements 5, 10, 15, 20 is a color shift represented by number where 1 mean full color shift, while on Android it's 255 for full color shift.

## Test

```tsx
<svg width="180" height="180" viewBox="0 0 180 180">
  <rect width="180" height="180" fill="red" filter="url(#filter)"/>
  <filter id="filter">
    <feColorMatrix type="matrix" values="0 0 0 0 1
                                         0 1 0 0 0
                                         0 0 1 0 0
                                         0 0 0 1 0"/>
  </filter>
</svg>
```