### PR TITLE
fix: `FilterImage` css filter on web

### DIFF
--- a/src/filter-image/FilterImage.tsx
+++ b/src/filter-image/FilterImage.tsx
@@ -25,8 +25,8 @@ export interface FilterImageProps extends ImageProps {
 
 export const FilterImage = (props: FilterImageProps) => {
   const { filters = [], source, style, ...imageProps } = props;
-  const styles = StyleSheet.flatten(style);
-  const extractedFilters = [...filters, ...extractFiltersCss(styles?.filter)];
+  const { filter: stylesFilter, ...styles } = StyleSheet.flatten(style);
+  const extractedFilters = [...filters, ...extractFiltersCss(stylesFilter)];
   const filterId = React.useMemo(() => `RNSVG-${getRandomNumber()}`, []);
 
   const src =


### PR DESCRIPTION
Small fix to destruct filter from style prop before passing down styles to View.