### PR TITLE
fix: deconstruct filter from styles

### DIFF
--- a/src/filter-image/FilterImage.tsx
+++ b/src/filter-image/FilterImage.tsx
@@ -25,7 +25,10 @@ export interface FilterImageProps extends ImageProps {
 
 export const FilterImage = (props: FilterImageProps) => {
   const { filters = [], source, style, ...imageProps } = props;
-  const { filter: stylesFilter, ...styles } = StyleSheet.flatten(style);
+  const { filter: stylesFilter, ...styles } = StyleSheet.flatten([
+    { filter: [] },
+    style,
+  ]);
   const extractedFilters = [...filters, ...extractFiltersCss(stylesFilter)];
   const filterId = React.useMemo(() => `RNSVG-${getRandomNumber()}`, []);
 

--- a/src/filter-image/FilterImage.tsx
+++ b/src/filter-image/FilterImage.tsx
@@ -25,10 +25,7 @@ export interface FilterImageProps extends ImageProps {
 
 export const FilterImage = (props: FilterImageProps) => {
   const { filters = [], source, style, ...imageProps } = props;
-  const { filter: stylesFilter, ...styles } = StyleSheet.flatten([
-    { filter: [] },
-    style,
-  ]);
+  const { filter: stylesFilter, ...styles } = StyleSheet.flatten(style ?? {});
   const extractedFilters = [...filters, ...extractFiltersCss(stylesFilter)];
   const filterId = React.useMemo(() => `RNSVG-${getRandomNumber()}`, []);
 


### PR DESCRIPTION
# Summary

Somehow deconstructing `filter` from `styles` are throwing error, when filter does not exist. These changes ensure that `filter` is always there (`[]` if not exists).