### PR TITLE
fix: problem with reanimated example in web platoform

### DIFF
--- a/apps/examples/src/examples/Reanimated.tsx
+++ b/apps/examples/src/examples/Reanimated.tsx
@@ -6,6 +6,7 @@ import Reanimated, {
   withRepeat,
   withSpring,
   withTiming,
+  withClamp,
 } from 'react-native-reanimated';
 import {Svg, Rect} from 'react-native-svg';
 
@@ -17,7 +18,7 @@ function ReanimatedRectExample() {
   const position = useSharedValue(0);
 
   useEffect(() => {
-    height.value = withRepeat(withSpring(100), -1, true);
+    height.value = withClamp({min: 0}, withRepeat(withSpring(100), -1, true));
     position.value = withRepeat(withTiming(300, {duration: 5000}), -1);
   });
   const animatedProps = useAnimatedProps(() => ({


### PR DESCRIPTION
# Summary
Fixed the problem with a reanimated example.
In the web platform, it can't be a negative value.
