### PR TITLE
fix: apple empty filter results

### DIFF
--- a/apple/Filters/RNSVGFilter.mm
+++ b/apple/Filters/RNSVGFilter.mm
@@ -104,7 +104,7 @@ using namespace facebook::react;
                                                                      fromRect:[result extent]];
       result = [CIImage imageWithCGImage:cgResult];
       CGImageRelease(cgResult);
-      if (currentFilter.result) {
+      if (result != nil && currentFilter.result) {
         [resultsMap setObject:result forKey:currentFilter.result];
       }
     } else {


### PR DESCRIPTION
# Summary

When there is no content of CGImage, ref will return `nil` instead of empty image and crash, we should ignore that results and continue applying filters.

## Example 
```tsx
<svg width="200" height="200">
  <filter id="offset">
    <feOffset dx="1000" dy="1000" />
  </filter>
  <rect
    x="0"
    y="0"
    width="100"
    height="100"
    fill="green"
    filter="url(#offset)" />
</svg>
```