### PR TITLE
refactor: unify filters types

### DIFF
--- a/src/elements/filters/FeColorMatrix.tsx
+++ b/src/elements/filters/FeColorMatrix.tsx
@@ -6,13 +6,13 @@ import {
   extractFilter,
   extractIn,
 } from '../../lib/extract/extractFilter';
-import { FilterColorMatrixType } from '../../lib/extract/types';
+import { FilterColorMatrixType, NumberArray } from '../../lib/extract/types';
 import FilterPrimitive from './FilterPrimitive';
 
 export type FeColorMatrixProps = {
   in?: string;
   type?: FilterColorMatrixType;
-  values?: number | Array<number> | string;
+  values?: NumberArray;
 };
 
 export default class FeColorMatrix extends FilterPrimitive<FeColorMatrixProps> {

--- a/src/elements/filters/FeGaussianBlur.tsx
+++ b/src/elements/filters/FeGaussianBlur.tsx
@@ -6,12 +6,12 @@ import {
   extractFilter,
   extractIn,
 } from '../../lib/extract/extractFilter';
-import { FilterEdgeMode, NumberProp } from '../../lib/extract/types';
+import { FilterEdgeMode, NumberArray } from '../../lib/extract/types';
 import FilterPrimitive from './FilterPrimitive';
 
 export interface FeGaussianBlurProps {
   in?: string;
-  stdDeviation?: NumberProp;
+  stdDeviation?: NumberArray;
   // edgeMode is hard to implement and not supported by any
   // browser except safari, so it's not implemented for now
   // https://caniuse.com/mdn-api_svgfegaussianblurelement_edgemode

--- a/src/lib/extract/extractFilter.ts
+++ b/src/lib/extract/extractFilter.ts
@@ -46,7 +46,9 @@ export const extractFeColorMatrix = (
 
   if (props.values !== undefined) {
     if (Array.isArray(props.values)) {
-      extracted.values = props.values;
+      extracted.values = props.values.map((num) =>
+        typeof num === 'number' ? num : parseFloat(num)
+      );
     } else if (typeof props.values === 'number') {
       extracted.values = [props.values];
     } else if (typeof props.values === 'string') {
@@ -70,7 +72,10 @@ export const extractFeGaussianBlur = (
 ): FeGaussianBlurNativeProps => {
   const extracted: FeGaussianBlurNativeProps = {};
 
-  if (
+  if (Array.isArray(props.stdDeviation)) {
+    extracted.stdDeviationX = Number(props.stdDeviation[0]) || 0;
+    extracted.stdDeviationY = Number(props.stdDeviation[1]) || 0;
+  } else if (
     typeof props.stdDeviation === 'string' &&
     props.stdDeviation.match(spaceReg)
   ) {


### PR DESCRIPTION
# Summary

Use unified SVG types for `FeColorMatrix` and `FeGaussianBlur`