### PR TITLE
feat: add support dataUri for android platform

### DIFF
--- a/apps/test-examples/App.js
+++ b/apps/test-examples/App.js
@@ -4,6 +4,7 @@ import React from 'react';
 import ColorTest from './src/ColorTest';
 import PointerEventsBoxNone from './src/PointerEventsBoxNone';
 import MountUnmount from './src/MountUnmount';
+import Test1318 from './src/Test1318';
 import Test1374 from './src/Test1374';
 import Test1442 from './src/Test1442';
 import Test1451 from './src/Test1451';
@@ -25,5 +26,5 @@ import Test2327 from './src/Test2327';
 import Test2366 from './src/Test2366';
 
 export default function App() {
-  return <ColorTest />;
+  return <Test1318 />;
 }

--- a/apps/test-examples/App.js
+++ b/apps/test-examples/App.js
@@ -26,5 +26,5 @@ import Test2327 from './src/Test2327';
 import Test2366 from './src/Test2366';
 
 export default function App() {
-  return <Test1318 />;
+  return <ColorTest />;
 }

--- a/apps/test-examples/src/Test1318.tsx
+++ b/apps/test-examples/src/Test1318.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import {SvgUri} from 'react-native-svg';
+import {SvgCssUri} from 'react-native-svg/css';
+
+export default function Test() {
+  return (
+    <>
+      <SvgCssUri
+        height={100}
+        width={100}
+        uri={
+          'data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%20100%20100%22%3E%3Cpath%20fill%3D%22%2354b847%22%20d%3D%22M0%200h100v100H0z%22%2F%3E%3Cpath%20fill%3D%22%23fff%22%20d%3D%22M61.6%2069.1h-17V38.3h8.6v25.4h8.2c5.7%200%208.1-3.9%208.1-14.1S66.8%2036.4%2061%2036.4H42.2v32.7h-8.4V36.3H21.4v-5.4h42.3c10.2%200%2015%205.3%2015%2018.6-.1%2017.4-7.3%2019.6-17.1%2019.6%22%2F%3E%3C%2Fsvg%3E'
+        }
+      />
+      <SvgCssUri
+        height={100}
+        width={100}
+        uri={
+          'data:image/svg+xml;utf8,%3Csvg%20width%3D%22300%22%20height%3D%22700%22%20viewBox%3D%2250%2050%20100%20100%22%20preserveAspectRatio%3D%22xMidYMid%20meet%22%3E%3Crect%20x%3D%2250%22%20y%3D%2250%22%20width%3D%22100%22%20height%3D%22100%22%20fill%3D%22yellow%22%3E%3C%2Frect%3E%3C%2Fsvg%3E'
+        }
+      />
+      <SvgUri
+        height={100}
+        width={100}
+        uri={
+          'data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%20100%20100%22%3E%3Cpath%20fill%3D%22%2354b847%22%20d%3D%22M0%200h100v100H0z%22%2F%3E%3Cpath%20fill%3D%22%23fff%22%20d%3D%22M61.6%2069.1h-17V38.3h8.6v25.4h8.2c5.7%200%208.1-3.9%208.1-14.1S66.8%2036.4%2061%2036.4H42.2v32.7h-8.4V36.3H21.4v-5.4h42.3c10.2%200%2015%205.3%2015%2018.6-.1%2017.4-7.3%2019.6-17.1%2019.6%22%2F%3E%3C%2Fsvg%3E'
+        }
+      />
+      <SvgUri
+        height={100}
+        width={100}
+        uri={
+          'data:image/svg+xml;utf8,%3Csvg%20width%3D%22300%22%20height%3D%22700%22%20viewBox%3D%2250%2050%20100%20100%22%20preserveAspectRatio%3D%22xMidYMid%20meet%22%3E%3Crect%20x%3D%2250%22%20y%3D%2250%22%20width%3D%22100%22%20height%3D%22100%22%20fill%3D%22yellow%22%3E%3C%2Frect%3E%3C%2Fsvg%3E'
+        }
+      />
+      <SvgUri
+        height={100}
+        width={100}
+        uri={
+          'data:image/svg+xml;utf8,%3Csvg%20width%3D%22300%22%20height%3D%22700%22%20viewBox%3D%2250%2050%20100%20100%22%20preserveAspectRatio%3D%22xMidYMid%20meet%22%3E%3Crect%20x%3D%2250%22%20y%3D%2250%22%20width%3D%22100%22%20height%3D%22100%22%20fill%3D%22yellow%22%3E%3C%2Frect%3E%3C%2Fsvg%3E'
+        }
+      />
+      <SvgUri
+        height={100}
+        width={100}
+        uri={
+          'data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22100%22%20height%3D%22100%22%20viewBox%3D%220%200%20100%20100%22%3E%3Cpolygon%20points%3D%2250%2C15%2061%2C40%2088%2C40%2066%2C57%2075%2C84%2050%2C68%2025%2C84%2034%2C57%2012%2C40%2039%2C40%22%20fill%3D%22gold%22%2F%3E%3C%2Fsvg%3E'
+        }
+      />
+    </>
+  );
+}

--- a/src/ReactNativeSVG.ts
+++ b/src/ReactNativeSVG.ts
@@ -2,7 +2,6 @@ import Shape from './elements/Shape';
 import {
   AstProps,
   camelCase,
-  fetchText,
   JsxAST,
   Middleware,
   parse,
@@ -18,6 +17,8 @@ import {
   XmlProps,
   XmlState,
 } from './xml';
+
+import { fetchText } from './utils/fetchData';
 
 import {
   RNSVGCircle,

--- a/src/ReactNativeSVG.web.ts
+++ b/src/ReactNativeSVG.web.ts
@@ -1,7 +1,6 @@
 import {
   AstProps,
   camelCase,
-  fetchText,
   JsxAST,
   Middleware,
   parse,
@@ -17,6 +16,8 @@ import {
   XmlProps,
   XmlState,
 } from './xml';
+
+import { fetchText } from './utils/fetchData';
 
 export {
   inlineStyles,

--- a/src/utils/fetchData.ts
+++ b/src/utils/fetchData.ts
@@ -1,0 +1,53 @@
+import { Buffer } from 'buffer';
+
+export function fetchText(uri?: string): Promise<string | null> {
+  if (uri && uri.startsWith('data:')) {
+    return new Promise((resolve) => {
+      resolve(dataUriToXml(uri));
+    });
+  } else {
+    return localFetch(uri);
+  }
+}
+
+// copy from https://www.npmjs.com/package/data-uri-to-buffer
+function dataUriToXml(uri: string) {
+  if (!/^data:/i.test(uri)) {
+    throw new TypeError(
+      '`uri` does not appear to be a Data URI (must begin with "data:")'
+    );
+  }
+  // strip newlines
+  uri = uri.replace(/\r?\n/g, '');
+  // split the URI up into the "metadata" and the "data" portions
+  const firstComma = uri.indexOf(',');
+  if (firstComma === -1 || firstComma <= 4) {
+    throw new TypeError('malformed data: URI');
+  }
+  // remove the "data:" scheme and parse the metadata
+  const meta = uri.substring(5, firstComma).split(';');
+  let base64 = false;
+  for (let i = 1; i < meta.length; i++) {
+    if (meta[i] === 'base64') {
+      base64 = true;
+    }
+  }
+
+  // get the encoded data portion and decode URI-encoded chars
+  const data = unescape(uri.substring(firstComma + 1));
+  if (!base64) {
+    return data;
+  }
+  return Buffer.from(data).toString('base64');
+}
+
+async function localFetch(uri?: string) {
+  if (!uri) {
+    return null;
+  }
+  const response = await fetch(uri);
+  if (response.ok || (response.status === 0 && uri.startsWith('file://'))) {
+    return await response.text();
+  }
+  throw new Error(`Fetching ${uri} failed with status ${response.status}`);
+}

--- a/src/xml.tsx
+++ b/src/xml.tsx
@@ -1,6 +1,7 @@
 import type { ComponentType, ComponentProps } from 'react';
 import * as React from 'react';
 import { Component, useEffect, useMemo, useState } from 'react';
+import { fetchText } from './utils/fetchData';
 import type { SvgProps } from './elements/Svg';
 import { tags } from './xmlTags';
 
@@ -76,17 +77,6 @@ export function SvgXml(props: XmlProps) {
     onError(error);
     return fallback ?? null;
   }
-}
-
-export async function fetchText(uri?: string) {
-  if (!uri) {
-    return null;
-  }
-  const response = await fetch(uri);
-  if (response.ok || (response.status === 0 && uri.startsWith('file://'))) {
-    return await response.text();
-  }
-  throw new Error(`Fetching ${uri} failed with status ${response.status}`);
 }
 
 export function SvgUri(props: UriProps) {


### PR DESCRIPTION
# Summary

Add support data URI in the Android platform. It already works on the iOS platform.

| Before1 | Before2 | After |
|--------|--------|--------|
|<img src="https://github.com/user-attachments/assets/4423ae12-0e67-4ff9-9a15-76fc6b707b26" width="300" height="600" /> | <img src="https://github.com/user-attachments/assets/a4412e8e-d965-41e9-95f3-06bffc6ebb76" width="300" height="600" />  | <img src="https://github.com/user-attachments/assets/69ba40ac-de52-4edf-9850-ea870270f426" width="300" height="600" /> |


## Test Plan




## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| Android |    ✅      |
| iOS		 |    ✅      |