### PR TITLE
fix: do not resolve asset url for every object on web.

### DIFF
--- a/src/web/utils/prepare.ts
+++ b/src/web/utils/prepare.ts
@@ -121,7 +121,7 @@ export const prepare = <T extends BaseProps>(
   if (onPress !== null) {
     clean.onClick = props.onPress;
   }
-  if (props.href !== null) {
+  if (props.href !== null && props.href !== undefined) {
     clean.href = resolveAssetUri(props.href)?.uri;
   }
   return clean;


### PR DESCRIPTION
# Summary

Do not resolve asset url for every object when href is undefined on WebShape.