### PR TITLE
fix: transforms on macOS old arch

### DIFF
--- a/apple/Elements/RNSVGSvgView.mm
+++ b/apple/Elements/RNSVGSvgView.mm
@@ -471,6 +471,13 @@ using namespace facebook::react;
   return _viewBoxTransform;
 }
 
+#if !RCT_NEW_ARCH_ENABLED && TARGET_OS_OSX // [macOS
+- (void)updateReactTransformInternal:(CATransform3D)transform
+{
+  [self setTransform:CATransform3DGetAffineTransform(transform)];
+}
+#endif // macOS]
+
 @end
 
 #ifdef RCT_NEW_ARCH_ENABLED


### PR DESCRIPTION
# Summary

Since `RNSVGPlatformView` on macOS old arch is just `RCTUIView`, we need to add `updateReactTransformInternal` to `RNSVGSvgView`.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| MacOS   |    ✅      |