### PR TITLE
feat: add check for scale 0 to avoid crash the app

### DIFF
--- a/android/src/main/java/com/horcrux/svg/SvgView.java
+++ b/android/src/main/java/com/horcrux/svg/SvgView.java
@@ -278,7 +278,7 @@ public class SvgView extends ReactViewGroup implements ReactCompoundView, ReactC
             || width < 1
             || height < 1
             || (Math.log10(width) + Math.log10(height) > 42);
-    if (invalid) {
+    if (invalid || mScaleX == 0 || mScaleY == 0) {
       return null;
     }
     Bitmap bitmap =

--- a/apps/test-examples/index.tsx
+++ b/apps/test-examples/index.tsx
@@ -29,6 +29,7 @@ import Test2366 from './src/Test2366';
 import Test2397 from './src/Test2397';
 import Test2403 from './src/Test2403';
 import Test2407 from './src/Test2407';
+import Test2421 from './src/Test2421';
 
 export default function App() {
   return <ColorTest />;

--- a/apps/test-examples/src/Test2421.tsx
+++ b/apps/test-examples/src/Test2421.tsx
@@ -1,0 +1,25 @@
+import {StyleSheet, View} from 'react-native';
+import Svg, {Rect} from 'react-native-svg';
+
+export default function App() {
+  return (
+    <View style={styles.main}>
+      <Svg style={styles.svg}>
+        <Rect x="0" y="0" width="100%" height="100%" fill="#080" />
+      </Svg>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  main: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  svg: {
+    width: 100,
+    height: 100,
+    transform: [{scale: 0}], // Causes the application to crash
+  },
+});

--- a/apps/test-examples/src/Test2421.tsx
+++ b/apps/test-examples/src/Test2421.tsx
@@ -4,9 +4,11 @@ import Svg, {Rect} from 'react-native-svg';
 export default function App() {
   return (
     <View style={styles.main}>
-      <Svg style={styles.svg}>
-        <Rect x="0" y="0" width="100%" height="100%" fill="#080" />
-      </Svg>
+      <View style={styles.main}>
+        <Svg style={styles.svg} viewBox="0 0 100 100" fill="none">
+          <Rect x="0" y="0" width="100%" height="100%" fill="#080" />
+        </Svg>
+      </View>
     </View>
   );
 }

--- a/apps/test-examples/src/Test2421.tsx
+++ b/apps/test-examples/src/Test2421.tsx
@@ -1,14 +1,16 @@
 import {StyleSheet, View} from 'react-native';
-import Svg, {Rect} from 'react-native-svg';
+import Svg, {Circle, Mask, Path, Rect} from 'react-native-svg';
 
 export default function App() {
   return (
     <View style={styles.main}>
-      <View style={styles.main}>
-        <Svg style={styles.svg} viewBox="0 0 100 100" fill="none">
-          <Rect x="0" y="0" width="100%" height="100%" fill="#080" />
-        </Svg>
-      </View>
+      <Svg
+        height="200"
+        viewBox="0 0 200 200"
+        width="200"
+        transform={[{scale: -2}]}>
+        <Path d="M10,35 A20,20,0,0,1,50,35 A20,20,0,0,1,90,35 Q90,65,50,95 Q10,65,10,35 Z" />
+      </Svg>
     </View>
   );
 }


### PR DESCRIPTION
# Summary
Fixes #2421 

The application crashes when applying a style with a scaling parameter equal to zero.

## Test Plan

The example is available in the test-examples app as Test2421

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| Android |    ✅          |
