### PR TITLE
fix: android svg scale 0

### DIFF
--- a/android/src/main/java/com/horcrux/svg/SvgView.java
+++ b/android/src/main/java/com/horcrux/svg/SvgView.java
@@ -128,7 +128,7 @@ public class SvgView extends ReactViewGroup implements ReactCompoundView, ReactC
 
   @Override
   protected void onDraw(Canvas canvas) {
-    if (getParent() instanceof VirtualView) {
+    if (getParent() instanceof VirtualView || mScaleX <= 0 || mScaleY <= 0) {
       return;
     }
     super.onDraw(canvas);


### PR DESCRIPTION
# Summary

Fixes #2421, bug introduced in https://github.com/software-mansion/react-native-svg/pull/2403/files#diff-7f8adeb6e7faded1a7ef711b4fa9d2b12d29ff386217e838c4551866afdd8befR286 this line. When bitmap size is less or equal to 0 we want to stop rendering the SVG to avoid Android crash.

## Test Plan

Set `transform="scale(0)"` to `Svg` element.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| Android |    ✅      |

## Checklist

- [x] I have tested this on a device and a simulator