### PR TITLE
feat: add un-escape special symbols functionality

### DIFF
--- a/apps/test-examples/index.tsx
+++ b/apps/test-examples/index.tsx
@@ -29,6 +29,7 @@ import Test2366 from './src/Test2366';
 import Test2397 from './src/Test2397';
 import Test2403 from './src/Test2403';
 import Test2407 from './src/Test2407';
+import Test2411 from './src/Test2411';
 
 export default function App() {
   return <ColorTest />;

--- a/apps/test-examples/src/Test2411.tsx
+++ b/apps/test-examples/src/Test2411.tsx
@@ -1,0 +1,12 @@
+import {SafeAreaView} from 'react-native';
+import {SvgFromXml} from 'react-native-svg';
+
+export default function App() {
+  return (
+    <SafeAreaView>
+      <SvgFromXml
+        xml={`<svg><text x="10" y="32" fontSize="32">&amp; &lt; &gt;</text></svg>`}
+      />
+    </SafeAreaView>
+  );
+}

--- a/src/xml.tsx
+++ b/src/xml.tsx
@@ -272,6 +272,14 @@ export function parse(source: string, middleware?: Middleware): JsxAST | null {
     );
   }
 
+  // New function to decode HTML entities
+  function decodeEntities(text: string): string {
+    return text
+      .replace(/&amp;/g, '&')
+      .replace(/&lt;/g, '<')
+      .replace(/&gt;/g, '>');
+  }
+
   function metadata() {
     while (
       i + 1 < length &&
@@ -296,7 +304,7 @@ export function parse(source: string, middleware?: Middleware): JsxAST | null {
     }
 
     if (/\S/.test(text)) {
-      children.push(text);
+      children.push(decodeEntities(text)); // Decode entities before pushing text to children
     }
 
     if (source[i] === '<') {
@@ -391,7 +399,7 @@ export function parse(source: string, middleware?: Middleware): JsxAST | null {
       error('expected ]]>');
     }
 
-    children.push(source.slice(i + 7, index));
+    children.push(decodeEntities(source.slice(i + 7, index))); // Decode entities in CDATA section
 
     i = index + 2;
     return neutral;
@@ -457,7 +465,7 @@ export function parse(source: string, middleware?: Middleware): JsxAST | null {
         i += 1;
         allowSpaces();
 
-        value = getAttributeValue();
+        value = decodeEntities(getAttributeValue()); // Decode entities in attribute values
         if (!isNaN(+value) && value.trim() !== '') {
           value = +value;
         }

--- a/src/xml.tsx
+++ b/src/xml.tsx
@@ -272,7 +272,6 @@ export function parse(source: string, middleware?: Middleware): JsxAST | null {
     );
   }
 
-  // New function to decode HTML entities
   function decodeEntities(text: string): string {
     return text
       .replace(/&amp;/g, '&')


### PR DESCRIPTION
# Summary
Fixes #2411
Motivation: the parse function does not un-escape text from the SVG element. It prevents displaying special characters (such as <, >, &, and others) in SVG text elements.

## Test Plan
The example is available in the test-examples app as Test2411

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅      |
| MacOS   |    ✅      |
| Android |    ✅     |
| Web     |    ✅      |

