### PR TITLE
feat: add format and quality in toDataURL function

### DIFF
--- a/android/src/main/java/com/horcrux/svg/SvgView.java
+++ b/android/src/main/java/com/horcrux/svg/SvgView.java
@@ -356,7 +356,7 @@ public class SvgView extends ReactViewGroup implements ReactCompoundView, ReactC
     return Base64.encodeToString(bitmapBytes, Base64.NO_WRAP);
   }
 
-  String toDataURL(int width, int height) {
+  String toDataURL(int width, int height, String format, Integer quality) {
     Bitmap bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888);
 
     clearChildCache();
@@ -364,7 +364,12 @@ public class SvgView extends ReactViewGroup implements ReactCompoundView, ReactC
     clearChildCache();
     this.invalidate();
     ByteArrayOutputStream stream = new ByteArrayOutputStream();
-    bitmap.compress(Bitmap.CompressFormat.PNG, 100, stream);
+    if (format.equals("jpeg")) {
+      int checkQualityValue = (quality != null) ? quality : 100;
+      bitmap.compress(Bitmap.CompressFormat.JPEG, checkQualityValue, stream);
+    } else {
+      bitmap.compress(Bitmap.CompressFormat.PNG, 100, stream);
+    }
     bitmap.recycle();
     byte[] bitmapBytes = stream.toByteArray();
     return Base64.encodeToString(bitmapBytes, Base64.NO_WRAP);

--- a/android/src/main/java/com/horcrux/svg/SvgViewModule.java
+++ b/android/src/main/java/com/horcrux/svg/SvgViewModule.java
@@ -67,8 +67,10 @@ class SvgViewModule extends NativeSvgViewModuleSpec {
                   });
             } else {
               if (options != null) {
+                  Integer quality = options.hasKey("quality") ? options.getInt("quality") : null;
+                  String format = options.hasKey("format") ? options.getString("format") : null;
                 successCallback.invoke(
-                    svg.toDataURL(options.getInt("width"), options.getInt("height")));
+                    svg.toDataURL(options.getInt("width"), options.getInt("height"), format, quality));
               } else {
                 successCallback.invoke(svg.toDataURL());
               }

--- a/apple/Elements/RNSVGSvgView.h
+++ b/apple/Elements/RNSVGSvgView.h
@@ -62,7 +62,8 @@
 
 - (RNSVGFilter *)getDefinedFilter:(NSString *)filterName;
 
-- (NSString *)getDataURLWithBounds:(CGRect)bounds;
+- (NSString *)getDataURLWithBounds:(CGRect)bounds format:(NSString *)format;
+- (NSString *)getDataURLWithBounds:(CGRect)bounds format:(NSString *)format quality:(CGFloat *)quality;
 
 - (CGRect)getContextBounds;
 

--- a/apple/Elements/RNSVGSvgView.h
+++ b/apple/Elements/RNSVGSvgView.h
@@ -63,7 +63,7 @@
 - (RNSVGFilter *)getDefinedFilter:(NSString *)filterName;
 
 - (NSString *)getDataURLWithBounds:(CGRect)bounds format:(NSString *)format;
-- (NSString *)getDataURLWithBounds:(CGRect)bounds format:(NSString *)format quality:(CGFloat *)quality;
+- (NSString *)getDataURLWithBounds:(CGRect)bounds format:(NSString *)format quality:(CGFloat)quality;
 
 - (CGRect)getContextBounds;
 

--- a/apple/Elements/RNSVGSvgView.mm
+++ b/apple/Elements/RNSVGSvgView.mm
@@ -358,7 +358,7 @@ using namespace facebook::react;
   return isPointInside ? self : nil;
 }
 
-- (NSString *)getDataURLWithBounds:(CGRect)bounds
+- (NSString *)getDataURLWithBounds:(CGRect)bounds format:(NSString *)format quality:(CGFloat *)quality
 {
 #if !TARGET_OS_OSX // [macOS]
   UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize:bounds.size];
@@ -374,7 +374,13 @@ using namespace facebook::react;
   }];
 #endif
 #if !TARGET_OS_OSX // [macOS]
-  NSData *imageData = UIImagePNGRepresentation(image);
+  NSData *imageData;
+  if ([format isEqual:@"jpeg"]) {
+    CGFloat checkQualityValue = (quality != nil) ? *quality : 1.0;
+    imageData = UIImageJPEGRepresentation(image, checkQualityValue);
+  } else {
+    imageData = UIImagePNGRepresentation(image);
+  }
   NSString *base64 = [imageData base64EncodedStringWithOptions:NSDataBase64EncodingEndLineWithLineFeed];
 #else // [macOS
   NSData *imageData = UIImagePNGRepresentation(UIGraphicsGetImageFromCurrentImageContext());

--- a/apple/Elements/RNSVGSvgView.mm
+++ b/apple/Elements/RNSVGSvgView.mm
@@ -358,7 +358,7 @@ using namespace facebook::react;
   return isPointInside ? self : nil;
 }
 
-- (NSString *)getDataURLWithBounds:(CGRect)bounds format:(NSString *)format quality:(CGFloat *)quality
+- (NSString *)getDataURLWithBounds:(CGRect)bounds format:(NSString *)format quality:(CGFloat)quality
 {
 #if !TARGET_OS_OSX // [macOS]
   UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize:bounds.size];
@@ -376,8 +376,7 @@ using namespace facebook::react;
 #if !TARGET_OS_OSX // [macOS]
   NSData *imageData;
   if ([format isEqual:@"jpeg"]) {
-    CGFloat checkQualityValue = (quality != nil) ? *quality : 1.0;
-    imageData = UIImageJPEGRepresentation(image, checkQualityValue);
+    imageData = UIImageJPEGRepresentation(image, quality);
   } else {
     imageData = UIImagePNGRepresentation(image);
   }

--- a/apple/Elements/RNSVGSvgView.mm
+++ b/apple/Elements/RNSVGSvgView.mm
@@ -382,7 +382,13 @@ using namespace facebook::react;
   }
   NSString *base64 = [imageData base64EncodedStringWithOptions:NSDataBase64EncodingEndLineWithLineFeed];
 #else // [macOS
-  NSData *imageData = UIImagePNGRepresentation(UIGraphicsGetImageFromCurrentImageContext());
+  NSData *imageData;
+  NSImage *image = UIGraphicsGetImageFromCurrentImageContext();
+  if ([format isEqual:@"jpeg"]) {
+    imageData = UIImageJPEGRepresentation(image, quality);
+  } else {
+    imageData = UIImagePNGRepresentation(image);
+  }
   NSString *base64 = [imageData base64EncodedStringWithOptions:NSDataBase64EncodingEndLineWithLineFeed];
   UIGraphicsEndImageContext();
 #endif // macOS]

--- a/apple/RNSVGSvgViewModule.mm
+++ b/apple/RNSVGSvgViewModule.mm
@@ -38,7 +38,7 @@ RCT_EXPORT_MODULE()
     if ([view isKindOfClass:[RNSVGSvgView class]]) {
       RNSVGSvgView *svg = view;
       if (options == nil) {
-        b64 = [svg getDataURLWithBounds:svg.boundingBox];
+        b64 = [svg getDataURLWithBounds:svg.boundingBox format:@"png"];
       } else {
         id width = [options objectForKey:@"width"];
         id height = [options objectForKey:@"height"];
@@ -52,7 +52,9 @@ RCT_EXPORT_MODULE()
         NSInteger hi = (NSInteger)[h intValue];
 
         CGRect bounds = CGRectMake(0, 0, wi, hi);
-        b64 = [svg getDataURLWithBounds:bounds];
+        NSString *format = [options objectForKey:@"format"];
+        NSNumber *quality = [options objectForKey:@"quality"];
+        b64 = [svg getDataURLWithBounds:bounds format:format quality:quality];
       }
     } else {
       RCTLogError(@"Invalid svg returned from registry, expecting RNSVGSvgView, got: %@", view);

--- a/apple/RNSVGSvgViewModule.mm
+++ b/apple/RNSVGSvgViewModule.mm
@@ -53,7 +53,8 @@ RCT_EXPORT_MODULE()
 
         CGRect bounds = CGRectMake(0, 0, wi, hi);
         NSString *format = [options objectForKey:@"format"];
-        NSNumber *quality = [options objectForKey:@"quality"];
+        NSNumber *qualityNumber = [options objectForKey:@"quality"];
+        CGFloat quality = qualityNumber ? [qualityNumber doubleValue] : 1.0;
         b64 = [svg getDataURLWithBounds:bounds format:format quality:quality];
       }
     } else {

--- a/apps/test-examples/src/Test2233.tsx
+++ b/apps/test-examples/src/Test2233.tsx
@@ -5,7 +5,7 @@ import Svg, {Path, type ToDataUrlOptions} from 'react-native-svg';
 const SvgLogoWelcome = () => {
   const ref = React.useRef<Svg | null>(null);
 
-  const {width, height} = Dimensions.get('window');
+  const {width, height} = Dimensions.get('screen');
   const optionsWithJPEGFormat: ToDataUrlOptions = {
     format: 'jpeg',
     width,
@@ -20,7 +20,13 @@ const SvgLogoWelcome = () => {
   };
 
   return (
-    <View>
+    <View
+      style={{
+        width: '100%',
+        height: '100%',
+        justifyContent: 'center',
+        alignItems: 'center',
+      }}>
       <Button
         onPress={() => {
           ref.current?.toDataURL(base64Image => {
@@ -29,7 +35,7 @@ const SvgLogoWelcome = () => {
         }}
         title="log"
       />
-      <Svg ref={ref} viewBox="0 0 24 24" fill="black">
+      <Svg ref={ref} viewBox="0 0 24 24" fill="black" width={250} height={250}>
         <Path d="M12 2c5.514 0 10 4.486 10 10s-4.486 10-10 10S2 17.514 2 12 6.486 2 12 2zm0-2C5.373 0 0 5.373 0 12s5.373 12 12 12 12-5.373 12-12S18.627 0 12 0zm5.507 13.941c-1.512 1.195-3.174 1.931-5.506 1.931-2.334 0-3.996-.736-5.508-1.931L6 14.434C7.127 16.154 9.2 18 12.001 18c2.8 0 4.872-1.846 5.999-3.566l-.493-.493zM8.5 8a1.5 1.5 0 100 3 1.5 1.5 0 000-3zm7 0a1.5 1.5 0 100 3 1.5 1.5 0 000-3z" />
       </Svg>
     </View>

--- a/apps/test-examples/src/Test2233.tsx
+++ b/apps/test-examples/src/Test2233.tsx
@@ -1,16 +1,30 @@
 import * as React from 'react';
 import {Button, SafeAreaView, View} from 'react-native';
-import Svg, {Path} from 'react-native-svg';
+import Svg, {Path, type ToDataUrlOptions} from 'react-native-svg';
 
 const SvgLogoWelcome = () => {
   const ref = React.useRef<Svg | null>(null);
+
+  const optionsWithJPEGFormat: ToDataUrlOptions = {
+    format: 'jpeg',
+    width: 100,
+    height: 100,
+    quality: 1,
+  };
+
+  const optionsWithPNGFormat: ToDataUrlOptions = {
+    format: 'png',
+    width: 100,
+    height: 100,
+  };
+
   return (
     <View>
       <Button
         onPress={() => {
           ref.current?.toDataURL(base64Image => {
             console.log(base64Image, 'data');
-          });
+          }, optionsWithJPEGFormat);
         }}
         title="log"
       />

--- a/apps/test-examples/src/Test2233.tsx
+++ b/apps/test-examples/src/Test2233.tsx
@@ -1,21 +1,22 @@
 import * as React from 'react';
-import {Button, SafeAreaView, View} from 'react-native';
+import {Button, Dimensions, SafeAreaView, View} from 'react-native';
 import Svg, {Path, type ToDataUrlOptions} from 'react-native-svg';
 
 const SvgLogoWelcome = () => {
   const ref = React.useRef<Svg | null>(null);
 
+  const {width, height} = Dimensions.get('window');
   const optionsWithJPEGFormat: ToDataUrlOptions = {
     format: 'jpeg',
-    width: 100,
-    height: 100,
-    quality: 1,
+    width,
+    height,
+    quality: 100,
   };
 
   const optionsWithPNGFormat: ToDataUrlOptions = {
     format: 'png',
-    width: 100,
-    height: 100,
+    width,
+    height,
   };
 
   return (

--- a/src/ReactNativeSVG.ts
+++ b/src/ReactNativeSVG.ts
@@ -107,7 +107,7 @@ export type { PolylineProps } from './elements/Polyline';
 export type { RadialGradientProps } from './elements/RadialGradient';
 export type { RectProps } from './elements/Rect';
 export type { StopProps } from './elements/Stop';
-export type { SvgProps } from './elements/Svg';
+export type { SvgProps, ToDataUrlOptions } from './elements/Svg';
 export type { SymbolProps } from './elements/Symbol';
 export type { TextProps } from './elements/Text';
 export type { TextPathProps } from './elements/TextPath';

--- a/src/elements/Svg.tsx
+++ b/src/elements/Svg.tsx
@@ -45,6 +45,21 @@ export interface SvgProps extends GProps, ViewProps, HitSlop {
   title?: string;
 }
 
+export type ToDataUrlOptions = JpegOptions | PngOptions;
+
+interface JpegOptions {
+  format: 'jpeg';
+  quality?: number; // Quality is optional but only available when format is 'jpeg'
+  width?: number;
+  height?: number;
+}
+
+interface PngOptions {
+  format: 'png';
+  width?: number;
+  height?: number;
+}
+
 export default class Svg extends Shape<SvgProps> {
   static displayName = 'Svg';
 
@@ -81,10 +96,29 @@ export default class Svg extends Shape<SvgProps> {
     root && root.setNativeProps(props);
   };
 
-  toDataURL = (callback: (base64: string) => void, options?: object) => {
+  someFunction(options?: ToDataUrlOptions) {
+    if (options) {
+      if (!options.width && !options.height) {
+        throw new Error(
+          'toDataURL: Please provide width and height in options.'
+        );
+      }
+      if (options.width && !options.height) {
+        options.height = options.width;
+      } else if (!options.width && options.height) {
+        options.width = options.height;
+      }
+    }
+  }
+
+  toDataURL = (
+    callback: (base64: string) => void,
+    options?: ToDataUrlOptions
+  ) => {
     if (!callback) {
       return;
     }
+    this.someFunction(options);
     const handle = findNodeHandle(this.root as Component);
     const RNSVGSvgViewModule: Spec =
       // eslint-disable-next-line @typescript-eslint/no-var-requires

--- a/src/elements/Svg.tsx
+++ b/src/elements/Svg.tsx
@@ -60,6 +60,41 @@ interface PngOptions {
   height?: number;
 }
 
+function checkOptions(options?: ToDataUrlOptions) {
+  if (options) {
+    if (options?.format === 'jpeg') {
+      validateJpegQualityParameter(options);
+    }
+    if (!options.width && !options.height) {
+      throw new Error('toDataURL: Please provide width and height in options.');
+    }
+    if (options.width && !options.height) {
+      options.height = options.width;
+    } else if (!options.width && options.height) {
+      options.width = options.height;
+    }
+  }
+}
+
+function validateJpegQualityParameter(options: JpegOptions): boolean {
+  if (Platform.OS === 'android') {
+    if (
+      options.quality !== undefined &&
+      (options.quality < 1 || options.quality > 100)
+    ) {
+      return false;
+    }
+  } else if (Platform.OS === 'ios') {
+    if (
+      options.quality !== undefined &&
+      (options.quality < 0.1 || options.quality > 1)
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
 export default class Svg extends Shape<SvgProps> {
   static displayName = 'Svg';
 
@@ -96,21 +131,6 @@ export default class Svg extends Shape<SvgProps> {
     root && root.setNativeProps(props);
   };
 
-  someFunction(options?: ToDataUrlOptions) {
-    if (options) {
-      if (!options.width && !options.height) {
-        throw new Error(
-          'toDataURL: Please provide width and height in options.'
-        );
-      }
-      if (options.width && !options.height) {
-        options.height = options.width;
-      } else if (!options.width && options.height) {
-        options.width = options.height;
-      }
-    }
-  }
-
   toDataURL = (
     callback: (base64: string) => void,
     options?: ToDataUrlOptions
@@ -118,7 +138,7 @@ export default class Svg extends Shape<SvgProps> {
     if (!callback) {
       return;
     }
-    this.someFunction(options);
+    checkOptions(options);
     const handle = findNodeHandle(this.root as Component);
     const RNSVGSvgViewModule: Spec =
       // eslint-disable-next-line @typescript-eslint/no-var-requires

--- a/src/elements/Svg.tsx
+++ b/src/elements/Svg.tsx
@@ -84,7 +84,7 @@ function validateJpegQualityParameter(options: JpegOptions): boolean {
     ) {
       return false;
     }
-  } else if (Platform.OS === 'ios') {
+  } else if (Platform.OS === 'ios' || Platform.OS === 'macos') {
     if (
       options.quality !== undefined &&
       (options.quality < 0.1 || options.quality > 1)


### PR DESCRIPTION
# Summary
Introduce new parameters, format, and quality, for the toDataURL function.

Allow users to select the compressed format (defaulting to PNG or JPEG) in the toDataURL function. Additionally, include a new parameter called quality for the JPEG format.
Created a new type, ToDataUrlOptions, and exported it externally.

The data structure appears as follows:
```ts
  const optionsWithJPEGFormat: ToDataUrlOptions = {
    format: 'jpeg',
    width,
    height,
    quality: 100,
  };
```

```ts
  const optionsWithPNGFormat: ToDataUrlOptions = {
    format: 'png',
    width,
    height,
  };
```

## Test Plan


### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅      |
| MacOS   |    ✅      |
| Android |    ✅      |
| Web     |    ✅❌      |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [x] I updated the typed files (typescript)
