### PR TITLE
fix: reset paint settings before drawing final bitmap

### DIFF
--- a/android/src/main/java/com/horcrux/svg/SvgView.java
+++ b/android/src/main/java/com/horcrux/svg/SvgView.java
@@ -136,6 +136,9 @@ public class SvgView extends ReactViewGroup implements ReactCompoundView, ReactC
       mBitmap = drawOutput();
     }
     if (mBitmap != null) {
+      mPaint.reset();
+      mPaint.setFlags(Paint.ANTI_ALIAS_FLAG | Paint.DEV_KERN_TEXT_FLAG | Paint.SUBPIXEL_TEXT_FLAG);
+      mPaint.setTypeface(Typeface.DEFAULT);
       if (mScaleX != 1 || mScaleY != 1) {
         canvas.drawBitmap(
             mBitmap,


### PR DESCRIPTION
# Summary

Fixes #2436.
#2403 introduced shared `Paint` between the node render method and the final bitmap. However, Paint properties are not cleared after drawing, so we need to call the `.clear()` method and re-enable antialiasing.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| Android |    ✅     |
