### PR TITLE
fix: render G offscreen only when it's needed (opacity != 1)

### DIFF
--- a/android/src/main/java/com/horcrux/svg/GroupView.java
+++ b/android/src/main/java/com/horcrux/svg/GroupView.java
@@ -97,19 +97,24 @@ class GroupView extends RenderableView {
     final SvgView svg = getSvgView();
     final GroupView self = this;
     final RectF groupRect = new RectF();
-    if (mLayerBitmap == null) {
-      mLayerBitmap =
-          Bitmap.createBitmap(canvas.getWidth(), canvas.getHeight(), Bitmap.Config.ARGB_8888);
-      mLayerCanvas = new Canvas(mLayerBitmap);
+
+    if (opacity != 1) {
+      if (mLayerBitmap == null) {
+        mLayerBitmap =
+            Bitmap.createBitmap(canvas.getWidth(), canvas.getHeight(), Bitmap.Config.ARGB_8888);
+        mLayerCanvas = new Canvas(mLayerBitmap);
+      } else {
+        mLayerBitmap.recycle();
+        mLayerBitmap =
+            Bitmap.createBitmap(canvas.getWidth(), canvas.getHeight(), Bitmap.Config.ARGB_8888);
+        mLayerCanvas.setBitmap(mLayerBitmap);
+      }
+      // Copy current matrix from original canvas
+      mLayerCanvas.save();
+      mLayerCanvas.setMatrix(canvas.getMatrix());
     } else {
-      mLayerBitmap.recycle();
-      mLayerBitmap =
-          Bitmap.createBitmap(canvas.getWidth(), canvas.getHeight(), Bitmap.Config.ARGB_8888);
-      mLayerCanvas.setBitmap(mLayerBitmap);
+      mLayerCanvas = canvas;
     }
-    // Copy current matrix from original canvas
-    int saveCount = mLayerCanvas.save();
-    mLayerCanvas.setMatrix(canvas.getMatrix());
 
     elements = new ArrayList<>();
     for (int i = 0; i < getChildCount(); i++) {
@@ -157,13 +162,15 @@ class GroupView extends RenderableView {
       }
     }
 
-    // Restore copied canvas and temporary reset original canvas matrix to draw bitmap 1:1
-    mLayerCanvas.restoreToCount(saveCount);
-    saveCount = canvas.save();
-    canvas.setMatrix(null);
-    mLayerPaint.setAlpha((int) (mOpacity * 255));
-    canvas.drawBitmap(mLayerBitmap, 0, 0, mLayerPaint);
-    canvas.restoreToCount(saveCount);
+    if (opacity != 1) {
+      // Restore copied canvas and temporary reset original canvas matrix to draw bitmap 1:1
+      mLayerCanvas.restore();
+      int saveCount = canvas.save();
+      canvas.setMatrix(null);
+      mLayerPaint.setAlpha((int) (mOpacity * 255));
+      canvas.drawBitmap(mLayerBitmap, 0, 0, mLayerPaint);
+      canvas.restoreToCount(saveCount);
+    }
     this.setClientRect(groupRect);
     popGlyphContext();
   }

--- a/android/src/main/java/com/horcrux/svg/GroupView.java
+++ b/android/src/main/java/com/horcrux/svg/GroupView.java
@@ -98,7 +98,7 @@ class GroupView extends RenderableView {
     final GroupView self = this;
     final RectF groupRect = new RectF();
 
-    if (opacity != 1) {
+    if (mOpacity != 1) {
       if (mLayerBitmap == null) {
         mLayerBitmap =
             Bitmap.createBitmap(canvas.getWidth(), canvas.getHeight(), Bitmap.Config.ARGB_8888);
@@ -162,7 +162,7 @@ class GroupView extends RenderableView {
       }
     }
 
-    if (opacity != 1) {
+    if (mOpacity != 1) {
       // Restore copied canvas and temporary reset original canvas matrix to draw bitmap 1:1
       mLayerCanvas.restore();
       int saveCount = canvas.save();


### PR DESCRIPTION
# Summary

Improve #2417 by applying offscreen canvas only when opacity attribute is set

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| Android |    ✅      |
