### PR TITLE
fix: exclude e2e from types in release

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,5 +21,5 @@
     "resolveJsonModule": true,
     "isolatedModules": true
   },
-  "include": ["src", "e2e", "__tests__/e2e/GeneralSvgRenderingTest.spec.tsx"]
+  "include": ["src"]
 }


### PR DESCRIPTION
# Summary

Hot fix for #2453 missing types.
Closes #2453.