### PR TITLE
fix: masked element layer opacity when previous item has stroke opacity

### DIFF
--- a/android/src/main/java/com/horcrux/svg/RenderableView.java
+++ b/android/src/main/java/com/horcrux/svg/RenderableView.java
@@ -377,7 +377,7 @@ public abstract class RenderableView extends VirtualView implements ReactHitSlop
         canvas.drawBitmap(elementBitmap, 0, 0, bitmapPaint);
         canvas.restoreToCount(saveCount);
       } else {
-        canvas.saveLayer(null, paint);
+        canvas.saveLayer(null, new Paint());
         draw(canvas, paint, opacity);
       }
 


### PR DESCRIPTION
# Summary

On Android when element before masked element has strokeOpacity different from 1, the paint is reused to draw an offscreen layer resulting in wrong opacity. Partially fixes (only on Android) #2449 

## Test Plan

Add `stroke` and `strokeOpacity` to element directly before masked element.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| Android |    ✅      |
