### PR TITLE
feat: Support `fontFeatureSettings` on web

### DIFF
--- a/src/web/types.ts
+++ b/src/web/types.ts
@@ -55,6 +55,7 @@ export interface BaseProps {
   fontWeight?: NumberProp;
   fontSize?: NumberProp;
   fontFamily?: string;
+  fontFeatureSettings?: string;
   forwardedRef?:
     | React.RefCallback<SVGElement>
     | React.MutableRefObject<SVGElement | null>;

--- a/src/web/utils/prepare.ts
+++ b/src/web/utils/prepare.ts
@@ -30,6 +30,7 @@ export const prepare = <T extends BaseProps>(
     fontSize,
     fontWeight,
     fontStyle,
+    fontFeatureSettings,
     style,
     forwardedRef,
     gradientTransform,
@@ -103,6 +104,7 @@ export const prepare = <T extends BaseProps>(
     fontFamily?: string;
     fontSize?: NumberProp;
     fontWeight?: NumberProp;
+    fontFeatureSettings?: string;
   } = {};
 
   if (fontFamily != null) {
@@ -116,6 +118,9 @@ export const prepare = <T extends BaseProps>(
   }
   if (fontStyle != null) {
     styles.fontStyle = fontStyle;
+  }
+  if (fontFeatureSettings != null) {
+    styles.fontFeatureSettings = fontFeatureSettings;
   }
   clean.style = resolve(style, styles);
   if (onPress !== null) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Support is just a matter of making sure we pass through the value properly.  Hopefully the property is supported on iOS soon, but for now, 2 (Android + web) out of 3 is better than 1 out of 3.

## Test Plan

Ran change locally, worked fine.  It's a pretty trivial change.

### What's required for testing (prerequisites)?

An SVG with `fontFeatureSettings` set on a Text element

### What are the steps to reproduce (after prerequisites)?

1. Open browser
2. See that `fontFeatureSettings` is not applied
3. Apply this change
4. See that `fontFeatureSettings` is applied properly

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌      |
| MacOS   |    ❓      |
| Android |    ✅      |
| Web     |    ✅      |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [x] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
