### PR TITLE
fix: currentColor dimming

### DIFF
--- a/apple/Elements/RNSVGSvgView.mm
+++ b/apple/Elements/RNSVGSvgView.mm
@@ -43,6 +43,8 @@ using namespace facebook::react;
 - (instancetype)initWithFrame:(CGRect)frame
 {
   if (self = [super initWithFrame:frame]) {
+    // We don't want the dimming effect on tint as it's used as currentColor
+    self.tintAdjustmentMode = UIViewTintAdjustmentModeNormal;
 #if !TARGET_OS_OSX // Not available on macOS
     // This is necessary to ensure that [self setNeedsDisplay] actually triggers
     // a redraw when our parent transitions between hidden and visible.

--- a/apple/Elements/RNSVGSvgView.mm
+++ b/apple/Elements/RNSVGSvgView.mm
@@ -43,12 +43,12 @@ using namespace facebook::react;
 - (instancetype)initWithFrame:(CGRect)frame
 {
   if (self = [super initWithFrame:frame]) {
-    // We don't want the dimming effect on tint as it's used as currentColor
-    self.tintAdjustmentMode = UIViewTintAdjustmentModeNormal;
 #if !TARGET_OS_OSX // Not available on macOS
     // This is necessary to ensure that [self setNeedsDisplay] actually triggers
     // a redraw when our parent transitions between hidden and visible.
     self.contentMode = UIViewContentModeRedraw;
+    // We don't want the dimming effect on tint as it's used as currentColor
+    self.tintAdjustmentMode = UIViewTintAdjustmentModeNormal;
 #endif // TARGET_OS_OSX
     rendered = false;
 #ifdef RCT_NEW_ARCH_ENABLED

--- a/apps/test-examples/index.tsx
+++ b/apps/test-examples/index.tsx
@@ -31,6 +31,7 @@ import Test2397 from './src/Test2397';
 import Test2403 from './src/Test2403';
 import Test2407 from './src/Test2407';
 import Test2417 from './src/Test2417';
+import Test2455 from './src/Test2455';
 
 export default function App() {
   return <ColorTest />;

--- a/apps/test-examples/src/Test2455.tsx
+++ b/apps/test-examples/src/Test2455.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import {Button, Share, Text, TouchableOpacity, View} from 'react-native';
+import {G, Path, Rect, Svg} from 'react-native-svg';
+
+const Favorite = ({color}: {color: string}): JSX.Element => {
+  return (
+    <Svg color={color} width="60" height="60" viewBox="0 0 24 24" fill="none">
+      <Path
+        d="M22.7927 11.1242C21.359 18.5187 12.0003 22.7782 12.0003 22.7782C12.0003 22.7782 2.64153 18.5187 1.20661 11.1242C0.326598 6.58719 2.24925 2.02329 7.13701 2.00007C10.7781 1.98296 12.0003 5.65211 12.0003 5.65211C12.0003 5.65211 13.2226 1.98173 16.8624 2.00007C21.7612 2.02329 23.6727 6.58841 22.7927 11.1242Z"
+        fill="currentColor"
+      />
+      <G color={color === 'green' ? 'red' : 'green'} fill={'purple'}>
+        <Rect x="16" y="16" width="8" height="8" fill="currentColor" />
+        <G color="pink">
+          <Rect x="0" y="16" width="8" height="8" fill="currentColor" />
+        </G>
+      </G>
+    </Svg>
+  );
+};
+
+export default () => {
+  const [color, setColor] = React.useState('green');
+  return (
+    <View style={{flex: 1, justifyContent: 'center', alignItems: 'center'}}>
+      <Favorite color={color} />
+      <Button
+        onPress={() => setColor(prev => (prev === 'green' ? 'red' : 'green'))}
+        title="toggle color"
+      />
+      <Button
+        title="share"
+        onPress={() => Share.share({message: 'This is test message'})}
+      />
+    </View>
+  );
+};


### PR DESCRIPTION
# Summary

Fixes #2455. When the shared modal was triggered, the `currentColor` (which is `tintColor` under the hood) was being greyscaled because the default value of `tintAdjustmentMode` was set to `UIViewTintAdjustmentModeDimmed`. Changing it to `UIViewTintAdjustmentModeNormal` resolves the issue.

## Test Plan

Example apps -> `Test2455`

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅      |
