### PR TITLE
feat: improve animating colors 

### DIFF
--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGCircleManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGCircleManagerDelegate.java
@@ -14,7 +14,6 @@ import androidx.annotation.Nullable;
 import com.facebook.react.bridge.ColorPropConverter;
 import com.facebook.react.bridge.DynamicFromObject;
 import com.facebook.react.bridge.ReadableArray;
-import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.BaseViewManagerInterface;
 
@@ -65,7 +64,7 @@ public class RNSVGCircleManagerDelegate<T extends View, U extends BaseViewManage
         mViewManager.setColor(view, ColorPropConverter.getColor(value, view.getContext()));
         break;
       case "fill":
-        mViewManager.setFill(view, (ReadableMap) value);
+        mViewManager.setFill(view, new DynamicFromObject(value));
         break;
       case "fillOpacity":
         mViewManager.setFillOpacity(view, value == null ? 1f : ((Double) value).floatValue());
@@ -74,7 +73,7 @@ public class RNSVGCircleManagerDelegate<T extends View, U extends BaseViewManage
         mViewManager.setFillRule(view, value == null ? 1 : ((Double) value).intValue());
         break;
       case "stroke":
-        mViewManager.setStroke(view, (ReadableMap) value);
+        mViewManager.setStroke(view, new DynamicFromObject(value));
         break;
       case "strokeOpacity":
         mViewManager.setStrokeOpacity(view, value == null ? 1f : ((Double) value).floatValue());

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGCircleManagerInterface.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGCircleManagerInterface.java
@@ -13,7 +13,6 @@ import android.view.View;
 import androidx.annotation.Nullable;
 import com.facebook.react.bridge.Dynamic;
 import com.facebook.react.bridge.ReadableArray;
-import com.facebook.react.bridge.ReadableMap;
 
 public interface RNSVGCircleManagerInterface<T extends View> {
   void setName(T view, @Nullable String value);
@@ -29,10 +28,10 @@ public interface RNSVGCircleManagerInterface<T extends View> {
   void setDisplay(T view, @Nullable String value);
   void setPointerEvents(T view, @Nullable String value);
   void setColor(T view, @Nullable Integer value);
-  void setFill(T view, @Nullable ReadableMap value);
+  void setFill(T view, Dynamic value);
   void setFillOpacity(T view, float value);
   void setFillRule(T view, int value);
-  void setStroke(T view, @Nullable ReadableMap value);
+  void setStroke(T view, Dynamic value);
   void setStrokeOpacity(T view, float value);
   void setStrokeWidth(T view, Dynamic value);
   void setStrokeLinecap(T view, int value);

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGClipPathManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGClipPathManagerDelegate.java
@@ -14,7 +14,6 @@ import androidx.annotation.Nullable;
 import com.facebook.react.bridge.ColorPropConverter;
 import com.facebook.react.bridge.DynamicFromObject;
 import com.facebook.react.bridge.ReadableArray;
-import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.BaseViewManagerInterface;
 
@@ -65,7 +64,7 @@ public class RNSVGClipPathManagerDelegate<T extends View, U extends BaseViewMana
         mViewManager.setColor(view, ColorPropConverter.getColor(value, view.getContext()));
         break;
       case "fill":
-        mViewManager.setFill(view, (ReadableMap) value);
+        mViewManager.setFill(view, new DynamicFromObject(value));
         break;
       case "fillOpacity":
         mViewManager.setFillOpacity(view, value == null ? 1f : ((Double) value).floatValue());
@@ -74,7 +73,7 @@ public class RNSVGClipPathManagerDelegate<T extends View, U extends BaseViewMana
         mViewManager.setFillRule(view, value == null ? 1 : ((Double) value).intValue());
         break;
       case "stroke":
-        mViewManager.setStroke(view, (ReadableMap) value);
+        mViewManager.setStroke(view, new DynamicFromObject(value));
         break;
       case "strokeOpacity":
         mViewManager.setStrokeOpacity(view, value == null ? 1f : ((Double) value).floatValue());

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGClipPathManagerInterface.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGClipPathManagerInterface.java
@@ -13,7 +13,6 @@ import android.view.View;
 import androidx.annotation.Nullable;
 import com.facebook.react.bridge.Dynamic;
 import com.facebook.react.bridge.ReadableArray;
-import com.facebook.react.bridge.ReadableMap;
 
 public interface RNSVGClipPathManagerInterface<T extends View> {
   void setName(T view, @Nullable String value);
@@ -29,10 +28,10 @@ public interface RNSVGClipPathManagerInterface<T extends View> {
   void setDisplay(T view, @Nullable String value);
   void setPointerEvents(T view, @Nullable String value);
   void setColor(T view, @Nullable Integer value);
-  void setFill(T view, @Nullable ReadableMap value);
+  void setFill(T view, Dynamic value);
   void setFillOpacity(T view, float value);
   void setFillRule(T view, int value);
-  void setStroke(T view, @Nullable ReadableMap value);
+  void setStroke(T view, Dynamic value);
   void setStrokeOpacity(T view, float value);
   void setStrokeWidth(T view, Dynamic value);
   void setStrokeLinecap(T view, int value);

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGEllipseManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGEllipseManagerDelegate.java
@@ -14,7 +14,6 @@ import androidx.annotation.Nullable;
 import com.facebook.react.bridge.ColorPropConverter;
 import com.facebook.react.bridge.DynamicFromObject;
 import com.facebook.react.bridge.ReadableArray;
-import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.BaseViewManagerInterface;
 
@@ -65,7 +64,7 @@ public class RNSVGEllipseManagerDelegate<T extends View, U extends BaseViewManag
         mViewManager.setColor(view, ColorPropConverter.getColor(value, view.getContext()));
         break;
       case "fill":
-        mViewManager.setFill(view, (ReadableMap) value);
+        mViewManager.setFill(view, new DynamicFromObject(value));
         break;
       case "fillOpacity":
         mViewManager.setFillOpacity(view, value == null ? 1f : ((Double) value).floatValue());
@@ -74,7 +73,7 @@ public class RNSVGEllipseManagerDelegate<T extends View, U extends BaseViewManag
         mViewManager.setFillRule(view, value == null ? 1 : ((Double) value).intValue());
         break;
       case "stroke":
-        mViewManager.setStroke(view, (ReadableMap) value);
+        mViewManager.setStroke(view, new DynamicFromObject(value));
         break;
       case "strokeOpacity":
         mViewManager.setStrokeOpacity(view, value == null ? 1f : ((Double) value).floatValue());

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGEllipseManagerInterface.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGEllipseManagerInterface.java
@@ -13,7 +13,6 @@ import android.view.View;
 import androidx.annotation.Nullable;
 import com.facebook.react.bridge.Dynamic;
 import com.facebook.react.bridge.ReadableArray;
-import com.facebook.react.bridge.ReadableMap;
 
 public interface RNSVGEllipseManagerInterface<T extends View> {
   void setName(T view, @Nullable String value);
@@ -29,10 +28,10 @@ public interface RNSVGEllipseManagerInterface<T extends View> {
   void setDisplay(T view, @Nullable String value);
   void setPointerEvents(T view, @Nullable String value);
   void setColor(T view, @Nullable Integer value);
-  void setFill(T view, @Nullable ReadableMap value);
+  void setFill(T view, Dynamic value);
   void setFillOpacity(T view, float value);
   void setFillRule(T view, int value);
-  void setStroke(T view, @Nullable ReadableMap value);
+  void setStroke(T view, Dynamic value);
   void setStrokeOpacity(T view, float value);
   void setStrokeWidth(T view, Dynamic value);
   void setStrokeLinecap(T view, int value);

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGForeignObjectManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGForeignObjectManagerDelegate.java
@@ -14,7 +14,6 @@ import androidx.annotation.Nullable;
 import com.facebook.react.bridge.ColorPropConverter;
 import com.facebook.react.bridge.DynamicFromObject;
 import com.facebook.react.bridge.ReadableArray;
-import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.BaseViewManagerInterface;
 
@@ -65,7 +64,7 @@ public class RNSVGForeignObjectManagerDelegate<T extends View, U extends BaseVie
         mViewManager.setColor(view, ColorPropConverter.getColor(value, view.getContext()));
         break;
       case "fill":
-        mViewManager.setFill(view, (ReadableMap) value);
+        mViewManager.setFill(view, new DynamicFromObject(value));
         break;
       case "fillOpacity":
         mViewManager.setFillOpacity(view, value == null ? 1f : ((Double) value).floatValue());
@@ -74,7 +73,7 @@ public class RNSVGForeignObjectManagerDelegate<T extends View, U extends BaseVie
         mViewManager.setFillRule(view, value == null ? 1 : ((Double) value).intValue());
         break;
       case "stroke":
-        mViewManager.setStroke(view, (ReadableMap) value);
+        mViewManager.setStroke(view, new DynamicFromObject(value));
         break;
       case "strokeOpacity":
         mViewManager.setStrokeOpacity(view, value == null ? 1f : ((Double) value).floatValue());

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGForeignObjectManagerInterface.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGForeignObjectManagerInterface.java
@@ -13,7 +13,6 @@ import android.view.View;
 import androidx.annotation.Nullable;
 import com.facebook.react.bridge.Dynamic;
 import com.facebook.react.bridge.ReadableArray;
-import com.facebook.react.bridge.ReadableMap;
 
 public interface RNSVGForeignObjectManagerInterface<T extends View> {
   void setName(T view, @Nullable String value);
@@ -29,10 +28,10 @@ public interface RNSVGForeignObjectManagerInterface<T extends View> {
   void setDisplay(T view, @Nullable String value);
   void setPointerEvents(T view, @Nullable String value);
   void setColor(T view, @Nullable Integer value);
-  void setFill(T view, @Nullable ReadableMap value);
+  void setFill(T view, Dynamic value);
   void setFillOpacity(T view, float value);
   void setFillRule(T view, int value);
-  void setStroke(T view, @Nullable ReadableMap value);
+  void setStroke(T view, Dynamic value);
   void setStrokeOpacity(T view, float value);
   void setStrokeWidth(T view, Dynamic value);
   void setStrokeLinecap(T view, int value);

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGGroupManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGGroupManagerDelegate.java
@@ -14,7 +14,6 @@ import androidx.annotation.Nullable;
 import com.facebook.react.bridge.ColorPropConverter;
 import com.facebook.react.bridge.DynamicFromObject;
 import com.facebook.react.bridge.ReadableArray;
-import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.BaseViewManagerInterface;
 
@@ -65,7 +64,7 @@ public class RNSVGGroupManagerDelegate<T extends View, U extends BaseViewManager
         mViewManager.setColor(view, ColorPropConverter.getColor(value, view.getContext()));
         break;
       case "fill":
-        mViewManager.setFill(view, (ReadableMap) value);
+        mViewManager.setFill(view, new DynamicFromObject(value));
         break;
       case "fillOpacity":
         mViewManager.setFillOpacity(view, value == null ? 1f : ((Double) value).floatValue());
@@ -74,7 +73,7 @@ public class RNSVGGroupManagerDelegate<T extends View, U extends BaseViewManager
         mViewManager.setFillRule(view, value == null ? 1 : ((Double) value).intValue());
         break;
       case "stroke":
-        mViewManager.setStroke(view, (ReadableMap) value);
+        mViewManager.setStroke(view, new DynamicFromObject(value));
         break;
       case "strokeOpacity":
         mViewManager.setStrokeOpacity(view, value == null ? 1f : ((Double) value).floatValue());

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGGroupManagerInterface.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGGroupManagerInterface.java
@@ -13,7 +13,6 @@ import android.view.View;
 import androidx.annotation.Nullable;
 import com.facebook.react.bridge.Dynamic;
 import com.facebook.react.bridge.ReadableArray;
-import com.facebook.react.bridge.ReadableMap;
 
 public interface RNSVGGroupManagerInterface<T extends View> {
   void setName(T view, @Nullable String value);
@@ -29,10 +28,10 @@ public interface RNSVGGroupManagerInterface<T extends View> {
   void setDisplay(T view, @Nullable String value);
   void setPointerEvents(T view, @Nullable String value);
   void setColor(T view, @Nullable Integer value);
-  void setFill(T view, @Nullable ReadableMap value);
+  void setFill(T view, Dynamic value);
   void setFillOpacity(T view, float value);
   void setFillRule(T view, int value);
-  void setStroke(T view, @Nullable ReadableMap value);
+  void setStroke(T view, Dynamic value);
   void setStrokeOpacity(T view, float value);
   void setStrokeWidth(T view, Dynamic value);
   void setStrokeLinecap(T view, int value);

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGImageManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGImageManagerDelegate.java
@@ -65,7 +65,7 @@ public class RNSVGImageManagerDelegate<T extends View, U extends BaseViewManager
         mViewManager.setColor(view, ColorPropConverter.getColor(value, view.getContext()));
         break;
       case "fill":
-        mViewManager.setFill(view, (ReadableMap) value);
+        mViewManager.setFill(view, new DynamicFromObject(value));
         break;
       case "fillOpacity":
         mViewManager.setFillOpacity(view, value == null ? 1f : ((Double) value).floatValue());
@@ -74,7 +74,7 @@ public class RNSVGImageManagerDelegate<T extends View, U extends BaseViewManager
         mViewManager.setFillRule(view, value == null ? 1 : ((Double) value).intValue());
         break;
       case "stroke":
-        mViewManager.setStroke(view, (ReadableMap) value);
+        mViewManager.setStroke(view, new DynamicFromObject(value));
         break;
       case "strokeOpacity":
         mViewManager.setStrokeOpacity(view, value == null ? 1f : ((Double) value).floatValue());

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGImageManagerInterface.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGImageManagerInterface.java
@@ -29,10 +29,10 @@ public interface RNSVGImageManagerInterface<T extends View> {
   void setDisplay(T view, @Nullable String value);
   void setPointerEvents(T view, @Nullable String value);
   void setColor(T view, @Nullable Integer value);
-  void setFill(T view, @Nullable ReadableMap value);
+  void setFill(T view, Dynamic value);
   void setFillOpacity(T view, float value);
   void setFillRule(T view, int value);
-  void setStroke(T view, @Nullable ReadableMap value);
+  void setStroke(T view, Dynamic value);
   void setStrokeOpacity(T view, float value);
   void setStrokeWidth(T view, Dynamic value);
   void setStrokeLinecap(T view, int value);

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGLineManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGLineManagerDelegate.java
@@ -14,7 +14,6 @@ import androidx.annotation.Nullable;
 import com.facebook.react.bridge.ColorPropConverter;
 import com.facebook.react.bridge.DynamicFromObject;
 import com.facebook.react.bridge.ReadableArray;
-import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.BaseViewManagerInterface;
 
@@ -65,7 +64,7 @@ public class RNSVGLineManagerDelegate<T extends View, U extends BaseViewManagerI
         mViewManager.setColor(view, ColorPropConverter.getColor(value, view.getContext()));
         break;
       case "fill":
-        mViewManager.setFill(view, (ReadableMap) value);
+        mViewManager.setFill(view, new DynamicFromObject(value));
         break;
       case "fillOpacity":
         mViewManager.setFillOpacity(view, value == null ? 1f : ((Double) value).floatValue());
@@ -74,7 +73,7 @@ public class RNSVGLineManagerDelegate<T extends View, U extends BaseViewManagerI
         mViewManager.setFillRule(view, value == null ? 1 : ((Double) value).intValue());
         break;
       case "stroke":
-        mViewManager.setStroke(view, (ReadableMap) value);
+        mViewManager.setStroke(view, new DynamicFromObject(value));
         break;
       case "strokeOpacity":
         mViewManager.setStrokeOpacity(view, value == null ? 1f : ((Double) value).floatValue());

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGLineManagerInterface.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGLineManagerInterface.java
@@ -13,7 +13,6 @@ import android.view.View;
 import androidx.annotation.Nullable;
 import com.facebook.react.bridge.Dynamic;
 import com.facebook.react.bridge.ReadableArray;
-import com.facebook.react.bridge.ReadableMap;
 
 public interface RNSVGLineManagerInterface<T extends View> {
   void setName(T view, @Nullable String value);
@@ -29,10 +28,10 @@ public interface RNSVGLineManagerInterface<T extends View> {
   void setDisplay(T view, @Nullable String value);
   void setPointerEvents(T view, @Nullable String value);
   void setColor(T view, @Nullable Integer value);
-  void setFill(T view, @Nullable ReadableMap value);
+  void setFill(T view, Dynamic value);
   void setFillOpacity(T view, float value);
   void setFillRule(T view, int value);
-  void setStroke(T view, @Nullable ReadableMap value);
+  void setStroke(T view, Dynamic value);
   void setStrokeOpacity(T view, float value);
   void setStrokeWidth(T view, Dynamic value);
   void setStrokeLinecap(T view, int value);

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGMarkerManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGMarkerManagerDelegate.java
@@ -14,7 +14,6 @@ import androidx.annotation.Nullable;
 import com.facebook.react.bridge.ColorPropConverter;
 import com.facebook.react.bridge.DynamicFromObject;
 import com.facebook.react.bridge.ReadableArray;
-import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.BaseViewManagerInterface;
 
@@ -65,7 +64,7 @@ public class RNSVGMarkerManagerDelegate<T extends View, U extends BaseViewManage
         mViewManager.setColor(view, ColorPropConverter.getColor(value, view.getContext()));
         break;
       case "fill":
-        mViewManager.setFill(view, (ReadableMap) value);
+        mViewManager.setFill(view, new DynamicFromObject(value));
         break;
       case "fillOpacity":
         mViewManager.setFillOpacity(view, value == null ? 1f : ((Double) value).floatValue());
@@ -74,7 +73,7 @@ public class RNSVGMarkerManagerDelegate<T extends View, U extends BaseViewManage
         mViewManager.setFillRule(view, value == null ? 1 : ((Double) value).intValue());
         break;
       case "stroke":
-        mViewManager.setStroke(view, (ReadableMap) value);
+        mViewManager.setStroke(view, new DynamicFromObject(value));
         break;
       case "strokeOpacity":
         mViewManager.setStrokeOpacity(view, value == null ? 1f : ((Double) value).floatValue());

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGMarkerManagerInterface.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGMarkerManagerInterface.java
@@ -13,7 +13,6 @@ import android.view.View;
 import androidx.annotation.Nullable;
 import com.facebook.react.bridge.Dynamic;
 import com.facebook.react.bridge.ReadableArray;
-import com.facebook.react.bridge.ReadableMap;
 
 public interface RNSVGMarkerManagerInterface<T extends View> {
   void setName(T view, @Nullable String value);
@@ -29,10 +28,10 @@ public interface RNSVGMarkerManagerInterface<T extends View> {
   void setDisplay(T view, @Nullable String value);
   void setPointerEvents(T view, @Nullable String value);
   void setColor(T view, @Nullable Integer value);
-  void setFill(T view, @Nullable ReadableMap value);
+  void setFill(T view, Dynamic value);
   void setFillOpacity(T view, float value);
   void setFillRule(T view, int value);
-  void setStroke(T view, @Nullable ReadableMap value);
+  void setStroke(T view, Dynamic value);
   void setStrokeOpacity(T view, float value);
   void setStrokeWidth(T view, Dynamic value);
   void setStrokeLinecap(T view, int value);

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGMaskManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGMaskManagerDelegate.java
@@ -14,7 +14,6 @@ import androidx.annotation.Nullable;
 import com.facebook.react.bridge.ColorPropConverter;
 import com.facebook.react.bridge.DynamicFromObject;
 import com.facebook.react.bridge.ReadableArray;
-import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.BaseViewManagerInterface;
 
@@ -65,7 +64,7 @@ public class RNSVGMaskManagerDelegate<T extends View, U extends BaseViewManagerI
         mViewManager.setColor(view, ColorPropConverter.getColor(value, view.getContext()));
         break;
       case "fill":
-        mViewManager.setFill(view, (ReadableMap) value);
+        mViewManager.setFill(view, new DynamicFromObject(value));
         break;
       case "fillOpacity":
         mViewManager.setFillOpacity(view, value == null ? 1f : ((Double) value).floatValue());
@@ -74,7 +73,7 @@ public class RNSVGMaskManagerDelegate<T extends View, U extends BaseViewManagerI
         mViewManager.setFillRule(view, value == null ? 1 : ((Double) value).intValue());
         break;
       case "stroke":
-        mViewManager.setStroke(view, (ReadableMap) value);
+        mViewManager.setStroke(view, new DynamicFromObject(value));
         break;
       case "strokeOpacity":
         mViewManager.setStrokeOpacity(view, value == null ? 1f : ((Double) value).floatValue());

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGMaskManagerInterface.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGMaskManagerInterface.java
@@ -13,7 +13,6 @@ import android.view.View;
 import androidx.annotation.Nullable;
 import com.facebook.react.bridge.Dynamic;
 import com.facebook.react.bridge.ReadableArray;
-import com.facebook.react.bridge.ReadableMap;
 
 public interface RNSVGMaskManagerInterface<T extends View> {
   void setName(T view, @Nullable String value);
@@ -29,10 +28,10 @@ public interface RNSVGMaskManagerInterface<T extends View> {
   void setDisplay(T view, @Nullable String value);
   void setPointerEvents(T view, @Nullable String value);
   void setColor(T view, @Nullable Integer value);
-  void setFill(T view, @Nullable ReadableMap value);
+  void setFill(T view, Dynamic value);
   void setFillOpacity(T view, float value);
   void setFillRule(T view, int value);
-  void setStroke(T view, @Nullable ReadableMap value);
+  void setStroke(T view, Dynamic value);
   void setStrokeOpacity(T view, float value);
   void setStrokeWidth(T view, Dynamic value);
   void setStrokeLinecap(T view, int value);

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGPathManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGPathManagerDelegate.java
@@ -14,7 +14,6 @@ import androidx.annotation.Nullable;
 import com.facebook.react.bridge.ColorPropConverter;
 import com.facebook.react.bridge.DynamicFromObject;
 import com.facebook.react.bridge.ReadableArray;
-import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.BaseViewManagerInterface;
 
@@ -65,7 +64,7 @@ public class RNSVGPathManagerDelegate<T extends View, U extends BaseViewManagerI
         mViewManager.setColor(view, ColorPropConverter.getColor(value, view.getContext()));
         break;
       case "fill":
-        mViewManager.setFill(view, (ReadableMap) value);
+        mViewManager.setFill(view, new DynamicFromObject(value));
         break;
       case "fillOpacity":
         mViewManager.setFillOpacity(view, value == null ? 1f : ((Double) value).floatValue());
@@ -74,7 +73,7 @@ public class RNSVGPathManagerDelegate<T extends View, U extends BaseViewManagerI
         mViewManager.setFillRule(view, value == null ? 1 : ((Double) value).intValue());
         break;
       case "stroke":
-        mViewManager.setStroke(view, (ReadableMap) value);
+        mViewManager.setStroke(view, new DynamicFromObject(value));
         break;
       case "strokeOpacity":
         mViewManager.setStrokeOpacity(view, value == null ? 1f : ((Double) value).floatValue());

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGPathManagerInterface.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGPathManagerInterface.java
@@ -13,7 +13,6 @@ import android.view.View;
 import androidx.annotation.Nullable;
 import com.facebook.react.bridge.Dynamic;
 import com.facebook.react.bridge.ReadableArray;
-import com.facebook.react.bridge.ReadableMap;
 
 public interface RNSVGPathManagerInterface<T extends View> {
   void setName(T view, @Nullable String value);
@@ -29,10 +28,10 @@ public interface RNSVGPathManagerInterface<T extends View> {
   void setDisplay(T view, @Nullable String value);
   void setPointerEvents(T view, @Nullable String value);
   void setColor(T view, @Nullable Integer value);
-  void setFill(T view, @Nullable ReadableMap value);
+  void setFill(T view, Dynamic value);
   void setFillOpacity(T view, float value);
   void setFillRule(T view, int value);
-  void setStroke(T view, @Nullable ReadableMap value);
+  void setStroke(T view, Dynamic value);
   void setStrokeOpacity(T view, float value);
   void setStrokeWidth(T view, Dynamic value);
   void setStrokeLinecap(T view, int value);

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGPatternManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGPatternManagerDelegate.java
@@ -14,7 +14,6 @@ import androidx.annotation.Nullable;
 import com.facebook.react.bridge.ColorPropConverter;
 import com.facebook.react.bridge.DynamicFromObject;
 import com.facebook.react.bridge.ReadableArray;
-import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.BaseViewManagerInterface;
 
@@ -65,7 +64,7 @@ public class RNSVGPatternManagerDelegate<T extends View, U extends BaseViewManag
         mViewManager.setColor(view, ColorPropConverter.getColor(value, view.getContext()));
         break;
       case "fill":
-        mViewManager.setFill(view, (ReadableMap) value);
+        mViewManager.setFill(view, new DynamicFromObject(value));
         break;
       case "fillOpacity":
         mViewManager.setFillOpacity(view, value == null ? 1f : ((Double) value).floatValue());
@@ -74,7 +73,7 @@ public class RNSVGPatternManagerDelegate<T extends View, U extends BaseViewManag
         mViewManager.setFillRule(view, value == null ? 1 : ((Double) value).intValue());
         break;
       case "stroke":
-        mViewManager.setStroke(view, (ReadableMap) value);
+        mViewManager.setStroke(view, new DynamicFromObject(value));
         break;
       case "strokeOpacity":
         mViewManager.setStrokeOpacity(view, value == null ? 1f : ((Double) value).floatValue());

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGPatternManagerInterface.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGPatternManagerInterface.java
@@ -13,7 +13,6 @@ import android.view.View;
 import androidx.annotation.Nullable;
 import com.facebook.react.bridge.Dynamic;
 import com.facebook.react.bridge.ReadableArray;
-import com.facebook.react.bridge.ReadableMap;
 
 public interface RNSVGPatternManagerInterface<T extends View> {
   void setName(T view, @Nullable String value);
@@ -29,10 +28,10 @@ public interface RNSVGPatternManagerInterface<T extends View> {
   void setDisplay(T view, @Nullable String value);
   void setPointerEvents(T view, @Nullable String value);
   void setColor(T view, @Nullable Integer value);
-  void setFill(T view, @Nullable ReadableMap value);
+  void setFill(T view, Dynamic value);
   void setFillOpacity(T view, float value);
   void setFillRule(T view, int value);
-  void setStroke(T view, @Nullable ReadableMap value);
+  void setStroke(T view, Dynamic value);
   void setStrokeOpacity(T view, float value);
   void setStrokeWidth(T view, Dynamic value);
   void setStrokeLinecap(T view, int value);

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGRectManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGRectManagerDelegate.java
@@ -14,7 +14,6 @@ import androidx.annotation.Nullable;
 import com.facebook.react.bridge.ColorPropConverter;
 import com.facebook.react.bridge.DynamicFromObject;
 import com.facebook.react.bridge.ReadableArray;
-import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.BaseViewManagerInterface;
 
@@ -65,7 +64,7 @@ public class RNSVGRectManagerDelegate<T extends View, U extends BaseViewManagerI
         mViewManager.setColor(view, ColorPropConverter.getColor(value, view.getContext()));
         break;
       case "fill":
-        mViewManager.setFill(view, (ReadableMap) value);
+        mViewManager.setFill(view, new DynamicFromObject(value));
         break;
       case "fillOpacity":
         mViewManager.setFillOpacity(view, value == null ? 1f : ((Double) value).floatValue());
@@ -74,7 +73,7 @@ public class RNSVGRectManagerDelegate<T extends View, U extends BaseViewManagerI
         mViewManager.setFillRule(view, value == null ? 1 : ((Double) value).intValue());
         break;
       case "stroke":
-        mViewManager.setStroke(view, (ReadableMap) value);
+        mViewManager.setStroke(view, new DynamicFromObject(value));
         break;
       case "strokeOpacity":
         mViewManager.setStrokeOpacity(view, value == null ? 1f : ((Double) value).floatValue());

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGRectManagerInterface.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGRectManagerInterface.java
@@ -13,7 +13,6 @@ import android.view.View;
 import androidx.annotation.Nullable;
 import com.facebook.react.bridge.Dynamic;
 import com.facebook.react.bridge.ReadableArray;
-import com.facebook.react.bridge.ReadableMap;
 
 public interface RNSVGRectManagerInterface<T extends View> {
   void setName(T view, @Nullable String value);
@@ -29,10 +28,10 @@ public interface RNSVGRectManagerInterface<T extends View> {
   void setDisplay(T view, @Nullable String value);
   void setPointerEvents(T view, @Nullable String value);
   void setColor(T view, @Nullable Integer value);
-  void setFill(T view, @Nullable ReadableMap value);
+  void setFill(T view, Dynamic value);
   void setFillOpacity(T view, float value);
   void setFillRule(T view, int value);
-  void setStroke(T view, @Nullable ReadableMap value);
+  void setStroke(T view, Dynamic value);
   void setStrokeOpacity(T view, float value);
   void setStrokeWidth(T view, Dynamic value);
   void setStrokeLinecap(T view, int value);

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGSymbolManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGSymbolManagerDelegate.java
@@ -14,7 +14,6 @@ import androidx.annotation.Nullable;
 import com.facebook.react.bridge.ColorPropConverter;
 import com.facebook.react.bridge.DynamicFromObject;
 import com.facebook.react.bridge.ReadableArray;
-import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.BaseViewManagerInterface;
 
@@ -65,7 +64,7 @@ public class RNSVGSymbolManagerDelegate<T extends View, U extends BaseViewManage
         mViewManager.setColor(view, ColorPropConverter.getColor(value, view.getContext()));
         break;
       case "fill":
-        mViewManager.setFill(view, (ReadableMap) value);
+        mViewManager.setFill(view, new DynamicFromObject(value));
         break;
       case "fillOpacity":
         mViewManager.setFillOpacity(view, value == null ? 1f : ((Double) value).floatValue());
@@ -74,7 +73,7 @@ public class RNSVGSymbolManagerDelegate<T extends View, U extends BaseViewManage
         mViewManager.setFillRule(view, value == null ? 1 : ((Double) value).intValue());
         break;
       case "stroke":
-        mViewManager.setStroke(view, (ReadableMap) value);
+        mViewManager.setStroke(view, new DynamicFromObject(value));
         break;
       case "strokeOpacity":
         mViewManager.setStrokeOpacity(view, value == null ? 1f : ((Double) value).floatValue());

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGSymbolManagerInterface.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGSymbolManagerInterface.java
@@ -13,7 +13,6 @@ import android.view.View;
 import androidx.annotation.Nullable;
 import com.facebook.react.bridge.Dynamic;
 import com.facebook.react.bridge.ReadableArray;
-import com.facebook.react.bridge.ReadableMap;
 
 public interface RNSVGSymbolManagerInterface<T extends View> {
   void setName(T view, @Nullable String value);
@@ -29,10 +28,10 @@ public interface RNSVGSymbolManagerInterface<T extends View> {
   void setDisplay(T view, @Nullable String value);
   void setPointerEvents(T view, @Nullable String value);
   void setColor(T view, @Nullable Integer value);
-  void setFill(T view, @Nullable ReadableMap value);
+  void setFill(T view, Dynamic value);
   void setFillOpacity(T view, float value);
   void setFillRule(T view, int value);
-  void setStroke(T view, @Nullable ReadableMap value);
+  void setStroke(T view, Dynamic value);
   void setStrokeOpacity(T view, float value);
   void setStrokeWidth(T view, Dynamic value);
   void setStrokeLinecap(T view, int value);

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGTSpanManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGTSpanManagerDelegate.java
@@ -14,7 +14,6 @@ import androidx.annotation.Nullable;
 import com.facebook.react.bridge.ColorPropConverter;
 import com.facebook.react.bridge.DynamicFromObject;
 import com.facebook.react.bridge.ReadableArray;
-import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.BaseViewManagerInterface;
 
@@ -65,7 +64,7 @@ public class RNSVGTSpanManagerDelegate<T extends View, U extends BaseViewManager
         mViewManager.setColor(view, ColorPropConverter.getColor(value, view.getContext()));
         break;
       case "fill":
-        mViewManager.setFill(view, (ReadableMap) value);
+        mViewManager.setFill(view, new DynamicFromObject(value));
         break;
       case "fillOpacity":
         mViewManager.setFillOpacity(view, value == null ? 1f : ((Double) value).floatValue());
@@ -74,7 +73,7 @@ public class RNSVGTSpanManagerDelegate<T extends View, U extends BaseViewManager
         mViewManager.setFillRule(view, value == null ? 1 : ((Double) value).intValue());
         break;
       case "stroke":
-        mViewManager.setStroke(view, (ReadableMap) value);
+        mViewManager.setStroke(view, new DynamicFromObject(value));
         break;
       case "strokeOpacity":
         mViewManager.setStrokeOpacity(view, value == null ? 1f : ((Double) value).floatValue());

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGTSpanManagerInterface.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGTSpanManagerInterface.java
@@ -13,7 +13,6 @@ import android.view.View;
 import androidx.annotation.Nullable;
 import com.facebook.react.bridge.Dynamic;
 import com.facebook.react.bridge.ReadableArray;
-import com.facebook.react.bridge.ReadableMap;
 
 public interface RNSVGTSpanManagerInterface<T extends View> {
   void setName(T view, @Nullable String value);
@@ -29,10 +28,10 @@ public interface RNSVGTSpanManagerInterface<T extends View> {
   void setDisplay(T view, @Nullable String value);
   void setPointerEvents(T view, @Nullable String value);
   void setColor(T view, @Nullable Integer value);
-  void setFill(T view, @Nullable ReadableMap value);
+  void setFill(T view, Dynamic value);
   void setFillOpacity(T view, float value);
   void setFillRule(T view, int value);
-  void setStroke(T view, @Nullable ReadableMap value);
+  void setStroke(T view, Dynamic value);
   void setStrokeOpacity(T view, float value);
   void setStrokeWidth(T view, Dynamic value);
   void setStrokeLinecap(T view, int value);

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGTextManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGTextManagerDelegate.java
@@ -14,7 +14,6 @@ import androidx.annotation.Nullable;
 import com.facebook.react.bridge.ColorPropConverter;
 import com.facebook.react.bridge.DynamicFromObject;
 import com.facebook.react.bridge.ReadableArray;
-import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.BaseViewManagerInterface;
 
@@ -65,7 +64,7 @@ public class RNSVGTextManagerDelegate<T extends View, U extends BaseViewManagerI
         mViewManager.setColor(view, ColorPropConverter.getColor(value, view.getContext()));
         break;
       case "fill":
-        mViewManager.setFill(view, (ReadableMap) value);
+        mViewManager.setFill(view, new DynamicFromObject(value));
         break;
       case "fillOpacity":
         mViewManager.setFillOpacity(view, value == null ? 1f : ((Double) value).floatValue());
@@ -74,7 +73,7 @@ public class RNSVGTextManagerDelegate<T extends View, U extends BaseViewManagerI
         mViewManager.setFillRule(view, value == null ? 1 : ((Double) value).intValue());
         break;
       case "stroke":
-        mViewManager.setStroke(view, (ReadableMap) value);
+        mViewManager.setStroke(view, new DynamicFromObject(value));
         break;
       case "strokeOpacity":
         mViewManager.setStrokeOpacity(view, value == null ? 1f : ((Double) value).floatValue());

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGTextManagerInterface.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGTextManagerInterface.java
@@ -13,7 +13,6 @@ import android.view.View;
 import androidx.annotation.Nullable;
 import com.facebook.react.bridge.Dynamic;
 import com.facebook.react.bridge.ReadableArray;
-import com.facebook.react.bridge.ReadableMap;
 
 public interface RNSVGTextManagerInterface<T extends View> {
   void setName(T view, @Nullable String value);
@@ -29,10 +28,10 @@ public interface RNSVGTextManagerInterface<T extends View> {
   void setDisplay(T view, @Nullable String value);
   void setPointerEvents(T view, @Nullable String value);
   void setColor(T view, @Nullable Integer value);
-  void setFill(T view, @Nullable ReadableMap value);
+  void setFill(T view, Dynamic value);
   void setFillOpacity(T view, float value);
   void setFillRule(T view, int value);
-  void setStroke(T view, @Nullable ReadableMap value);
+  void setStroke(T view, Dynamic value);
   void setStrokeOpacity(T view, float value);
   void setStrokeWidth(T view, Dynamic value);
   void setStrokeLinecap(T view, int value);

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGTextPathManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGTextPathManagerDelegate.java
@@ -14,7 +14,6 @@ import androidx.annotation.Nullable;
 import com.facebook.react.bridge.ColorPropConverter;
 import com.facebook.react.bridge.DynamicFromObject;
 import com.facebook.react.bridge.ReadableArray;
-import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.BaseViewManagerInterface;
 
@@ -65,7 +64,7 @@ public class RNSVGTextPathManagerDelegate<T extends View, U extends BaseViewMana
         mViewManager.setColor(view, ColorPropConverter.getColor(value, view.getContext()));
         break;
       case "fill":
-        mViewManager.setFill(view, (ReadableMap) value);
+        mViewManager.setFill(view, new DynamicFromObject(value));
         break;
       case "fillOpacity":
         mViewManager.setFillOpacity(view, value == null ? 1f : ((Double) value).floatValue());
@@ -74,7 +73,7 @@ public class RNSVGTextPathManagerDelegate<T extends View, U extends BaseViewMana
         mViewManager.setFillRule(view, value == null ? 1 : ((Double) value).intValue());
         break;
       case "stroke":
-        mViewManager.setStroke(view, (ReadableMap) value);
+        mViewManager.setStroke(view, new DynamicFromObject(value));
         break;
       case "strokeOpacity":
         mViewManager.setStrokeOpacity(view, value == null ? 1f : ((Double) value).floatValue());

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGTextPathManagerInterface.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGTextPathManagerInterface.java
@@ -13,7 +13,6 @@ import android.view.View;
 import androidx.annotation.Nullable;
 import com.facebook.react.bridge.Dynamic;
 import com.facebook.react.bridge.ReadableArray;
-import com.facebook.react.bridge.ReadableMap;
 
 public interface RNSVGTextPathManagerInterface<T extends View> {
   void setName(T view, @Nullable String value);
@@ -29,10 +28,10 @@ public interface RNSVGTextPathManagerInterface<T extends View> {
   void setDisplay(T view, @Nullable String value);
   void setPointerEvents(T view, @Nullable String value);
   void setColor(T view, @Nullable Integer value);
-  void setFill(T view, @Nullable ReadableMap value);
+  void setFill(T view, Dynamic value);
   void setFillOpacity(T view, float value);
   void setFillRule(T view, int value);
-  void setStroke(T view, @Nullable ReadableMap value);
+  void setStroke(T view, Dynamic value);
   void setStrokeOpacity(T view, float value);
   void setStrokeWidth(T view, Dynamic value);
   void setStrokeLinecap(T view, int value);

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGUseManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGUseManagerDelegate.java
@@ -14,7 +14,6 @@ import androidx.annotation.Nullable;
 import com.facebook.react.bridge.ColorPropConverter;
 import com.facebook.react.bridge.DynamicFromObject;
 import com.facebook.react.bridge.ReadableArray;
-import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.BaseViewManagerInterface;
 
@@ -65,7 +64,7 @@ public class RNSVGUseManagerDelegate<T extends View, U extends BaseViewManagerIn
         mViewManager.setColor(view, ColorPropConverter.getColor(value, view.getContext()));
         break;
       case "fill":
-        mViewManager.setFill(view, (ReadableMap) value);
+        mViewManager.setFill(view, new DynamicFromObject(value));
         break;
       case "fillOpacity":
         mViewManager.setFillOpacity(view, value == null ? 1f : ((Double) value).floatValue());
@@ -74,7 +73,7 @@ public class RNSVGUseManagerDelegate<T extends View, U extends BaseViewManagerIn
         mViewManager.setFillRule(view, value == null ? 1 : ((Double) value).intValue());
         break;
       case "stroke":
-        mViewManager.setStroke(view, (ReadableMap) value);
+        mViewManager.setStroke(view, new DynamicFromObject(value));
         break;
       case "strokeOpacity":
         mViewManager.setStrokeOpacity(view, value == null ? 1f : ((Double) value).floatValue());

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGUseManagerInterface.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGUseManagerInterface.java
@@ -13,7 +13,6 @@ import android.view.View;
 import androidx.annotation.Nullable;
 import com.facebook.react.bridge.Dynamic;
 import com.facebook.react.bridge.ReadableArray;
-import com.facebook.react.bridge.ReadableMap;
 
 public interface RNSVGUseManagerInterface<T extends View> {
   void setName(T view, @Nullable String value);
@@ -29,10 +28,10 @@ public interface RNSVGUseManagerInterface<T extends View> {
   void setDisplay(T view, @Nullable String value);
   void setPointerEvents(T view, @Nullable String value);
   void setColor(T view, @Nullable Integer value);
-  void setFill(T view, @Nullable ReadableMap value);
+  void setFill(T view, Dynamic value);
   void setFillOpacity(T view, float value);
   void setFillRule(T view, int value);
-  void setStroke(T view, @Nullable ReadableMap value);
+  void setStroke(T view, Dynamic value);
   void setStrokeOpacity(T view, float value);
   void setStrokeWidth(T view, Dynamic value);
   void setStrokeLinecap(T view, int value);

--- a/apple/Utils/RNSVGFabricConversions.h
+++ b/apple/Utils/RNSVGFabricConversions.h
@@ -56,38 +56,6 @@ static id RNSVGConvertFollyDynamicToId(const folly::dynamic &dyn)
 }
 
 template <typename T>
-RNSVGBrush *brushFromColorStruct(const T &fillObject)
-{
-  int type = fillObject.type;
-
-  switch (type) {
-    case -1: // empty struct
-      return nil;
-    case 0: // solid color
-    {
-      // These are probably expensive allocations since it's often the same value.
-      // We should memoize colors but look ups may be just as expensive.
-      RNSVGColor *color = RCTUIColorFromSharedColor(fillObject.payload) ?: [RNSVGColor clearColor];
-      return [[RNSVGSolidColorBrush alloc] initWithColor:color];
-    }
-    case 1: // brush
-    {
-      NSArray *arr = @[ @(type), RCTNSStringFromString(fillObject.brushRef) ];
-      return [[RNSVGPainterBrush alloc] initWithArray:arr];
-    }
-    case 2: // currentColor
-      return [[RNSVGBrush alloc] initWithArray:nil];
-    case 3: // context-fill
-      return [[RNSVGContextBrush alloc] initFill];
-    case 4: // context-stroke
-      return [[RNSVGContextBrush alloc] initStroke];
-    default:
-      RCTLogError(@"Unknown brush type: %d", type);
-      return nil;
-  }
-}
-
-template <typename T>
 void setCommonNodeProps(const T &nodeProps, RNSVGNode *node)
 {
   node.name = RCTNSStringFromStringNilIfEmpty(nodeProps.name);
@@ -143,10 +111,16 @@ void setCommonRenderableProps(const T &renderableProps, RNSVGRenderable *rendera
   if (RCTUIColorFromSharedColor(renderableProps.color)) {
     [renderableNode setColor:RCTUIColorFromSharedColor(renderableProps.color)];
   }
-  renderableNode.fill = brushFromColorStruct(renderableProps.fill);
+  id fill = RNSVGConvertFollyDynamicToId(renderableProps.fill);
+  if (fill != nil) {
+    renderableNode.fill = [RCTConvert RNSVGBrush:fill];
+  }
   renderableNode.fillOpacity = renderableProps.fillOpacity;
   renderableNode.fillRule = renderableProps.fillRule == 0 ? kRNSVGCGFCRuleEvenodd : kRNSVGCGFCRuleNonzero;
-  renderableNode.stroke = brushFromColorStruct(renderableProps.stroke);
+  id stroke = RNSVGConvertFollyDynamicToId(renderableProps.stroke);
+  if (stroke != nil) {
+    renderableNode.stroke = [RCTConvert RNSVGBrush:stroke];
+  }
   renderableNode.strokeOpacity = renderableProps.strokeOpacity;
   id strokeWidth = RNSVGConvertFollyDynamicToId(renderableProps.strokeWidth);
   if (strokeWidth != nil) {

--- a/apps/test-examples/index.tsx
+++ b/apps/test-examples/index.tsx
@@ -33,6 +33,7 @@ import Test2403 from './src/Test2403';
 import Test2407 from './src/Test2407';
 import Test2417 from './src/Test2417';
 import Test2455 from './src/Test2455';
+import Test2471 from './src/Test2471';
 
 export default function App() {
   return <ColorTest />;

--- a/apps/test-examples/src/Test2471.tsx
+++ b/apps/test-examples/src/Test2471.tsx
@@ -1,0 +1,108 @@
+import React, {useEffect, useRef} from 'react';
+import {Animated, Text, View} from 'react-native';
+import Reanimated, {
+  interpolateColor,
+  useAnimatedProps,
+  useSharedValue,
+  withRepeat,
+  withTiming,
+} from 'react-native-reanimated';
+import {Circle, Path, Svg} from 'react-native-svg';
+
+const AnimatedPath = Animated.createAnimatedComponent(Path);
+const AnimatedCircle = Animated.createAnimatedComponent(Circle);
+const AnimatedTest = (): JSX.Element => {
+  const animColor = useRef(new Animated.Value(0)).current;
+  useEffect(() => {
+    Animated.loop(
+      Animated.sequence([
+        Animated.timing(animColor, {
+          toValue: 1,
+          duration: 1000,
+          useNativeDriver: true,
+        }),
+        Animated.timing(animColor, {
+          toValue: 0,
+          duration: 1000,
+          useNativeDriver: true,
+        }),
+      ]),
+    ).start();
+  }, []);
+  return (
+    <Svg width="100" height="100" viewBox="-4 -4 32 32" fill="none">
+      <AnimatedPath
+        d="M22.7927 11.1242C21.359 18.5187 12.0003 22.7782 12.0003 22.7782C12.0003 22.7782 2.64153 18.5187 1.20661 11.1242C0.326598 6.58719 2.24925 2.02329 7.13701 2.00007C10.7781 1.98296 12.0003 5.65211 12.0003 5.65211C12.0003 5.65211 13.2226 1.98173 16.8624 2.00007C21.7612 2.02329 23.6727 6.58841 22.7927 11.1242Z"
+        strokeWidth="4"
+        fill={animColor.interpolate({
+          inputRange: [0, 1],
+          outputRange: ['red', 'green'],
+        })}
+        stroke={animColor.interpolate({
+          inputRange: [0, 1],
+          outputRange: ['blue', 'yellow'],
+        })}
+      />
+      <AnimatedCircle
+        cx="20"
+        cy="20"
+        r="6"
+        fill={animColor.interpolate({
+          inputRange: [0, 1],
+          outputRange: ['blue', 'red'],
+        })}
+        color={animColor.interpolate({
+          inputRange: [0, 1],
+          outputRange: ['pink', 'black'],
+        })}
+        stroke="currentColor"
+      />
+    </Svg>
+  );
+};
+
+const ReanimatedPath = Reanimated.createAnimatedComponent(Path);
+const ReanimatedCircle = Reanimated.createAnimatedComponent(Circle);
+const ReanimatedTest = (): JSX.Element => {
+  const progress = useSharedValue(0);
+  useEffect(() => {
+    progress.value = withRepeat(withTiming(1, {duration: 1000}), -1, true);
+  }, []);
+
+  const animatedProps = useAnimatedProps(() => ({
+    fill: interpolateColor(progress.value, [0, 1], ['red', 'green']),
+    stroke: interpolateColor(progress.value, [0, 1], ['blue', 'yellow']),
+  }));
+  const animatedProps2 = useAnimatedProps(() => ({
+    fill: interpolateColor(progress.value, [0, 1], ['blue', 'red']),
+    color: interpolateColor(progress.value, [0, 1], ['pink', 'black']),
+  }));
+
+  return (
+    <Svg width="100" height="100" viewBox="-4 -4 32 32" fill="none">
+      <ReanimatedPath
+        d="M22.7927 11.1242C21.359 18.5187 12.0003 22.7782 12.0003 22.7782C12.0003 22.7782 2.64153 18.5187 1.20661 11.1242C0.326598 6.58719 2.24925 2.02329 7.13701 2.00007C10.7781 1.98296 12.0003 5.65211 12.0003 5.65211C12.0003 5.65211 13.2226 1.98173 16.8624 2.00007C21.7612 2.02329 23.6727 6.58841 22.7927 11.1242Z"
+        strokeWidth="4"
+        animatedProps={animatedProps}
+      />
+      <ReanimatedCircle
+        cx="20"
+        cy="20"
+        r="6"
+        animatedProps={animatedProps2}
+        stroke="currentColor"
+      />
+    </Svg>
+  );
+};
+
+export default () => {
+  return (
+    <View style={{flex: 1, justifyContent: 'center', alignItems: 'center'}}>
+      <Text>Animated test</Text>
+      <AnimatedTest />
+      <Text>Reanimated test</Text>
+      <ReanimatedTest />
+    </View>
+  );
+};

--- a/src/elements/Shape.tsx
+++ b/src/elements/Shape.tsx
@@ -9,6 +9,7 @@ import type {
   TransformProps,
 } from '../lib/extract/types';
 import type { Spec } from '../fabric/NativeSvgRenderableModule';
+import { BrushProperties } from '../lib/extract/colors';
 
 export interface SVGBoundingBoxOptions {
   fill?: boolean;
@@ -268,9 +269,11 @@ export default class Shape<P> extends Component<P> {
       fill?: ColorValue;
     } & TransformProps
   ) => {
-    if (props.fill) {
-      // @ts-ignore TODO: native `fill` prop differs from the one passed in props
-      props.fill = extractBrush(props.fill);
+    for (const key in props) {
+      if (BrushProperties.includes(key)) {
+        // @ts-ignore TypeScript doesn't know that `key` is a key of `props`
+        props[key] = extractBrush(props[key]);
+      }
     }
     this.root?.setNativeProps(props);
   };

--- a/src/fabric/CircleNativeComponent.ts
+++ b/src/fabric/CircleNativeComponent.ts
@@ -33,10 +33,10 @@ type ColorStruct = Readonly<{
 
 interface SvgRenderableCommonProps {
   color?: ColorValue;
-  fill?: ColorStruct;
+  fill?: UnsafeMixed<ColorValue | ColorStruct>;
   fillOpacity?: WithDefault<Float, 1.0>;
   fillRule?: WithDefault<Int32, 1>;
-  stroke?: ColorStruct;
+  stroke?: UnsafeMixed<ColorValue | ColorStruct>;
   strokeOpacity?: WithDefault<Float, 1.0>;
   strokeWidth?: UnsafeMixed<NumberProp>;
   strokeLinecap?: WithDefault<Int32, 0>;

--- a/src/fabric/ClipPathNativeComponent.ts
+++ b/src/fabric/ClipPathNativeComponent.ts
@@ -33,10 +33,10 @@ type ColorStruct = Readonly<{
 
 interface SvgRenderableCommonProps {
   color?: ColorValue;
-  fill?: ColorStruct;
+  fill?: UnsafeMixed<ColorValue | ColorStruct>;
   fillOpacity?: WithDefault<Float, 1.0>;
   fillRule?: WithDefault<Int32, 1>;
-  stroke?: ColorStruct;
+  stroke?: UnsafeMixed<ColorValue | ColorStruct>;
   strokeOpacity?: WithDefault<Float, 1.0>;
   strokeWidth?: UnsafeMixed<NumberProp>;
   strokeLinecap?: WithDefault<Int32, 0>;

--- a/src/fabric/EllipseNativeComponent.ts
+++ b/src/fabric/EllipseNativeComponent.ts
@@ -33,10 +33,10 @@ type ColorStruct = Readonly<{
 
 interface SvgRenderableCommonProps {
   color?: ColorValue;
-  fill?: ColorStruct;
+  fill?: UnsafeMixed<ColorValue | ColorStruct>;
   fillOpacity?: WithDefault<Float, 1.0>;
   fillRule?: WithDefault<Int32, 1>;
-  stroke?: ColorStruct;
+  stroke?: UnsafeMixed<ColorValue | ColorStruct>;
   strokeOpacity?: WithDefault<Float, 1.0>;
   strokeWidth?: UnsafeMixed<NumberProp>;
   strokeLinecap?: WithDefault<Int32, 0>;

--- a/src/fabric/ForeignObjectNativeComponent.ts
+++ b/src/fabric/ForeignObjectNativeComponent.ts
@@ -33,10 +33,10 @@ type ColorStruct = Readonly<{
 
 interface SvgRenderableCommonProps {
   color?: ColorValue;
-  fill?: ColorStruct;
+  fill?: UnsafeMixed<ColorValue | ColorStruct>;
   fillOpacity?: WithDefault<Float, 1.0>;
   fillRule?: WithDefault<Int32, 1>;
-  stroke?: ColorStruct;
+  stroke?: UnsafeMixed<ColorValue | ColorStruct>;
   strokeOpacity?: WithDefault<Float, 1.0>;
   strokeWidth?: UnsafeMixed<NumberProp>;
   strokeLinecap?: WithDefault<Int32, 0>;

--- a/src/fabric/GroupNativeComponent.ts
+++ b/src/fabric/GroupNativeComponent.ts
@@ -33,10 +33,10 @@ type ColorStruct = Readonly<{
 
 interface SvgRenderableCommonProps {
   color?: ColorValue;
-  fill?: ColorStruct;
+  fill?: UnsafeMixed<ColorValue | ColorStruct>;
   fillOpacity?: WithDefault<Float, 1.0>;
   fillRule?: WithDefault<Int32, 1>;
-  stroke?: ColorStruct;
+  stroke?: UnsafeMixed<ColorValue | ColorStruct>;
   strokeOpacity?: WithDefault<Float, 1.0>;
   strokeWidth?: UnsafeMixed<NumberProp>;
   strokeLinecap?: WithDefault<Int32, 0>;

--- a/src/fabric/ImageNativeComponent.ts
+++ b/src/fabric/ImageNativeComponent.ts
@@ -46,10 +46,10 @@ type ColorStruct = Readonly<{
 
 interface SvgRenderableCommonProps {
   color?: ColorValue;
-  fill?: ColorStruct;
+  fill?: UnsafeMixed<ColorValue | ColorStruct>;
   fillOpacity?: WithDefault<Float, 1.0>;
   fillRule?: WithDefault<Int32, 1>;
-  stroke?: ColorStruct;
+  stroke?: UnsafeMixed<ColorValue | ColorStruct>;
   strokeOpacity?: WithDefault<Float, 1.0>;
   strokeWidth?: UnsafeMixed<NumberProp>;
   strokeLinecap?: WithDefault<Int32, 0>;

--- a/src/fabric/LineNativeComponent.ts
+++ b/src/fabric/LineNativeComponent.ts
@@ -33,10 +33,10 @@ type ColorStruct = Readonly<{
 
 interface SvgRenderableCommonProps {
   color?: ColorValue;
-  fill?: ColorStruct;
+  fill?: UnsafeMixed<ColorValue | ColorStruct>;
   fillOpacity?: WithDefault<Float, 1.0>;
   fillRule?: WithDefault<Int32, 1>;
-  stroke?: ColorStruct;
+  stroke?: UnsafeMixed<ColorValue | ColorStruct>;
   strokeOpacity?: WithDefault<Float, 1.0>;
   strokeWidth?: UnsafeMixed<NumberProp>;
   strokeLinecap?: WithDefault<Int32, 0>;

--- a/src/fabric/MarkerNativeComponent.ts
+++ b/src/fabric/MarkerNativeComponent.ts
@@ -33,10 +33,10 @@ type ColorStruct = Readonly<{
 
 interface SvgRenderableCommonProps {
   color?: ColorValue;
-  fill?: ColorStruct;
+  fill?: UnsafeMixed<ColorValue | ColorStruct>;
   fillOpacity?: WithDefault<Float, 1.0>;
   fillRule?: WithDefault<Int32, 1>;
-  stroke?: ColorStruct;
+  stroke?: UnsafeMixed<ColorValue | ColorStruct>;
   strokeOpacity?: WithDefault<Float, 1.0>;
   strokeWidth?: UnsafeMixed<NumberProp>;
   strokeLinecap?: WithDefault<Int32, 0>;

--- a/src/fabric/MaskNativeComponent.ts
+++ b/src/fabric/MaskNativeComponent.ts
@@ -33,10 +33,10 @@ type ColorStruct = Readonly<{
 
 interface SvgRenderableCommonProps {
   color?: ColorValue;
-  fill?: ColorStruct;
+  fill?: UnsafeMixed<ColorValue | ColorStruct>;
   fillOpacity?: WithDefault<Float, 1.0>;
   fillRule?: WithDefault<Int32, 1>;
-  stroke?: ColorStruct;
+  stroke?: UnsafeMixed<ColorValue | ColorStruct>;
   strokeOpacity?: WithDefault<Float, 1.0>;
   strokeWidth?: UnsafeMixed<NumberProp>;
   strokeLinecap?: WithDefault<Int32, 0>;

--- a/src/fabric/PathNativeComponent.ts
+++ b/src/fabric/PathNativeComponent.ts
@@ -33,10 +33,10 @@ type ColorStruct = Readonly<{
 
 interface SvgRenderableCommonProps {
   color?: ColorValue;
-  fill?: ColorStruct;
+  fill?: UnsafeMixed<ColorValue | ColorStruct>;
   fillOpacity?: WithDefault<Float, 1.0>;
   fillRule?: WithDefault<Int32, 1>;
-  stroke?: ColorStruct;
+  stroke?: UnsafeMixed<ColorValue | ColorStruct>;
   strokeOpacity?: WithDefault<Float, 1.0>;
   strokeWidth?: UnsafeMixed<NumberProp>;
   strokeLinecap?: WithDefault<Int32, 0>;

--- a/src/fabric/PatternNativeComponent.ts
+++ b/src/fabric/PatternNativeComponent.ts
@@ -33,10 +33,10 @@ type ColorStruct = Readonly<{
 
 interface SvgRenderableCommonProps {
   color?: ColorValue;
-  fill?: ColorStruct;
+  fill?: UnsafeMixed<ColorValue | ColorStruct>;
   fillOpacity?: WithDefault<Float, 1.0>;
   fillRule?: WithDefault<Int32, 1>;
-  stroke?: ColorStruct;
+  stroke?: UnsafeMixed<ColorValue | ColorStruct>;
   strokeOpacity?: WithDefault<Float, 1.0>;
   strokeWidth?: UnsafeMixed<NumberProp>;
   strokeLinecap?: WithDefault<Int32, 0>;

--- a/src/fabric/RectNativeComponent.ts
+++ b/src/fabric/RectNativeComponent.ts
@@ -33,10 +33,10 @@ type ColorStruct = Readonly<{
 
 interface SvgRenderableCommonProps {
   color?: ColorValue;
-  fill?: ColorStruct;
+  fill?: UnsafeMixed<ColorValue | ColorStruct>;
   fillOpacity?: WithDefault<Float, 1.0>;
   fillRule?: WithDefault<Int32, 1>;
-  stroke?: ColorStruct;
+  stroke?: UnsafeMixed<ColorValue | ColorStruct>;
   strokeOpacity?: WithDefault<Float, 1.0>;
   strokeWidth?: UnsafeMixed<NumberProp>;
   strokeLinecap?: WithDefault<Int32, 0>;

--- a/src/fabric/SymbolNativeComponent.ts
+++ b/src/fabric/SymbolNativeComponent.ts
@@ -33,10 +33,10 @@ type ColorStruct = Readonly<{
 
 interface SvgRenderableCommonProps {
   color?: ColorValue;
-  fill?: ColorStruct;
+  fill?: UnsafeMixed<ColorValue | ColorStruct>;
   fillOpacity?: WithDefault<Float, 1.0>;
   fillRule?: WithDefault<Int32, 1>;
-  stroke?: ColorStruct;
+  stroke?: UnsafeMixed<ColorValue | ColorStruct>;
   strokeOpacity?: WithDefault<Float, 1.0>;
   strokeWidth?: UnsafeMixed<NumberProp>;
   strokeLinecap?: WithDefault<Int32, 0>;

--- a/src/fabric/TSpanNativeComponent.ts
+++ b/src/fabric/TSpanNativeComponent.ts
@@ -33,10 +33,10 @@ type ColorStruct = Readonly<{
 
 interface SvgRenderableCommonProps {
   color?: ColorValue;
-  fill?: ColorStruct;
+  fill?: UnsafeMixed<ColorValue | ColorStruct>;
   fillOpacity?: WithDefault<Float, 1.0>;
   fillRule?: WithDefault<Int32, 1>;
-  stroke?: ColorStruct;
+  stroke?: UnsafeMixed<ColorValue | ColorStruct>;
   strokeOpacity?: WithDefault<Float, 1.0>;
   strokeWidth?: UnsafeMixed<NumberProp>;
   strokeLinecap?: WithDefault<Int32, 0>;

--- a/src/fabric/TextNativeComponent.ts
+++ b/src/fabric/TextNativeComponent.ts
@@ -33,10 +33,10 @@ type ColorStruct = Readonly<{
 
 interface SvgRenderableCommonProps {
   color?: ColorValue;
-  fill?: ColorStruct;
+  fill?: UnsafeMixed<ColorValue | ColorStruct>;
   fillOpacity?: WithDefault<Float, 1.0>;
   fillRule?: WithDefault<Int32, 1>;
-  stroke?: ColorStruct;
+  stroke?: UnsafeMixed<ColorValue | ColorStruct>;
   strokeOpacity?: WithDefault<Float, 1.0>;
   strokeWidth?: UnsafeMixed<NumberProp>;
   strokeLinecap?: WithDefault<Int32, 0>;

--- a/src/fabric/TextPathNativeComponent.ts
+++ b/src/fabric/TextPathNativeComponent.ts
@@ -33,10 +33,10 @@ type ColorStruct = Readonly<{
 
 interface SvgRenderableCommonProps {
   color?: ColorValue;
-  fill?: ColorStruct;
+  fill?: UnsafeMixed<ColorValue | ColorStruct>;
   fillOpacity?: WithDefault<Float, 1.0>;
   fillRule?: WithDefault<Int32, 1>;
-  stroke?: ColorStruct;
+  stroke?: UnsafeMixed<ColorValue | ColorStruct>;
   strokeOpacity?: WithDefault<Float, 1.0>;
   strokeWidth?: UnsafeMixed<NumberProp>;
   strokeLinecap?: WithDefault<Int32, 0>;

--- a/src/fabric/UseNativeComponent.ts
+++ b/src/fabric/UseNativeComponent.ts
@@ -33,10 +33,10 @@ type ColorStruct = Readonly<{
 
 interface SvgRenderableCommonProps {
   color?: ColorValue;
-  fill?: ColorStruct;
+  fill?: UnsafeMixed<ColorValue | ColorStruct>;
   fillOpacity?: WithDefault<Float, 1.0>;
   fillRule?: WithDefault<Int32, 1>;
-  stroke?: ColorStruct;
+  stroke?: UnsafeMixed<ColorValue | ColorStruct>;
   strokeOpacity?: WithDefault<Float, 1.0>;
   strokeWidth?: UnsafeMixed<NumberProp>;
   strokeLinecap?: WithDefault<Int32, 0>;

--- a/src/lib/extract/colors.ts
+++ b/src/lib/extract/colors.ts
@@ -1,0 +1,8 @@
+// https://www.w3.org/TR/SVG11/color.html
+export const BrushProperties = [
+  'fill',
+  'stroke',
+  'stopColor',
+  'floodColor',
+  'lightingColor',
+];


### PR DESCRIPTION
# Summary

Currently on Fabric, you cannot animate color properties like `fill` or `stroke` using Animated with `useNativeDriver: true` or Reanimated. That's because we have custom structure that needs to be parsed on `JS` and looks like:

```ts
type ColorStruct = Readonly<{
  type?: WithDefault<Int32, -1>;
  payload?: ColorValue;
  brushRef?: string;
}>;
```

However, special values like `currentColor` / `context-fill` / `context-stroke` / `/^url\(#(.+)\)$/` can not be animated anyway. Instead, we should allow passing `ColorValue` directly and detect on the native side if its ColorValue or ColorStruct.

## Test Plan

Example app -> TestX

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅      |
| MacOS   |    ✅      |
| Android |    ✅      |

## Checklist

- [x] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
