### PR TITLE
fix: filter subregion depend on primitive units not filter units

### DIFF
--- a/android/src/main/java/com/horcrux/svg/FilterRegion.java
+++ b/android/src/main/java/com/horcrux/svg/FilterRegion.java
@@ -36,18 +36,18 @@ public class FilterRegion {
 
   public Rect getCropRect(VirtualView view, FilterProperties.Units units, RectF bounds) {
     double x, y, width, height;
-    if (units == FilterProperties.Units.USER_SPACE_ON_USE) {
+    if (units == FilterProperties.Units.OBJECT_BOUNDING_BOX) {
+      x = bounds.left + view.relativeOnFraction(this.mX, bounds.width());
+      y = bounds.top + view.relativeOnFraction(this.mY, bounds.height());
+      width = view.relativeOnFraction(this.mW, bounds.width());
+      height = view.relativeOnFraction(this.mH, bounds.height());
+    } else { // FilterProperties.Units.USER_SPACE_ON_USE
       float canvasWidth = view.getSvgView().getCanvasWidth();
       float canvasHeight = view.getSvgView().getCanvasHeight();
       x = getRelativeOrDefault(view, mX, canvasWidth, bounds.left);
       y = getRelativeOrDefault(view, mY, canvasHeight, bounds.top);
       width = getRelativeOrDefault(view, mW, canvasWidth, bounds.width());
       height = getRelativeOrDefault(view, mH, canvasHeight, bounds.height());
-    } else { // FilterProperties.Units.OBJECT_BOUNDING_BOX
-      x = bounds.left + view.relativeOnFraction(this.mX, bounds.width());
-      y = bounds.top + view.relativeOnFraction(this.mY, bounds.height());
-      width = view.relativeOnFraction(this.mW, bounds.width());
-      height = view.relativeOnFraction(this.mH, bounds.height());
     }
     return new Rect((int) x, (int) y, (int) (x + width), (int) (y + height));
   }

--- a/android/src/main/java/com/horcrux/svg/FilterView.java
+++ b/android/src/main/java/com/horcrux/svg/FilterView.java
@@ -92,7 +92,7 @@ class FilterView extends DefinitionView {
             currentFilter.mFilterSubregion.getCropRect(
                 currentFilter,
                 this.mPrimitiveUnits,
-                this.mFilterUnits == FilterProperties.Units.USER_SPACE_ON_USE
+                this.mPrimitiveUnits == FilterProperties.Units.USER_SPACE_ON_USE
                     ? new RectF(filterRegionRect)
                     : renderableBounds);
         canvas.drawBitmap(currentFilter.applyFilter(mResultsMap, res), cropRect, cropRect, null);


### PR DESCRIPTION
# Summary

This fix addresses a minor bug/typo that was recently introduced, where the filter subregion was incorrectly relying on filterUnits instead of primitiveUnits.