### PR TITLE
fix: crop rect invalid bounds crash 

### DIFF
--- a/android/src/main/java/com/horcrux/svg/FilterRegion.java
+++ b/android/src/main/java/com/horcrux/svg/FilterRegion.java
@@ -36,6 +36,9 @@ public class FilterRegion {
 
   public Rect getCropRect(VirtualView view, FilterProperties.Units units, RectF bounds) {
     double x, y, width, height;
+    if (bounds == null) {
+      return new Rect(0, 0, 0, 0);
+    }
     if (units == FilterProperties.Units.OBJECT_BOUNDING_BOX) {
       x = bounds.left + view.relativeOnFraction(this.mX, bounds.width());
       y = bounds.top + view.relativeOnFraction(this.mY, bounds.height());

--- a/apps/examples/src/examples/Filters/FeFlood.tsx
+++ b/apps/examples/src/examples/Filters/FeFlood.tsx
@@ -27,7 +27,7 @@ class BasicFlood extends Component {
             floodOpacity="0.5"
           />
         </Filter>
-        <Use href="url(#useless)" filter="url(#floodFilter)" />
+        <Rect x="0" y="0" width="1" height="1" filter="url(#floodFilter)" />
       </Svg>
     );
   }


### PR DESCRIPTION
# Summary

Do not crash on `getCropRect` call when renderableBounds is null

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| Android |    ✅      |
