### PR TITLE
docs: add entry to supported react-native version

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ npx expo install react-native-svg
 | >=9              | >=0.57.4     |
 | >=12.3.0         | >=0.64.0     |
 | >=15.0.0         | >=0.70.0     |
+| >=15.8.0         | >=0.73.0     |
 
 ## Support for Fabric
 


### PR DESCRIPTION
# Summary

`react-native-svg@15.8.0` requires `react-native@0.73.0+` or above.