### PR TITLE
chore: set yarn version

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,5 +136,6 @@
     "android": {
       "javaPackageName": "com.horcrux.svg"
     }
-  }
+  },
+  "packageManager": "yarn@1.22.22"
 }


### PR DESCRIPTION
# Summary

Similar to https://github.com/software-mansion/react-native-gesture-handler/pull/2882
Sets the package manager used in the example apps and in the root of the repository to yarn@1.22.22.

## Test Plan

Install dependencies & build apps