### PR TITLE
fix: client rect on use element

### DIFF
--- a/android/src/main/java/com/horcrux/svg/UseView.java
+++ b/android/src/main/java/com/horcrux/svg/UseView.java
@@ -13,6 +13,7 @@ import android.graphics.Canvas;
 import android.graphics.Matrix;
 import android.graphics.Paint;
 import android.graphics.Path;
+import android.graphics.RectF;
 import com.facebook.common.logging.FLog;
 import com.facebook.react.bridge.Dynamic;
 import com.facebook.react.bridge.ReactContext;
@@ -86,7 +87,11 @@ class UseView extends RenderableView {
       template.draw(canvas, paint, opacity * mOpacity);
     }
 
-    this.setClientRect(template.getClientRect());
+    // TODO: replace getMatrix with mCTM when it will be fixed
+    RectF clientRect = new RectF();
+    this.getPath(canvas, paint).computeBounds(clientRect, true);
+    canvas.getMatrix().mapRect(clientRect);
+    this.setClientRect(clientRect);
 
     template.restoreCanvas(canvas, count);
     if (template instanceof RenderableView) {


### PR DESCRIPTION
# Summary

Use elements had incorrect `clientRect` based on templates' rect, which was incorrect. With this change, it ensures client rect is based on path transformed by CTM.

## Test Plan

Example app -> Filters -> FeComposite

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| Android |    ✅      |
