### PR TITLE
fix: FeComposite in2 on Android

### DIFF
--- a/android/src/main/java/com/horcrux/svg/FeCompositeView.java
+++ b/android/src/main/java/com/horcrux/svg/FeCompositeView.java
@@ -90,6 +90,7 @@ class FeCompositeView extends FilterPrimitiveView {
         int[] pixels2 = new int[nPixels];
         result.getPixels(
             pixels1, 0, result.getWidth(), 0, 0, result.getWidth(), result.getHeight());
+        in2.getPixels(pixels2, 0, result.getWidth(), 0, 0, result.getWidth(), result.getHeight());
 
         for (int i = 0; i < nPixels; i++) {
           int color1 = pixels1[i];


### PR DESCRIPTION
# Summary

While working on https://github.com/software-mansion/react-native-svg/pull/2514 I've noticed a bug in `FeComposite` on Android that `in2` was ignored 

## Test Plan

Run Example app -> filters -> FeComposite on Android

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| Android |    ✅      |
