### PR TITLE
fix: update warnUnimplementedFilter list

### DIFF
--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -24,14 +24,10 @@ export const warnUnimplementedFilter = () => {
     `Some of the used filters are not yet supported on native platforms. Please check the USAGE.md for more info. Not implemented filters:\n`,
     JSON.stringify(
       [
-        'FeBlend',
         'FeComponentTransfer',
-        'FeComposite',
         'FeConvolveMatrix',
         'FeDiffuseLighting',
         'FeDisplacementMap',
-        'FeDropShadow',
-        'FeFlood',
         'FeFuncA',
         'FeFuncB',
         'FeFuncG',


### PR DESCRIPTION
# Summary

Closes #2523
Since `FeBlend`, `FeComposite`, `FeDropShadow` and `FeFlood` is already supported (see: #2362) we should remove it from `warnUnimplementedFilter` list