### PR TITLE
fix: add default FeBlend mode

### DIFF
--- a/src/elements/filters/FeBlend.tsx
+++ b/src/elements/filters/FeBlend.tsx
@@ -20,6 +20,7 @@ export default class FeBlend extends FilterPrimitive<FeBlendProps> {
 
   static defaultProps = {
     ...this.defaultPrimitiveProps,
+    mode: 'normal',
   };
 
   render() {


### PR DESCRIPTION
# Summary

Fixes #2529
`FeBlend` should have default blend mode set to `normal`

## Test Plan

Test case specified in #2529

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| Android |    ✅      |
