### PR TITLE
fix parsing of doctype after comment

### DIFF
--- a/src/xml.tsx
+++ b/src/xml.tsx
@@ -296,7 +296,7 @@ export function parse(source: string, middleware?: Middleware): JsxAST | null {
     }
 
     if (/\S/.test(text)) {
-      children.push(text);
+      children?.push(text);
     }
 
     if (source[i] === '<') {


### PR DESCRIPTION

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

fixes https://github.com/software-mansion/react-native-svg/issues/2532

## Test Plan


### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅❌      |
| MacOS   |    ✅❌      |
| Android |    ✅❌      |
| Web     |    ✅❌      |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [ ] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
