### PR TITLE
fix: filters memory leak on apple

### DIFF
--- a/apple/Filters/RNSVGFilter.mm
+++ b/apple/Filters/RNSVGFilter.mm
@@ -172,9 +172,10 @@ using namespace facebook::react;
   CGContextAddPath(context, path);
   CGContextFillPath(context);
 
-  CGImageRef maskImage = CGBitmapContextCreateImage(context);
-
-  return [CIImage imageWithCGImage:maskImage];
+  CGImage *maskImage = CGBitmapContextCreateImage(context);
+  CIImage *ciMaskImage = [CIImage imageWithCGImage:maskImage];
+  CGImageRelease(maskImage);
+  return ciMaskImage;
 }
 
 static CIFilter *sourceAlphaFilter()


### PR DESCRIPTION
# Summary

While animating filters, I discovered a memory leak due to not releasing the `CGImage` after creating the mask.

## Test Plan

```tsx
import {useEffect} from 'react';
import Animated, { useSharedValue, withRepeat, withTiming } from 'react-native-reanimated';
import Svg, {FeOffset, Filter, Rect} from 'react-native-svg';

const AnimatedFilter = Animated.createAnimatedComponent(Filter);
const AnimatedFeOffset = Animated.createAnimatedComponent(FeOffset);
const AnimatedRect = Animated.createAnimatedComponent(Rect);
export default function Example() {
  const offset = useSharedValue(0.5);

  useEffect(() => {
    offset.value = withRepeat(withTiming(300, {duration: 3000}), -1, true);
  }, []);

  return (
    <Svg height="300" width="300">
      <AnimatedFilter id="filter">
        <AnimatedFeOffset dx={offset} dy={offset} result="offOut" />
      </AnimatedFilter>
      <AnimatedRect
        x="0"
        y="0"
        width="300"
        height="300"
        fill="red"
        filter="url(#filter)"
      />
    </Svg>
  );
}
```

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅      |
| macOS   |    ✅      |