### PR TITLE
fix: remove fill and stroke when its unset

### DIFF
--- a/apple/Utils/RCTConvert+RNSVG.mm
+++ b/apple/Utils/RCTConvert+RNSVG.mm
@@ -100,6 +100,9 @@ RCT_ENUM_CONVERTER(
 
 + (RNSVGBrush *)RNSVGBrush:(id)json
 {
+  if (json == nil) {
+    return nil;
+  }
   if ([json isKindOfClass:[NSNumber class]]) {
     return [[RNSVGSolidColorBrush alloc] initWithNumber:json];
   }

--- a/apple/Utils/RNSVGFabricConversions.h
+++ b/apple/Utils/RNSVGFabricConversions.h
@@ -112,15 +112,11 @@ void setCommonRenderableProps(const T &renderableProps, RNSVGRenderable *rendera
     [renderableNode setColor:RCTUIColorFromSharedColor(renderableProps.color)];
   }
   id fill = RNSVGConvertFollyDynamicToId(renderableProps.fill);
-  if (fill != nil) {
-    renderableNode.fill = [RCTConvert RNSVGBrush:fill];
-  }
+  renderableNode.fill = [RCTConvert RNSVGBrush:fill];
   renderableNode.fillOpacity = renderableProps.fillOpacity;
   renderableNode.fillRule = renderableProps.fillRule == 0 ? kRNSVGCGFCRuleEvenodd : kRNSVGCGFCRuleNonzero;
   id stroke = RNSVGConvertFollyDynamicToId(renderableProps.stroke);
-  if (stroke != nil) {
-    renderableNode.stroke = [RCTConvert RNSVGBrush:stroke];
-  }
+  renderableNode.stroke = [RCTConvert RNSVGBrush:stroke];
   renderableNode.strokeOpacity = renderableProps.strokeOpacity;
   id strokeWidth = RNSVGConvertFollyDynamicToId(renderableProps.strokeWidth);
   if (strokeWidth != nil) {


### PR DESCRIPTION
# Summary

Closes #2535
When `fill` or `stroke` is set to `'none'` we should remove the value instead of keeping the last valid value.

## Test Plan

```tsx
import React, {useState} from 'react';
import {Text, TouchableOpacity} from 'react-native';
import {Path, Rect, Svg} from 'react-native-svg';

function Example() {
  const [color, setColor] = useState('#0000FF');
  return (
    <>
      <Svg width={120} height={150} viewBox="0 0 12 15" fill="none">
        <Path
          d="M1 3.353C1 2.053 2.053 1 3.353 1H8.647C9.947 1 11 2.053 11 3.353V13.207C11 13.3008 10.9736 13.3927 10.9238 13.4722C10.874 13.5518 10.8029 13.6157 10.7185 13.6567C10.6341 13.6976 10.5399 13.7141 10.4466 13.7041C10.3533 13.694 10.2648 13.658 10.191 13.6L7.202 11.25C6.99452 11.0876 6.7385 10.9995 6.475 11H3.353C2.72895 11 2.13045 10.7521 1.68918 10.3108C1.2479 9.86955 1 9.27105 1 8.647V3.353Z"
          stroke={color}
          fill={color}
          strokeOpacity={0.5}
          strokeWidth={1.5}
        />
      </Svg>
      <TouchableOpacity onPress={() => setColor('none')}>
        <Text>Click to remove color</Text>
      </TouchableOpacity>
    </>
  );
}
```

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅      |
| macOS   |    ✅      |