### PR TITLE
chore: fix paper-macos-example workflow

### DIFF
--- a/apps/paper-macos-example/macos/PaperMacOSExample.xcodeproj/project.pbxproj
+++ b/apps/paper-macos-example/macos/PaperMacOSExample.xcodeproj/project.pbxproj
@@ -11,12 +11,11 @@
 		514201522437B4B40078DB4F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 514201512437B4B40078DB4F /* Assets.xcassets */; };
 		514201552437B4B40078DB4F /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 514201532437B4B40078DB4F /* Main.storyboard */; };
 		514201582437B4B40078DB4F /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 514201572437B4B40078DB4F /* main.m */; };
-		982B0FFA8A60B718DA7D3A56 /* libPods-PaperMacOSExample-macOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 1656368CC5B48B587F373209 /* libPods-PaperMacOSExample-macOS.a */; };
+		735DA51C525CB9043DAA8325 /* libPods-PaperMacOSExample-macOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6E5D302ACB3EF5BE37E96E87 /* libPods-PaperMacOSExample-macOS.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
 		13B07F961A680F5B00A75B9A /* PaperMacOSExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PaperMacOSExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		1656368CC5B48B587F373209 /* libPods-PaperMacOSExample-macOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-PaperMacOSExample-macOS.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		514201492437B4B30078DB4F /* PaperMacOSExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PaperMacOSExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		5142014B2437B4B30078DB4F /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
 		5142014C2437B4B30078DB4F /* AppDelegate.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = AppDelegate.mm; sourceTree = "<group>"; };
@@ -25,9 +24,10 @@
 		514201562437B4B40078DB4F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		514201572437B4B40078DB4F /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		514201592437B4B40078DB4F /* PaperMacOSExample.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = PaperMacOSExample.entitlements; sourceTree = "<group>"; };
-		ACBD3C18F70A8C7C955A2CE0 /* Pods-PaperMacOSExample-macOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PaperMacOSExample-macOS.release.xcconfig"; path = "Target Support Files/Pods-PaperMacOSExample-macOS/Pods-PaperMacOSExample-macOS.release.xcconfig"; sourceTree = "<group>"; };
+		540B84DE650D6DCC381BBB64 /* Pods-PaperMacOSExample-macOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PaperMacOSExample-macOS.debug.xcconfig"; path = "Target Support Files/Pods-PaperMacOSExample-macOS/Pods-PaperMacOSExample-macOS.debug.xcconfig"; sourceTree = "<group>"; };
+		6E5D302ACB3EF5BE37E96E87 /* libPods-PaperMacOSExample-macOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-PaperMacOSExample-macOS.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		B6263DDE42469F6A500FCF05 /* Pods-PaperMacOSExample-macOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PaperMacOSExample-macOS.release.xcconfig"; path = "Target Support Files/Pods-PaperMacOSExample-macOS/Pods-PaperMacOSExample-macOS.release.xcconfig"; sourceTree = "<group>"; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
-		EF69AF76FA250837EEAAC288 /* Pods-PaperMacOSExample-macOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PaperMacOSExample-macOS.debug.xcconfig"; path = "Target Support Files/Pods-PaperMacOSExample-macOS/Pods-PaperMacOSExample-macOS.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -42,7 +42,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				982B0FFA8A60B718DA7D3A56 /* libPods-PaperMacOSExample-macOS.a in Frameworks */,
+				735DA51C525CB9043DAA8325 /* libPods-PaperMacOSExample-macOS.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -53,9 +53,19 @@
 			isa = PBXGroup;
 			children = (
 				ED297162215061F000B7C4FE /* JavaScriptCore.framework */,
-				1656368CC5B48B587F373209 /* libPods-PaperMacOSExample-macOS.a */,
+				6E5D302ACB3EF5BE37E96E87 /* libPods-PaperMacOSExample-macOS.a */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		303D916010AF14CD581EE1BD /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				540B84DE650D6DCC381BBB64 /* Pods-PaperMacOSExample-macOS.debug.xcconfig */,
+				B6263DDE42469F6A500FCF05 /* Pods-PaperMacOSExample-macOS.release.xcconfig */,
+			);
+			name = Pods;
+			path = Pods;
 			sourceTree = "<group>";
 		};
 		5142014A2437B4B30078DB4F /* PaperMacOSExample-macOS */ = {
@@ -86,7 +96,7 @@
 				832341AE1AAA6A7D00B99B32 /* Libraries */,
 				83CBBA001A601CBA00E9B192 /* Products */,
 				2D16E6871FA4F8E400B85C8A /* Frameworks */,
-				9348B3E2C8EED0C8F847828C /* Pods */,
+				303D916010AF14CD581EE1BD /* Pods */,
 			);
 			indentWidth = 2;
 			sourceTree = "<group>";
@@ -100,16 +110,6 @@
 				514201492437B4B30078DB4F /* PaperMacOSExample.app */,
 			);
 			name = Products;
-			sourceTree = "<group>";
-		};
-		9348B3E2C8EED0C8F847828C /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				EF69AF76FA250837EEAAC288 /* Pods-PaperMacOSExample-macOS.debug.xcconfig */,
-				ACBD3C18F70A8C7C955A2CE0 /* Pods-PaperMacOSExample-macOS.release.xcconfig */,
-			);
-			name = Pods;
-			path = Pods;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -137,13 +137,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 5142015A2437B4B40078DB4F /* Build configuration list for PBXNativeTarget "PaperMacOSExample-macOS" */;
 			buildPhases = (
-				1A938104A937498D81B3BD3B /* [CP] Check Pods Manifest.lock */,
+				61B2948F4C3B372137FE0033 /* [CP] Check Pods Manifest.lock */,
 				514201452437B4B30078DB4F /* Sources */,
 				514201462437B4B30078DB4F /* Frameworks */,
 				514201472437B4B30078DB4F /* Resources */,
 				381D8A6E24576A4E00465D17 /* Bundle React Native code and images */,
-				D63F043FB5BA4885270555AE /* [CP] Copy Pods Resources */,
-				384E31E09B8542AF46C4CDBF /* [CP] Embed Pods Frameworks */,
+				A16FF77180B75F3128EDCEA7 /* [CP] Embed Pods Frameworks */,
+				F98C670A7FD9C4F1ED76034E /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -224,7 +224,25 @@
 			shellPath = /bin/sh;
 			shellScript = "export NODE_BINARY=node\n../node_modules/react-native-macos/scripts/react-native-xcode.sh\n";
 		};
-		1A938104A937498D81B3BD3B /* [CP] Check Pods Manifest.lock */ = {
+		381D8A6E24576A4E00465D17 /* Bundle React Native code and images */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Bundle React Native code and images";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "export NODE_BINARY=node\n../node_modules/react-native-macos/scripts/react-native-xcode.sh\n";
+		};
+		61B2948F4C3B372137FE0033 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -246,25 +264,7 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		381D8A6E24576A4E00465D17 /* Bundle React Native code and images */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "Bundle React Native code and images";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "export NODE_BINARY=node\n../node_modules/react-native-macos/scripts/react-native-xcode.sh\n";
-		};
-		384E31E09B8542AF46C4CDBF /* [CP] Embed Pods Frameworks */ = {
+		A16FF77180B75F3128EDCEA7 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -282,7 +282,7 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-PaperMacOSExample-macOS/Pods-PaperMacOSExample-macOS-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		D63F043FB5BA4885270555AE /* [CP] Copy Pods Resources */ = {
+		F98C670A7FD9C4F1ED76034E /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -381,7 +381,7 @@
 		};
 		5142015B2437B4B40078DB4F /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = EF69AF76FA250837EEAAC288 /* Pods-PaperMacOSExample-macOS.debug.xcconfig */;
+			baseConfigurationReference = 540B84DE650D6DCC381BBB64 /* Pods-PaperMacOSExample-macOS.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
@@ -405,7 +405,7 @@
 		};
 		5142015C2437B4B40078DB4F /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = ACBD3C18F70A8C7C955A2CE0 /* Pods-PaperMacOSExample-macOS.release.xcconfig */;
+			baseConfigurationReference = B6263DDE42469F6A500FCF05 /* Pods-PaperMacOSExample-macOS.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;

--- a/apps/paper-macos-example/macos/Podfile.lock
+++ b/apps/paper-macos-example/macos/Podfile.lock
@@ -11,9 +11,9 @@ PODS:
     - ReactCommon/turbomodule/core (= 0.73.35)
   - fmt (9.1.0)
   - glog (0.3.5)
-  - hermes-engine (0.73.10):
-    - hermes-engine/Pre-built (= 0.73.10)
-  - hermes-engine/Pre-built (0.73.10)
+  - hermes-engine (0.73.11):
+    - hermes-engine/Pre-built (= 0.73.11)
+  - hermes-engine/Pre-built (0.73.11)
   - libevent (2.1.12)
   - RCT-Folly (2022.05.16.00):
     - boost
@@ -1076,7 +1076,7 @@ PODS:
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
     - ReactCommon/turbomodule/core
-  - RNSVG (15.8.0):
+  - RNSVG (15.9.0):
     - React-Core
   - SocketRocket (0.7.0)
   - Yoga (1.14.0)
@@ -1262,7 +1262,7 @@ SPEC CHECKSUMS:
   FBReactNativeSpec: 956febc0d5ab01f66e9add48644d30aa9f9fbfcf
   fmt: 03574da4b7ba40de39da59677ca66610ce8c4a02
   glog: 3a72874c0322c7caf24931d3a2777cb7a3090529
-  hermes-engine: 42a7a4cbe3e20050fb031f64aaaffbe0c0b4a38f
+  hermes-engine: d992945b77c506e5164e6a9a77510c9d57472c59
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   RCT-Folly: 68e9c0fd4c0f05964afd447041d3ac2d67298f27
   RCTRequired: 8f165b521fb1031cdeae4e5cabaa116bbeef00a5
@@ -1308,7 +1308,7 @@ SPEC CHECKSUMS:
   RNCAsyncStorage: d35c79ffba52c1013013e16b1fc295aec2feabb6
   RNGestureHandler: bb81850add626ddd265294323310fec6e861c96b
   RNReanimated: ba95f6d26ca4b8a8f7f2b15f62a3513750762f6b
-  RNSVG: 3d518c7ae7df237f15f350dec5f8603b4e211015
+  RNSVG: 3d2bdcaef51c8071880a9c0072fe324f4423a3ba
   SocketRocket: f6c6249082c011e6de2de60ed641ef8bbe0cfac9
   Yoga: 0639c9c8a20ae8043b0b64e2ef6d7a2cd5806aac
 


### PR DESCRIPTION
# Summary

Regenerate pods to fix `paper-macos-example` workflow. `fabric-macos-example` will still fail as it doesn't have any startup command, but it's not our fault.

## Test Plan

CI for `peper-macos-example` should be green