### PR TITLE
**feat**: provide svg props in onload

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -92,14 +92,15 @@ If remote SVG file contains CSS in `<style>` element, use `SvgCssUri`:
 import * as React from 'react';
 import { ActivityIndicator, View, StyleSheet } from 'react-native';
 import { SvgCssUri } from 'react-native-svg/css';
+import type { SvgProps } from 'react-native-svg';
 export default function TestComponent() {
   const [loading, setLoading] = React.useState(true);
   const onError = (e: Error) => {
     console.log(e.message);
     setLoading(false);
   };
-  const onLoad = () => {
-    console.log('Svg loaded!');
+  const onLoad = (svgProps: SvgProps) => {
+    console.log('Svg loaded!', svgProps);
     setLoading(false);
   };
   return (

--- a/apps/common/test/SvgUriOnLoad.tsx
+++ b/apps/common/test/SvgUriOnLoad.tsx
@@ -1,0 +1,181 @@
+import React, {useState} from 'react';
+import {View, Text} from 'react-native';
+import {SvgProps, SvgUri} from '../../../src';
+import {SvgCssUri} from 'react-native-svg/css';
+
+const svgDataUri =
+  'data:image/svg+xml;base64,' +
+  btoa(`
+    <svg width="60" height="60" viewBox="0 0 60 60" xmlns="http://www.w3.org/2000/svg" fill="pink">
+     <ellipse cx="30" cy="30" rx="30" ry="15" fill="yellow" />
+    </svg>
+    `);
+
+const cssSvgDataUri =
+  'data:image/svg+xml;base64,' +
+  btoa(`
+    <svg width="100" height="100" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+      <style>
+        .small { font: italic 13px sans-serif; }
+      </style>
+      <rect x="0" y="0" width="100" height="100" fill="yellow" />
+      <text x="20" y="35" class="small">CSS Styled</text>
+    </svg>
+`);
+
+const calculateWidth = (svgProps: SvgProps, desiredHeight: number) => {
+  let originalHeight = svgProps.height;
+  let originalWidth = svgProps.width;
+  if (originalWidth && originalHeight) {
+    return (Number(originalWidth) / Number(originalHeight)) * desiredHeight;
+  }
+};
+
+const ExampleWithSvgUri = () => {
+  const [width, setWidth] = useState(0);
+  const height = 12;
+
+  const handleLoad = (svgProps: SvgProps) => {
+    const calculatedWidth = calculateWidth(svgProps, height);
+    if (calculatedWidth) {
+      setWidth(calculatedWidth);
+    }
+  };
+  return (
+    <View style={{flex: 1}}>
+      <Text style={{fontSize: 24, color: '#fff'}}>SvgUri component</Text>
+
+      <Text style={{marginTop: 10, color: '#fff'}}>Original Size ✅</Text>
+      <SvgUri style={{backgroundColor: 'blue'}} uri={svgDataUri} />
+
+      <Text style={{marginTop: 10, color: '#fff'}}>
+        Set different height ❌
+      </Text>
+      <SvgUri
+        style={{backgroundColor: 'red'}}
+        uri={svgDataUri}
+        height={height}
+      />
+
+      <Text style={{marginTop: 10, color: '#fff'}}>
+        Preserve Aspect Ratio Meet ❌
+      </Text>
+      <SvgUri
+        style={{backgroundColor: 'red'}}
+        uri={svgDataUri}
+        height={height}
+        preserveAspectRatio="xMinYMid meet"
+      />
+
+      <Text style={{marginTop: 10, color: '#fff'}}>
+        Preserve Aspect Ratio Slice ❌
+      </Text>
+      <SvgUri
+        style={{backgroundColor: 'red'}}
+        uri={svgDataUri}
+        height={height}
+        preserveAspectRatio="xMinYMid slice"
+      />
+
+      <Text style={{marginTop: 10, color: '#fff'}}>
+        Preserve Aspect Ratio None ❌
+      </Text>
+      <SvgUri
+        style={{backgroundColor: 'red'}}
+        uri={svgDataUri}
+        height={height}
+        preserveAspectRatio="none"
+      />
+
+      <Text style={{marginTop: 10, color: '#fff'}}>
+        Auto calculate width ✅
+      </Text>
+      <SvgUri
+        style={{backgroundColor: 'green'}}
+        uri={svgDataUri}
+        height={height}
+        width={width}
+        onLoad={handleLoad}
+      />
+    </View>
+  );
+};
+
+const ExampleWithSvgCssUri = () => {
+  const [width, setWidth] = useState(0);
+  const height = 25;
+  const handleLoad = (svgProps: SvgProps) => {
+    const calculatedWidth = calculateWidth(svgProps, height);
+    if (calculatedWidth) {
+      setWidth(calculatedWidth);
+    }
+  };
+
+  return (
+    <View style={{flex: 1}}>
+      <Text style={{fontSize: 24, color: '#fff'}}>SvgCssUri component</Text>
+
+      <Text style={{marginTop: 10, color: '#fff'}}>Original Size ✅</Text>
+      <SvgCssUri style={{backgroundColor: 'blue'}} uri={cssSvgDataUri} />
+
+      <Text style={{marginTop: 10, color: '#fff'}}>
+        Set different height ❌
+      </Text>
+      <SvgCssUri
+        style={{backgroundColor: 'red'}}
+        height={height}
+        uri={cssSvgDataUri}
+      />
+
+      <Text style={{marginTop: 10, color: '#fff'}}>
+        Preserve Aspect Ratio Meet ❌
+      </Text>
+      <SvgCssUri
+        style={{backgroundColor: 'red'}}
+        height={height}
+        uri={cssSvgDataUri}
+        preserveAspectRatio="xMinYMid meet"
+      />
+
+      <Text style={{marginTop: 10, color: '#fff'}}>
+        Preserve Aspect Ratio Slice ❌
+      </Text>
+      <SvgCssUri
+        style={{backgroundColor: 'red'}}
+        height={height}
+        uri={cssSvgDataUri}
+        preserveAspectRatio="xMinYMid slice"
+      />
+
+      <Text style={{marginTop: 10, color: '#fff'}}>
+        Preserve Aspect Ratio None ❌
+      </Text>
+      <SvgCssUri
+        style={{backgroundColor: 'red'}}
+        height={height}
+        uri={cssSvgDataUri}
+        preserveAspectRatio="none"
+      />
+
+      <Text style={{marginTop: 10, color: '#fff'}}>
+        Auto calculate width ✅
+      </Text>
+      <SvgCssUri
+        style={{backgroundColor: 'green'}}
+        height={height}
+        uri={cssSvgDataUri}
+        width={width}
+        onLoad={handleLoad}
+      />
+    </View>
+  );
+};
+
+export default () => {
+  return (
+    <View style={{flex: 1, padding: 10, flexDirection: 'row'}}>
+      <ExampleWithSvgUri />
+      <ExampleWithSvgCssUri />
+    </View>
+  );
+};

--- a/apps/common/test/index.tsx
+++ b/apps/common/test/index.tsx
@@ -35,6 +35,7 @@ import Test2417 from './Test2417';
 import Test2455 from './Test2455';
 import Test2471 from './Test2471';
 import Test2520 from './Test2520';
+import Test2540 from './SvgUriOnLoad';
 import Test2670 from './Test2670';
 
 export default function App() {


### PR DESCRIPTION
# Summary

The onLoad handler is called when the SVG is loaded, but does not provide any information about the SVG nor reference it. In this change, the onLoad handler is not called with the SvgProps of the loaded SVG (e.g. height, width, viewBox etc) - so basically the attributes of the root `<svg>`tag.

The SvgProps are now provided to the onLoad handler of the SvgUri and SvgCssUri components. Then we can react on different aspects of the SVG when loaded.

Background: Had an issue with SVGs not scaling correctly when changing the height of the image. With the handler I could fix my problem on my app side. I can imagine other use cases for this feature and decided to contribute this change here.

This PR does not fix the issue I had, but adds the feature for the onLoad handler. Any ideas to fix the issue itself are warmly welcome. The issue is described in the PR's test case.

Other considerations in this PR:
- using useMemo or UseEffect in conditionals/try-catch is not recommended, so restyled this code structure.


## Test Plan

The added test showcase uses the onLoad handler to calculate the required with to keep the aspect ratio. It is tested on the SvgUri and the SvgCssUri component.

Screenshot of the test example (Android):

<img width="1360" alt="SvgUri on Android" src="https://github.com/user-attachments/assets/1670d5c6-945d-4778-812c-0b18b49b233d">


### What's required for testing (prerequisites)?

XCode / Android studio

Open the UI test

### What are the steps to reproduce (after prerequisites)?

Just open the test example

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅❌      |
| MacOS   |    ✅❌      |
| Android |    ✅❌      |
| Web     |    ✅❌      |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [X] I added documentation in `USAGE.md`
- [X] I updated the typed files (typescript)
- [X] I added a test for the API in the `__tests__` folder

