### PR TITLE
fix: resolve transforms on new architecture

### DIFF
--- a/apple/RNSVGNode.mm
+++ b/apple/RNSVGNode.mm
@@ -248,6 +248,16 @@ CGFloat const RNSVG_DEFAULT_FONT_SIZE = 12;
   }
 }
 
+- (void)setTransforms:(CGAffineTransform)transforms
+{
+  if (CGAffineTransformEqualToTransform(transforms, _transforms)) {
+    return;
+  }
+
+  _transforms = transforms;
+  [self invalidate];
+}
+
 - (void)setClientRect:(CGRect)clientRect
 {
   if (CGRectEqualToRect(_clientRect, clientRect)) {

--- a/apple/Utils/RNSVGFabricConversions.h
+++ b/apple/Utils/RNSVGFabricConversions.h
@@ -55,6 +55,8 @@ static id RNSVGConvertFollyDynamicToId(const folly::dynamic &dyn)
   }
 }
 
+static const facebook::react::LayoutMetrics MinimalLayoutMetrics = {{{0, 0}, {1, 1}}};
+
 template <typename T>
 void setCommonNodeProps(const T &nodeProps, RNSVGNode *node)
 {
@@ -69,7 +71,8 @@ void setCommonNodeProps(const T &nodeProps, RNSVGNode *node)
         nodeProps.matrix.at(4),
         nodeProps.matrix.at(5));
   }
-  CATransform3D transform3d = RCTCATransform3DFromTransformMatrix(nodeProps.transform);
+  auto newTransform = nodeProps.resolveTransform(MinimalLayoutMetrics);
+  CATransform3D transform3d = RCTCATransform3DFromTransformMatrix(newTransform);
   CGAffineTransform transform = CATransform3DGetAffineTransform(transform3d);
   node.invTransform = CGAffineTransformInvert(transform);
   node.transforms = transform;

--- a/apple/ViewManagers/RNSVGNodeManager.mm
+++ b/apple/ViewManagers/RNSVGNodeManager.mm
@@ -34,7 +34,6 @@ RCT_CUSTOM_VIEW_PROPERTY(transform, CATransform3D, RNSVGNode)
   CGAffineTransform transform = CATransform3DGetAffineTransform(transform3d);
   view.invTransform = CGAffineTransformInvert(transform);
   view.transforms = transform;
-  [view invalidate];
 }
 RCT_EXPORT_VIEW_PROPERTY(mask, NSString)
 RCT_EXPORT_VIEW_PROPERTY(markerStart, NSString)


### PR DESCRIPTION
# Summary

Add `resolveTransforms` on `updateProps` to get correct matrix. It will improve animating transformations, as Animated/Reanimated skips JS `processTransform` and passes transformations directly. 

## Test Plan

Animate `transform` prop in react-native style.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅      |
| MacOS   |    ✅      |
