### PR TITLE
fix: getBBox size

### DIFF
--- a/apple/RNSVGRenderableModule.mm
+++ b/apple/RNSVGRenderableModule.mm
@@ -139,13 +139,13 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(getBBox : (nonnull NSNumber *)reactTag op
   [svg getPath:nil];
 
   CGRect bounds = CGRectNull;
-  if (fill) {
+  if (fill && !CGRectIsEmpty(svg.fillBounds)) {
     bounds = CGRectUnion(bounds, svg.fillBounds);
   }
-  if (stroke) {
+  if (stroke && !CGRectIsEmpty(svg.strokeBounds)) {
     bounds = CGRectUnion(bounds, svg.strokeBounds);
   }
-  if (markers) {
+  if (markers && !CGRectIsEmpty(svg.markerBounds)) {
     bounds = CGRectUnion(bounds, svg.markerBounds);
   }
   if (clipped) {
@@ -155,8 +155,9 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(getBBox : (nonnull NSNumber *)reactTag op
       bounds = CGRectIntersection(bounds, clipBounds);
     }
   }
-  if (CGRectIsNull(bounds))
+  if (CGRectIsNull(bounds)) {
     bounds = CGRectZero;
+  }
   CGPoint origin = bounds.origin;
   CGSize size = bounds.size;
   return @{@"x" : @(origin.x), @"y" : @(origin.y), @"width" : @(size.width), @"height" : @(size.height)};


### PR DESCRIPTION
# Summary

When calling `getBBox` on rect, it will not give correct dimensions as `markers` that are 90% `CGRectZero` so CGRectUnion between some values and (0, 0, 0, 0) will return (0, 0, width, height)

## Test Plan

```tsx
import React, { useRef } from 'react';
import { Button, View } from 'react-native';
import { Rect, Svg } from 'react-native-svg';

function App(): React.JSX.Element {
  const ref1 = useRef<Rect>(null);

  return (
    <View style={{flex: 1, justifyContent: 'center', alignItems: 'center'}}>
      <Svg width={300} height={300}>
        <Rect
          x={100}
          y={100}
          width={100}
          height={100}
          fill="red"
          opacity={0.5}
          ref={ref1}
        />
      </Svg>
      <Button
        title="Press me"
        onPress={() => console.log(ref1.current?.getBBox())}
      />
    </View>
  );
}

export default App;
```

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅      |
| MacOS   |    ✅      |