### PR TITLE
feat: make `RenderableView.hitTest` public to create a cross-library interface

### DIFF
--- a/android/src/main/java/com/horcrux/svg/ClipPathView.java
+++ b/android/src/main/java/com/horcrux/svg/ClipPathView.java
@@ -40,7 +40,7 @@ class ClipPathView extends GroupView {
   }
 
   @Override
-  int hitTest(float[] src) {
+  public int hitTest(float[] src) {
     return -1;
   }
 

--- a/android/src/main/java/com/horcrux/svg/GroupView.java
+++ b/android/src/main/java/com/horcrux/svg/GroupView.java
@@ -254,7 +254,7 @@ class GroupView extends RenderableView {
   }
 
   @Override
-  int hitTest(final float[] src) {
+  public int hitTest(final float[] src) {
     if (!mInvertible) {
       return -1;
     }

--- a/android/src/main/java/com/horcrux/svg/RenderableView.java
+++ b/android/src/main/java/com/horcrux/svg/RenderableView.java
@@ -676,7 +676,7 @@ public abstract class RenderableView extends VirtualView implements ReactHitSlop
   abstract Path getPath(Canvas canvas, Paint paint);
 
   @Override
-  int hitTest(final float[] src) {
+  public int hitTest(final float[] src) {
     if (mPath == null || !mInvertible) {
       return -1;
     }

--- a/android/src/main/java/com/horcrux/svg/TSpanView.java
+++ b/android/src/main/java/com/horcrux/svg/TSpanView.java
@@ -1208,7 +1208,7 @@ class TSpanView extends TextView {
   }
 
   @Override
-  int hitTest(final float[] src) {
+  public int hitTest(final float[] src) {
     if (mContent == null) {
       return super.hitTest(src);
     }

--- a/android/src/main/java/com/horcrux/svg/UseView.java
+++ b/android/src/main/java/com/horcrux/svg/UseView.java
@@ -100,7 +100,7 @@ class UseView extends RenderableView {
   }
 
   @Override
-  int hitTest(float[] src) {
+  public int hitTest(float[] src) {
     if (!mInvertible) {
       return -1;
     }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Adding an `RNGH <-> RNSVG` interface requires usage of `RenderableView.hitTest` to work. ([link](https://github.com/software-mansion/react-native-gesture-handler/pull/3242))
Currently, `RenderableView.hitTest` is `package-private`, meaning it cannot be accessed by other packages.
This change does not change any functionality of the library, it only exposes existing functions to other libraries.

I only made public those `hitTest` implementation which are strictly necessary for this interface, this is why multiple, if not most `hitTest` implementations remain `package-private` despite the changes made in the PR. 

## Test Plan

- open the example app, see how the app builds successfully

### What's required for testing (prerequisites)?

- `RNSVG`'s `paper-example` app

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌      |
| MacOS   |    ❌      |
| Android |    ✅      |
| Web     |    ❌      |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [ ] ~~I updated the typed files (typescript)~~
- [ ] I added a test for the API in the `__tests__` folder
