### PR TITLE
fix: FeComposite add default value for k1...4

### DIFF
--- a/apple/Filters/RNSVGFeComposite.mm
+++ b/apple/Filters/RNSVGFeComposite.mm
@@ -179,10 +179,10 @@ using namespace facebook::react;
   } else if (self.operator1 == SVG_FECOMPOSITE_OPERATOR_ARITHMETIC) {
     [filter setValue:inputImage1 forKey:@"inputImage1"];
     [filter setValue:inputImage2 forKey:@"inputImage2"];
-    [filter setValue:(self.k1 != nil ? self.k1 : 0) forKey:@"inputK1"];
-    [filter setValue:(self.k2 != nil ? self.k2 : 0) forKey:@"inputK2"];
-    [filter setValue:(self.k3 != nil ? self.k3 : 0) forKey:@"inputK3"];
-    [filter setValue:(self.k4 != nil ? self.k4 : 0) forKey:@"inputK4"];
+    [filter setValue:(self.k1 != nil ? self.k1 : @0) forKey:@"inputK1"];
+    [filter setValue:(self.k2 != nil ? self.k2 : @0) forKey:@"inputK2"];
+    [filter setValue:(self.k3 != nil ? self.k3 : @0) forKey:@"inputK3"];
+    [filter setValue:(self.k4 != nil ? self.k4 : @0) forKey:@"inputK4"];
   } else {
     [filter setValue:inputImage1 forKey:@"inputImage"];
     [filter setValue:inputImage2 forKey:@"inputBackgroundImage"];

--- a/src/elements/filters/FeComposite.tsx
+++ b/src/elements/filters/FeComposite.tsx
@@ -30,6 +30,10 @@ export default class FeComposite extends FilterPrimitive<FeCompositeProps> {
 
   static defaultProps = {
     ...this.defaultPrimitiveProps,
+    k1: 0,
+    k2: 0,
+    k3: 0,
+    k4: 0,
   };
 
   render() {


### PR DESCRIPTION
# Summary

Fixes #2552 by adding default value for k1, k2, k3, k4 according to the spec: https://www.w3.org/TR/SVG11/filters.html#feCompositeElement

> If the attribute is not specified, the effect is as if a value of 0 were specified.

## Test Plan

[Repro from issue 2552](https://github.com/TomCorvus/RNSVG/blob/main/App.js)

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅      |
| MacOS   |    ✅      |
