### PR TITLE
fix: do not parse id as number in any case

### DIFF
--- a/src/xml.tsx
+++ b/src/xml.tsx
@@ -458,7 +458,7 @@ export function parse(source: string, middleware?: Middleware): JsxAST | null {
         allowSpaces();
 
         value = getAttributeValue();
-        if (!isNaN(+value) && value.trim() !== '') {
+        if (name !== 'id' && !isNaN(+value) && value.trim() !== '') {
           value = +value;
         }
       }


### PR DESCRIPTION
# Summary

When using `SvgXml` or `SvgCss`, an `id` attribute gets converted into a `number` instead of a `string`, which causes a crash because the native side expects a string value.

```js
import {SvgXml} from 'react-native-svg';
import {SvgCss} from 'react-native-svg/css';
```

## Test Plan

This example should not crash:
```jsx
import {SvgCss} from 'react-native-svg/css';

const svgXml = `
<svg width="100" height="100" viewBox="0 0 100 100">
  <filter x="0%" y="0%" width="100" height="100" id="0123456789">
    <feFlood flood-color="red" />
  </filter>
  <circle cx="50" cy="50" r="50" filter="url(#0123456789)" />
</svg>
`;

function Example() {
  return <SvgCss xml={svgXml} />;
}
```