### PR TITLE
fix: currentColor overflow

### DIFF
--- a/apple/RNSVGRenderable.mm
+++ b/apple/RNSVGRenderable.mm
@@ -723,9 +723,6 @@ UInt32 saturate(CGFloat value)
 
 - (void)mergeProperties:(__kindof RNSVGRenderable *)target
 {
-  if ([target isEqual:self]) {
-    return;
-  }
   _caller = target;
   NSArray<NSString *> *targetAttributeList = [target getAttributeList];
 

--- a/apple/RNSVGRenderable.mm
+++ b/apple/RNSVGRenderable.mm
@@ -241,6 +241,7 @@ static RNSVGRenderable *_contextElement;
   _vectorEffect = kRNSVGVectorEffectDefault;
   _propList = nil;
   _filter = nil;
+  _caller = nil;
 }
 #endif // RCT_NEW_ARCH_ENABLED
 
@@ -722,6 +723,9 @@ UInt32 saturate(CGFloat value)
 
 - (void)mergeProperties:(__kindof RNSVGRenderable *)target
 {
+  if ([target isEqual:self]) {
+    return;
+  }
   _caller = target;
   NSArray<NSString *> *targetAttributeList = [target getAttributeList];
 


### PR DESCRIPTION
# Summary  

This is a blind fix for issue #2566 that resets the caller on `prepareForRecycle`. While it should help address the overflow happening in some cases, I cannot guarantee that it will fully resolve the issue due to the lack of a reproducible scenario.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅      |
| MacOS   |    ✅      |
