### PR TITLE
feat: add codegen `ios.componentProvider`

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,6 +135,39 @@
     "jsSrcsDir": "./src/fabric",
     "android": {
       "javaPackageName": "com.horcrux.svg"
+    },
+    "ios": {
+      "componentProvider": {
+        "RNSVGCircle": "RNSVGCircle",
+        "RNSVGClipPath": "RNSVGClipPath",
+        "RNSVGDefs": "RNSVGDefs",
+        "RNSVGEllipse": "RNSVGEllipse",
+        "RNSVGFeBlend": "RNSVGFeBlend",
+        "RNSVGFeColorMatrix": "RNSVGFeColorMatrix",
+        "RNSVGFeComposite": "RNSVGFeComposite",
+        "RNSVGFeFlood": "RNSVGFeFlood",
+        "RNSVGFeGaussianBlur": "RNSVGFeGaussianBlur",
+        "RNSVGFeMerge": "RNSVGFeMerge",
+        "RNSVGFeOffset": "RNSVGFeOffset",
+        "RNSVGFilter": "RNSVGFilter",
+        "RNSVGForeignObject": "RNSVGForeignObject",
+        "RNSVGGroup": "RNSVGGroup",
+        "RNSVGImage": "RNSVGImage",
+        "RNSVGLine": "RNSVGLine",
+        "RNSVGLinearGradient": "RNSVGLinearGradient",
+        "RNSVGMarker": "RNSVGMarker",
+        "RNSVGMask": "RNSVGMask",
+        "RNSVGPath": "RNSVGPath",
+        "RNSVGPattern": "RNSVGPattern",
+        "RNSVGRadialGradient": "RNSVGRadialGradient",
+        "RNSVGRect": "RNSVGRect",
+        "RNSVGSvgView": "RNSVGSvgView",
+        "RNSVGSymbol": "RNSVGSymbol",
+        "RNSVGTSpan": "RNSVGTSpan",
+        "RNSVGText": "RNSVGText",
+        "RNSVGTextPath": "RNSVGTextPath",
+        "RNSVGUse": "RNSVGUse"
+      }
     }
   },
   "packageManager": "yarn@1.22.22"


### PR DESCRIPTION
# Summary

Add a newly introduced field `ios.componentProvider` to the `codegen` configuration to create an association map between JS components and their native implementations. 

When this field is defined, it is used and codegen don't crawl the file system looking for the mapping. You can find the documentation for it here: https://github.com/facebook/react-native-website/pull/4388/files#diff-7fbb6ff2e58f8bd50d2763e551c63e1816adb6d593f40d489785b575b0e82718R76

## Test Plan

Running `pod install` in the `tests-example` will currently hang and eventually crash, as it attempts to crawl through the entire repository.
 