### PR TITLE
fix: currentColor stale value

### DIFF
--- a/apple/RNSVGRenderable.mm
+++ b/apple/RNSVGRenderable.mm
@@ -231,6 +231,7 @@ static RNSVGRenderable *_contextElement;
   _strokeDashArrayData = nil;
 
   _contextElement = nil;
+  _color = nil;
   _fill = nil;
   _stroke = nil;
   _strokeLinecap = kCGLineCapButt;


### PR DESCRIPTION
# Summary
This is another fix for issue https://github.com/software-mansion/react-native-svg/issues/2566 that also resets the color on prepareForRecycle (in the same manner of this fix https://github.com/software-mansion/react-native-svg/pull/2570). I also don't have a sandboxed reproduce, but was able to verify the fix on my company's code which I unfortunately can't share.

## Compatibility
OS | Implemented
-- | --
iOS | ✅
MacOS | ✅