### PR TITLE
remove: *.metal from podspec source_files

### DIFF
--- a/RNSVG.podspec
+++ b/RNSVG.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.homepage          = package['homepage']
   s.authors           = 'Horcrux Chen'
   s.source            = { :git => 'https://github.com/react-native-community/react-native-svg.git', :tag => "v#{s.version}" }
-  s.source_files      = 'apple/**/*.{h,m,mm,metal}'
+  s.source_files      = 'apple/**/*.{h,m,mm}'
   s.ios.exclude_files = '**/*.macos.{h,m,mm}'
   s.tvos.exclude_files = '**/*.macos.{h,m,mm}'
   s.visionos.exclude_files = '**/*.macos.{h,m,mm}' if s.respond_to?(:visionos)


### PR DESCRIPTION
# Summary

Fixes #2571.
Since filter shaders are already provided as compiled `*.metallib` files, there is no need to include `*.metal` files in the `source_files` list.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅      |