### PR TITLE
feat!: Svg intrinsic size, auto and custom shadow nodes for RNSVGSvg

### DIFF
--- a/android/src/main/java/com/horcrux/svg/SVGLength.java
+++ b/android/src/main/java/com/horcrux/svg/SVGLength.java
@@ -43,6 +43,9 @@ class SVGLength {
     } else if (length.codePointAt(percentIndex) == '%') {
       unit = UnitType.PERCENTAGE;
       value = Double.valueOf(length.substring(0, percentIndex));
+    } else if (length.equals("auto")) {
+      unit = UnitType.PERCENTAGE;
+      value = 100;
     } else {
       int twoLetterUnitIndex = stringLength - 2;
       if (twoLetterUnitIndex > 0) {

--- a/apple/Elements/RNSVGSvgView.mm
+++ b/apple/Elements/RNSVGSvgView.mm
@@ -14,8 +14,8 @@
 #ifdef RCT_NEW_ARCH_ENABLED
 #import <React/RCTConversions.h>
 #import <React/RCTFabricComponentsPlugins.h>
-#import <react/renderer/components/rnsvg/ComponentDescriptors.h>
 #import <react/renderer/components/view/conversions.h>
+#import <rnsvg/RNSVGComponentDescriptors.h>
 #import "RNSVGFabricConversions.h"
 #endif // RCT_NEW_ARCH_ENABLED
 
@@ -71,6 +71,14 @@ using namespace facebook::react;
 + (ComponentDescriptorProvider)componentDescriptorProvider
 {
   return concreteComponentDescriptorProvider<RNSVGSvgViewComponentDescriptor>();
+}
+
+- (void)updateLayoutMetrics:(const facebook::react::LayoutMetrics &)layoutMetrics
+           oldLayoutMetrics:(const facebook::react::LayoutMetrics &)oldLayoutMetrics
+{
+  [super updateLayoutMetrics:layoutMetrics oldLayoutMetrics:oldLayoutMetrics];
+  [self clearChildCache];
+  [self invalidate];
 }
 
 - (void)updateProps:(Props::Shared const &)props oldProps:(Props::Shared const &)oldProps

--- a/apple/RNSVGNode.mm
+++ b/apple/RNSVGNode.mm
@@ -103,6 +103,9 @@ CGFloat const RNSVG_DEFAULT_FONT_SIZE = 12;
 - (void)clearChildCache
 {
   [self clearPath];
+  canvasWidth = -1;
+  canvasHeight = -1;
+  canvasDiagonal = -1;
   for (__kindof RNSVGNode *node in self.subviews) {
     if ([node isKindOfClass:[RNSVGNode class]]) {
       [node clearChildCache];

--- a/apple/Utils/RNSVGLength.mm
+++ b/apple/Utils/RNSVGLength.mm
@@ -34,6 +34,9 @@
   } else if ([length characterAtIndex:percentIndex] == '%') {
     output.unit = SVG_LENGTHTYPE_PERCENTAGE;
     output.value = (CGFloat)[[length substringWithRange:NSMakeRange(0, percentIndex)] doubleValue];
+  } else if ([length isEqualToString:@"auto"]) {
+    output.unit = SVG_LENGTHTYPE_PERCENTAGE;
+    output.value = 100;
   } else {
     NSInteger twoLetterUnitIndex = stringLength - 2;
     RNSVGLengthUnitType unit = SVG_LENGTHTYPE_NUMBER;

--- a/apps/common/example/examples/Svg.tsx
+++ b/apps/common/example/examples/Svg.tsx
@@ -70,39 +70,6 @@ function SvgViewbox() {
 SvgViewbox.title =
   'SVG with `viewBox="40 20 100 40" and preserveAspectRatio="none"';
 
-function SvgWithoutSizingAndVb() {
-  return (
-    <Svg>
-      <Rect
-        width="80%"
-        height="80%"
-        x="10%"
-        y="10%"
-        fill="purple"
-        stroke="yellow"
-        strokeWidth="4"
-      />
-      <Line
-        x1="10%"
-        y1="10%"
-        x2="90%"
-        y2="90%"
-        stroke="yellow"
-        strokeWidth="4"
-      />
-      <Line
-        x1="10%"
-        y1="90%"
-        x2="90%"
-        y2="10%"
-        stroke="yellow"
-        strokeWidth="4"
-      />
-    </Svg>
-  );
-}
-SvgWithoutSizingAndVb.title = 'SVG  without viewBox and width/height';
-
 function SvgWithoutSizing() {
   return (
     <View style={{width: '90%'}}>
@@ -138,42 +105,42 @@ function SvgWithoutSizing() {
 }
 SvgWithoutSizing.title = 'SVG with viewBox and without width/height';
 
-function SvgAutoHeight() {
+function SvgWithoutSizingAndVb() {
   return (
-    <Svg
-      width="50"
-      height="auto"
-      viewBox="0 0 100 100"
-      style={{backgroundColor: 'gray'}}>
-      <Circle
-        cx="50"
-        cy="50"
-        r="45"
-        stroke="blue"
-        strokeWidth="2.5"
-        fill="green"
-      />
+    <Svg>
       <Rect
-        x="15"
-        y="15"
-        width="70"
-        height="70"
-        stroke="red"
-        strokeWidth="2"
-        fill="yellow"
+        width="80%"
+        height="80%"
+        x="10%"
+        y="10%"
+        fill="purple"
+        stroke="yellow"
+        strokeWidth="4"
+      />
+      <Line
+        x1="10%"
+        y1="10%"
+        x2="90%"
+        y2="90%"
+        stroke="yellow"
+        strokeWidth="4"
+      />
+      <Line
+        x1="10%"
+        y1="90%"
+        x2="90%"
+        y2="10%"
+        stroke="yellow"
+        strokeWidth="4"
       />
     </Svg>
   );
 }
-SvgAutoHeight.title = 'SVG with auto height';
+SvgWithoutSizingAndVb.title = 'SVG without viewBox and width/height';
 
-function SvgAutoWidth() {
+function SvgIntrinsicWidth() {
   return (
-    <Svg
-      width="auto"
-      height="75"
-      viewBox="0 0 100 100"
-      style={{backgroundColor: 'gray'}}>
+    <Svg height="75" viewBox="0 0 100 100" style={{backgroundColor: 'gray'}}>
       <Circle
         cx="50"
         cy="50"
@@ -194,7 +161,32 @@ function SvgAutoWidth() {
     </Svg>
   );
 }
-SvgAutoWidth.title = 'SVG with auto width';
+SvgIntrinsicWidth.title = 'SVG with intrinsic width';
+
+function SvgIntrinsicHeight() {
+  return (
+    <Svg width="50" viewBox="0 0 100 100" style={{backgroundColor: 'gray'}}>
+      <Circle
+        cx="50"
+        cy="50"
+        r="45"
+        stroke="blue"
+        strokeWidth="2.5"
+        fill="green"
+      />
+      <Rect
+        x="15"
+        y="15"
+        width="70"
+        height="70"
+        stroke="red"
+        strokeWidth="2"
+        fill="yellow"
+      />
+    </Svg>
+  );
+}
+SvgIntrinsicHeight.title = 'SVG with intrinsic height';
 
 function SvgNativeMethods() {
   const [base64, setBase64] = useState('');
@@ -260,8 +252,8 @@ const samples = [
   SvgViewbox,
   SvgWithoutSizing,
   SvgWithoutSizingAndVb,
-  SvgAutoHeight,
-  SvgAutoWidth,
+  SvgIntrinsicWidth,
+  SvgIntrinsicHeight,
   SvgNativeMethods,
 ];
 

--- a/apps/common/example/examples/Svg.tsx
+++ b/apps/common/example/examples/Svg.tsx
@@ -2,18 +2,6 @@ import React, {useRef, useState} from 'react';
 import {Image, StyleSheet, View} from 'react-native';
 import {Circle, G, Line, Path, Rect, Svg} from 'react-native-svg';
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    height: 100,
-    width: 200,
-  },
-  svg: {
-    flex: 1,
-    alignSelf: 'stretch',
-  },
-});
-
 function SvgExample() {
   return (
     <Svg height="100" width="100">
@@ -82,10 +70,43 @@ function SvgViewbox() {
 SvgViewbox.title =
   'SVG with `viewBox="40 20 100 40" and preserveAspectRatio="none"';
 
-function SvgLayout() {
+function SvgWithoutSizingAndVb() {
   return (
-    <View style={styles.container}>
-      <Svg style={styles.svg}>
+    <Svg>
+      <Rect
+        width="80%"
+        height="80%"
+        x="10%"
+        y="10%"
+        fill="purple"
+        stroke="yellow"
+        strokeWidth="4"
+      />
+      <Line
+        x1="10%"
+        y1="10%"
+        x2="90%"
+        y2="90%"
+        stroke="yellow"
+        strokeWidth="4"
+      />
+      <Line
+        x1="10%"
+        y1="90%"
+        x2="90%"
+        y2="10%"
+        stroke="yellow"
+        strokeWidth="4"
+      />
+    </Svg>
+  );
+}
+SvgWithoutSizingAndVb.title = 'SVG  without viewBox and width/height';
+
+function SvgWithoutSizing() {
+  return (
+    <View style={{width: '90%'}}>
+      <Svg viewBox="0 0 300 100">
         <Rect
           width="80%"
           height="80%"
@@ -115,7 +136,65 @@ function SvgLayout() {
     </View>
   );
 }
-SvgLayout.title = 'SVG with flex layout';
+SvgWithoutSizing.title = 'SVG with viewBox and without width/height';
+
+function SvgAutoHeight() {
+  return (
+    <Svg
+      width="50"
+      height="auto"
+      viewBox="0 0 100 100"
+      style={{backgroundColor: 'gray'}}>
+      <Circle
+        cx="50"
+        cy="50"
+        r="45"
+        stroke="blue"
+        strokeWidth="2.5"
+        fill="green"
+      />
+      <Rect
+        x="15"
+        y="15"
+        width="70"
+        height="70"
+        stroke="red"
+        strokeWidth="2"
+        fill="yellow"
+      />
+    </Svg>
+  );
+}
+SvgAutoHeight.title = 'SVG with auto height';
+
+function SvgAutoWidth() {
+  return (
+    <Svg
+      width="auto"
+      height="75"
+      viewBox="0 0 100 100"
+      style={{backgroundColor: 'gray'}}>
+      <Circle
+        cx="50"
+        cy="50"
+        r="45"
+        stroke="blue"
+        strokeWidth="2.5"
+        fill="green"
+      />
+      <Rect
+        x="15"
+        y="15"
+        width="70"
+        height="70"
+        stroke="red"
+        strokeWidth="2"
+        fill="yellow"
+      />
+    </Svg>
+  );
+}
+SvgAutoWidth.title = 'SVG with auto width';
 
 function SvgNativeMethods() {
   const [base64, setBase64] = useState('');
@@ -179,7 +258,10 @@ const samples = [
   SvgExample,
   SvgOpacity,
   SvgViewbox,
-  SvgLayout,
+  SvgWithoutSizing,
+  SvgWithoutSizingAndVb,
+  SvgAutoHeight,
+  SvgAutoWidth,
   SvgNativeMethods,
 ];
 

--- a/common/cpp/react/renderer/components/rnsvg/RNSVGComponentDescriptors.h
+++ b/common/cpp/react/renderer/components/rnsvg/RNSVGComponentDescriptors.h
@@ -3,9 +3,14 @@
 #include <react/renderer/componentregistry/ComponentDescriptorProviderRegistry.h>
 #include <react/renderer/core/ConcreteComponentDescriptor.h>
 #include "RNSVGShadowNodes.h"
+#include "RNSVGSvgShadowNode.h"
 
 namespace facebook::react {
 
+using RNSVGSvgViewComponentDescriptor =
+    ConcreteComponentDescriptor<RNSVGSvgViewShadowNode>;
+using RNSVGSvgViewAndroidComponentDescriptor =
+    ConcreteComponentDescriptor<RNSVGSvgViewAndroidShadowNode>;
 using RNSVGCircleComponentDescriptor =
     ConcreteComponentDescriptor<RNSVGCircleShadowNode>;
 using RNSVGClipPathComponentDescriptor =

--- a/common/cpp/react/renderer/components/rnsvg/RNSVGShadowNodes.cpp
+++ b/common/cpp/react/renderer/components/rnsvg/RNSVGShadowNodes.cpp
@@ -2,6 +2,8 @@
 
 namespace facebook::react {
 
+extern const char RNSVGSvgViewAndroidComponentName[] = "RNSVGSvgViewAndroid";
+extern const char RNSVGSvgViewComponentName[] = "RNSVGSvgView";
 extern const char RNSVGCircleComponentName[] = "RNSVGCircle";
 extern const char RNSVGClipPathComponentName[] = "RNSVGClipPath";
 extern const char RNSVGDefsComponentName[] = "RNSVGDefs";

--- a/common/cpp/react/renderer/components/rnsvg/RNSVGShadowNodes.h
+++ b/common/cpp/react/renderer/components/rnsvg/RNSVGShadowNodes.h
@@ -5,8 +5,26 @@
 #include <react/renderer/components/rnsvg/Props.h>
 #include "RNSVGConcreteShadowNode.h"
 #include "RNSVGImageState.h"
+#include "RNSVGSvgShadowNode.h"
 
 namespace facebook::react {
+
+JSI_EXPORT extern const char RNSVGSvgViewComponentName[];
+
+/*
+ * `ShadowNode` for <RNSVGSvgView> component.
+ */
+using RNSVGSvgViewShadowNode =
+    RNSVGSvgShadowNode<RNSVGSvgViewComponentName, RNSVGSvgViewProps>;
+
+JSI_EXPORT extern const char RNSVGSvgViewAndroidComponentName[];
+
+/*
+ * `ShadowNode` for <RNSVGSvgViewAndroid> component.
+ */
+using RNSVGSvgViewAndroidShadowNode = RNSVGSvgShadowNode<
+    RNSVGSvgViewAndroidComponentName,
+    RNSVGSvgViewAndroidProps>;
 
 JSI_EXPORT extern const char RNSVGCircleComponentName[];
 

--- a/common/cpp/react/renderer/components/rnsvg/RNSVGSvgShadowNode.h
+++ b/common/cpp/react/renderer/components/rnsvg/RNSVGSvgShadowNode.h
@@ -83,14 +83,6 @@ class RNSVGSvgShadowNode final
     this->yogaNode_.setStyle(style);
     this->yogaNode_.setDirty(true);
   }
-
-  yoga::Style::Length parseLength(folly::dynamic length) {
-    yoga::Style::Length len;
-    PropsParserContext propsPareserContext =
-        PropsParserContext(0, ContextContainer());
-    fromRawValue(propsPareserContext, RawValue(length), len);
-    return len;
-  }
 };
 
 } // namespace facebook::react

--- a/common/cpp/react/renderer/components/rnsvg/RNSVGSvgShadowNode.h
+++ b/common/cpp/react/renderer/components/rnsvg/RNSVGSvgShadowNode.h
@@ -1,0 +1,87 @@
+#pragma once
+
+#include <jsi/jsi.h>
+#include <react/renderer/components/rnsvg/Props.h>
+#include <react/renderer/components/view/ConcreteViewShadowNode.h>
+#include <react/renderer/components/view/conversions.h>
+#include <react/renderer/core/LayoutConstraints.h>
+#include <react/renderer/core/LayoutContext.h>
+
+namespace facebook::react {
+
+template <const char *componentName, typename ViewPropsT = ViewProps>
+class RNSVGSvgShadowNode final
+    : public ConcreteViewShadowNode<componentName, ViewPropsT> {
+ public:
+  RNSVGSvgShadowNode(
+      const ShadowNodeFragment &fragment,
+      const ShadowNodeFamily::Shared &family,
+      ShadowNodeTraits traits)
+      : ConcreteViewShadowNode<componentName, ViewPropsT>(
+            fragment,
+            family,
+            traits) {
+    initialize();
+  }
+
+  RNSVGSvgShadowNode(
+      const ShadowNode &sourceShadowNode,
+      const ShadowNodeFragment &fragment)
+      : ConcreteViewShadowNode<componentName, ViewPropsT>(
+            sourceShadowNode,
+            fragment) {
+    initialize();
+  }
+
+  void layout(LayoutContext layoutContext) {
+    auto affectedNodes = layoutContext.affectedNodes;
+    layoutContext.affectedNodes = nullptr;
+    YogaLayoutableShadowNode::layout(layoutContext);
+    layoutContext.affectedNodes = affectedNodes;
+  }
+
+ private:
+  void initialize() {
+    auto style = this->yogaNode_.style();
+
+    const auto &props = this->getConcreteProps();
+    auto width = parseLength(props.bbWidth);
+    auto height = parseLength(props.bbHeight);
+
+    bool hasViewBox = props.vbWidth != 0 && props.vbHeight != 0;
+    bool widthIsAuto = width.unit() == yoga::Unit::Auto;
+    bool heightIsAuto = height.unit() == yoga::Unit::Auto;
+
+    if (!hasViewBox) {
+      if (widthIsAuto) {
+        style.setDimension(yoga::Dimension::Width, yoga::value::points(300));
+      }
+      if (heightIsAuto) {
+        style.setDimension(yoga::Dimension::Height, yoga::value::points(150));
+      }
+    } else if (widthIsAuto || heightIsAuto) {
+      auto aspectRatio = props.vbWidth / props.vbHeight;
+      style.setAspectRatio(yoga::FloatOptional(aspectRatio));
+      if (widthIsAuto && heightIsAuto) {
+        style.setDimension(yoga::Dimension::Width, yoga::value::percent(100));
+      } else if (heightIsAuto) {
+        style.setDimension(yoga::Dimension::Height, yoga::value::undefined());
+      } else if (widthIsAuto) {
+        style.setDimension(yoga::Dimension::Width, yoga::value::undefined());
+      }
+    }
+
+    this->yogaNode_.setStyle(style);
+    this->yogaNode_.setDirty(true);
+  }
+
+  yoga::Style::Length parseLength(folly::dynamic length) {
+    yoga::Style::Length len;
+    PropsParserContext propsPareserContext =
+        PropsParserContext(0, ContextContainer());
+    fromRawValue(propsPareserContext, RawValue(length), len);
+    return len;
+  }
+};
+
+} // namespace facebook::react

--- a/common/cpp/react/renderer/components/rnsvg/RNSVGSvgShadowNode.h
+++ b/common/cpp/react/renderer/components/rnsvg/RNSVGSvgShadowNode.h
@@ -43,32 +43,41 @@ class RNSVGSvgShadowNode final
  private:
   void initialize() {
     auto style = this->yogaNode_.style();
-
     const auto &props = this->getConcreteProps();
-    auto width = parseLength(props.bbWidth);
-    auto height = parseLength(props.bbHeight);
 
     bool hasViewBox = props.vbWidth != 0 && props.vbHeight != 0;
-    bool widthIsAuto = width.unit() == yoga::Unit::Auto;
-    bool heightIsAuto = height.unit() == yoga::Unit::Auto;
+    bool isWidthEmpty = props.bbWidth.empty();
+    bool isHeightEmpty = props.bbHeight.empty();
 
     if (!hasViewBox) {
-      if (widthIsAuto) {
+      if (isWidthEmpty) {
         style.setDimension(yoga::Dimension::Width, yoga::value::points(300));
       }
-      if (heightIsAuto) {
+      if (isHeightEmpty) {
         style.setDimension(yoga::Dimension::Height, yoga::value::points(150));
       }
-    } else if (widthIsAuto || heightIsAuto) {
-      auto aspectRatio = props.vbWidth / props.vbHeight;
-      style.setAspectRatio(yoga::FloatOptional(aspectRatio));
-      if (widthIsAuto && heightIsAuto) {
+    } else if (isWidthEmpty || isHeightEmpty) {
+      auto vbAspectRatio = props.vbWidth / props.vbHeight;
+      style.setAspectRatio(yoga::FloatOptional(vbAspectRatio));
+      if (isWidthEmpty && isHeightEmpty) {
         style.setDimension(yoga::Dimension::Width, yoga::value::percent(100));
-      } else if (heightIsAuto) {
-        style.setDimension(yoga::Dimension::Height, yoga::value::undefined());
-      } else if (widthIsAuto) {
+      } else if (isWidthEmpty) {
         style.setDimension(yoga::Dimension::Width, yoga::value::undefined());
+      } else if (isHeightEmpty) {
+        style.setDimension(yoga::Dimension::Height, yoga::value::undefined());
       }
+    }
+
+    bool isWidthAuto =
+        props.bbWidth.isString() && props.bbWidth.asString() == "auto";
+    bool isHeightAuto =
+        props.bbHeight.isString() && props.bbHeight.asString() == "auto";
+
+    if (isWidthAuto) {
+      style.setDimension(yoga::Dimension::Width, yoga::value::percent(100));
+    }
+    if (isHeightAuto) {
+      style.setDimension(yoga::Dimension::Height, yoga::value::percent(100));
     }
 
     this->yogaNode_.setStyle(style);

--- a/src/elements/Svg.tsx
+++ b/src/elements/Svg.tsx
@@ -50,8 +50,6 @@ export default class Svg extends Shape<SvgProps> {
 
   static defaultProps = {
     preserveAspectRatio: 'xMidYMid meet',
-    width: 'auto',
-    height: 'auto',
   };
 
   measureInWindow = (callback: MeasureInWindowOnSuccessCallback) => {

--- a/src/elements/Svg.tsx
+++ b/src/elements/Svg.tsx
@@ -37,8 +37,8 @@ const styles = StyleSheet.create({
 const defaultStyle = styles.svg;
 
 export interface SvgProps extends GProps, ViewProps, HitSlop {
-  width?: NumberProp;
-  height?: NumberProp;
+  width?: NumberProp | 'auto';
+  height?: NumberProp | 'auto';
   viewBox?: string;
   preserveAspectRatio?: string;
   color?: ColorValue;
@@ -50,6 +50,8 @@ export default class Svg extends Shape<SvgProps> {
 
   static defaultProps = {
     preserveAspectRatio: 'xMidYMid meet',
+    width: 'auto',
+    height: 'auto',
   };
 
   measureInWindow = (callback: MeasureInWindowOnSuccessCallback) => {
@@ -73,8 +75,8 @@ export default class Svg extends Shape<SvgProps> {
 
   setNativeProps = (
     props: SvgProps & {
-      bbWidth?: NumberProp;
-      bbHeight?: NumberProp;
+      width?: NumberProp;
+      height?: NumberProp;
     }
   ) => {
     const { root } = this;
@@ -106,7 +108,7 @@ export default class Svg extends Shape<SvgProps> {
       ...(Array.isArray(style) ? Object.assign({}, ...style) : style),
       ...extracted,
     };
-    let {
+    const {
       width,
       height,
       focusable,
@@ -126,9 +128,6 @@ export default class Svg extends Shape<SvgProps> {
       strokeLinejoin,
       strokeMiterlimit,
     } = stylesAndProps;
-    if (width === undefined && height === undefined) {
-      width = height = '100%';
-    }
 
     const props: extractedProps = extracted as extractedProps;
     props.focusable = Boolean(focusable) && focusable !== 'false';

--- a/src/fabric/AndroidSvgViewNativeComponent.ts
+++ b/src/fabric/AndroidSvgViewNativeComponent.ts
@@ -79,4 +79,5 @@ interface NativeProps extends ViewProps {
 
 export default codegenNativeComponent<NativeProps>('RNSVGSvgViewAndroid', {
   excludedPlatforms: ['iOS'],
+  interfaceOnly: true,
 });

--- a/src/fabric/IOSSvgViewNativeComponent.ts
+++ b/src/fabric/IOSSvgViewNativeComponent.ts
@@ -29,4 +29,5 @@ interface NativeProps extends ViewProps {
 
 export default codegenNativeComponent<NativeProps>('RNSVGSvgView', {
   excludedPlatforms: ['android'],
+  interfaceOnly: true,
 });


### PR DESCRIPTION
# Summary

BREAKING CHANGE / NEW ARCH ONLY

Implement intrinsic and `auto` value for `width` and `height` on `Svg` component based on the [specification](https://svgwg.org/specs/integration/#svg-css-sizing).

> Initial ‘[svg](https://svgwg.org/svg2-draft/struct.html#SVGElement)’ element [width](https://svgwg.org/svg2-draft/geometry.html#Sizing) and [height](https://svgwg.org/svg2-draft/geometry.html#Sizing) are set to 'auto' [...]
> 
> To resolve 'auto' value on ‘svg’ element if the ‘[viewBox](https://svgwg.org/svg2-draft/coords.html#ViewBoxAttribute)’ attribute is not specified:
> 
> * Use author specified width and height ‘svg’ element attributes.
> * If any of the sizing attributes are missing, resolve the missing ‘svg’ element width to '300px' and missing height to '150px' (using [CSS 2.1 replaced elements size calculation](https://www.w3.org/TR/CSS21/visudet.html#inline-replaced-width)).
> 
> To resolve 'auto' value on ‘svg’ element if the ‘viewBox’ attribute is specified:
> 
> * Use the ‘viewBox’ attribute to calculate the intrinsic aspect ratio of the ‘svg’ element.
> * If the width or height attributes are not specified - keep not specified width or height as 'auto'.

A huge thanks to @janicduplessis for #1720 with a similar concept. However, it needed to be implemented slightly different for some edge cases and the `RNSVGImage` implementation, which requires being a yoga node.

## Test Plan

Example app -> Svg examples

<img width="854" alt="image" src="https://github.com/user-attachments/assets/7e757561-83bf-450b-a1d6-c321f4b554be" />

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| MacOS   |    ✅      |
| Android |    ✅      |
| Web     |    ✅      |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [x] I updated the typed files (typescript)
