### PR TITLE
feat: allow single quote ID wrapper

### DIFF
--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -13,7 +13,7 @@ export function pickNotNil(object: { [prop: string]: unknown }) {
   return result;
 }
 
-export const idPattern = /#([^)]+)\)?$/;
+export const idPattern = /#([^)]+)'?\)?$/;
 
 export const getRandomNumber = () =>
   Math.floor(Math.random() * Math.floor(Math.random() * Date.now()));


### PR DESCRIPTION
# Summary  

The SVG specification does not strictly standardize linking, and most browsers permit the use of `'` as a wrapper in `url` links. As a result, I've added support for URLs such as `url('#id')`. 

## Test Plan

`url(#id)` and `url('#id')` should do the exact same thing.


Closes #1768