### PR TITLE
feat: use yoga::StyleLength instead of yoga::value on 77+

### DIFF
--- a/common/cpp/react/renderer/components/rnsvg/RNSVGLayoutableShadowNode.cpp
+++ b/common/cpp/react/renderer/components/rnsvg/RNSVGLayoutableShadowNode.cpp
@@ -8,27 +8,29 @@ RNSVGLayoutableShadowNode::RNSVGLayoutableShadowNode(
     const ShadowNodeFamily::Shared &family,
     ShadowNodeTraits traits)
     : YogaLayoutableShadowNode(fragment, family, traits) {
-  // SVG handles its layout manually on the native side and does not depend on
-  // the Yoga layout. Setting the dimensions to 0 eliminates randomly positioned
-  // views in the layout inspector when Yoga attempts to interpret SVG
-  // properties like width when viewBox scale is set.
-  auto style = yogaNode_.style();
-  style.setDimension(yoga::Dimension::Width, yoga::value::points(0));
-  style.setDimension(yoga::Dimension::Height, yoga::value::points(0));
-  yogaNode_.setStyle(style);
+  setZeroDimensions();
 }
 
 RNSVGLayoutableShadowNode::RNSVGLayoutableShadowNode(
     const ShadowNode &sourceShadowNode,
     const ShadowNodeFragment &fragment)
     : YogaLayoutableShadowNode(sourceShadowNode, fragment) {
+  setZeroDimensions();
+}
+
+void RNSVGLayoutableShadowNode::setZeroDimensions() {
   // SVG handles its layout manually on the native side and does not depend on
   // the Yoga layout. Setting the dimensions to 0 eliminates randomly positioned
   // views in the layout inspector when Yoga attempts to interpret SVG
   // properties like width when viewBox scale is set.
   auto style = yogaNode_.style();
+#if REACT_NATIVE_MINOR_VERSION >= 77
   style.setDimension(yoga::Dimension::Width, yoga::value::points(0));
   style.setDimension(yoga::Dimension::Height, yoga::value::points(0));
+#else
+  style.setDimension(yoga::Dimension::Width, yoga::StyleLength::points(0));
+  style.setDimension(yoga::Dimension::Height, yoga::StyleLength::points(0));
+#endif
   yogaNode_.setStyle(style);
 }
 

--- a/common/cpp/react/renderer/components/rnsvg/RNSVGLayoutableShadowNode.h
+++ b/common/cpp/react/renderer/components/rnsvg/RNSVGLayoutableShadowNode.h
@@ -14,6 +14,9 @@ class RNSVGLayoutableShadowNode : public YogaLayoutableShadowNode {
       const ShadowNodeFragment &fragment);
 
   void layout(LayoutContext layoutContext) override;
+
+ private:
+  void setZeroDimensions();
 };
 
 } // namespace facebook::react


### PR DESCRIPTION
# Summary

With react-native@0.77 `yoga::value` is no longer available and we should use `yoga::StyleLength`.

## Test Plan

App should build again on 0.77.rc-3