### PR TITLE
feat: additional stylesheet for `SvgCss`

### DIFF
--- a/src/css/css.tsx
+++ b/src/css/css.tsx
@@ -765,12 +765,41 @@ export const inlineStyles: Middleware = function inlineStyles(
   return document;
 };
 
-export function SvgCss(props: XmlProps) {
-  const { xml, override, fallback, onError = err } = props;
+const appendStylesheet: (stylesheet?: CssProps['stylesheet']) => Middleware =
+  (stylesheet) => (document) => {
+    if (stylesheet) {
+      const styles =
+        typeof stylesheet === 'string'
+          ? stylesheet
+          : Object.entries(stylesheet as { [key: string]: object })
+              .map(([selector, declarations]) => {
+                const props = Object.entries(declarations)
+                  .map(([property, value]) => `${property}:${value};`)
+                  .join('');
+                return `${selector}{${props}}`;
+              })
+              .join('\n');
+      document.children.push({
+        tag: 'style',
+        children: [styles],
+        parent: document,
+        props: {},
+        Tag: () => null,
+      });
+    }
+    return inlineStyles(document);
+  };
+
+type CssProps = { stylesheet?: string | { [key: string]: object } };
+export type CssXmlProps = XmlProps & CssProps;
+export type CssUriProps = UriProps & CssProps;
+
+export function SvgCss(props: CssXmlProps) {
+  const { xml, override, fallback, onError = err, stylesheet } = props;
   try {
     const ast = useMemo<JsxAST | null>(
-      () => (xml !== null ? parse(xml, inlineStyles) : null),
-      [xml]
+      () => (xml !== null ? parse(xml, appendStylesheet(stylesheet)) : null),
+      [xml, stylesheet]
     );
     return <SvgAst ast={ast} override={override || props} />;
   } catch (error) {
@@ -779,8 +808,8 @@ export function SvgCss(props: XmlProps) {
   }
 }
 
-export function SvgCssUri(props: UriProps) {
-  const { uri, onError = err, onLoad, fallback } = props;
+export function SvgCssUri(props: CssUriProps) {
+  const { uri, onError = err, onLoad, fallback, stylesheet } = props;
   const [xml, setXml] = useState<string | null>(null);
   const [isError, setIsError] = useState(false);
   useEffect(() => {
@@ -799,12 +828,18 @@ export function SvgCssUri(props: UriProps) {
   if (isError) {
     return fallback ?? null;
   }
-  return <SvgCss xml={xml} override={props} fallback={fallback} />;
+  return (
+    <SvgCss
+      xml={xml}
+      override={props}
+      fallback={fallback}
+      stylesheet={stylesheet}
+    />
+  );
 }
 
 // Extending Component is required for Animated support.
-
-export class SvgWithCss extends Component<XmlProps, XmlState> {
+export class SvgWithCss extends Component<CssXmlProps, XmlState> {
   state = { ast: null };
   componentDidMount() {
     this.parse(this.props.xml);
@@ -817,9 +852,11 @@ export class SvgWithCss extends Component<XmlProps, XmlState> {
     }
   }
 
-  parse(xml: string | null) {
+  parse(xml: string | null, stylesheet?: string) {
     try {
-      this.setState({ ast: xml ? parse(xml, inlineStyles) : null });
+      this.setState({
+        ast: xml ? parse(xml, appendStylesheet(stylesheet)) : null,
+      });
     } catch (e) {
       this.props.onError ? this.props.onError(e as Error) : console.error(e);
     }
@@ -834,7 +871,7 @@ export class SvgWithCss extends Component<XmlProps, XmlState> {
   }
 }
 
-export class SvgWithCssUri extends Component<UriProps, UriState> {
+export class SvgWithCssUri extends Component<CssUriProps, UriState> {
   state = { xml: null };
   componentDidMount() {
     this.fetch(this.props.uri);
@@ -860,6 +897,8 @@ export class SvgWithCssUri extends Component<UriProps, UriState> {
       props,
       state: { xml },
     } = this;
-    return <SvgWithCss xml={xml} override={props} />;
+    return (
+      <SvgWithCss xml={xml} override={props} stylesheet={props.stylesheet} />
+    );
   }
 }


### PR DESCRIPTION
# Summary

resolves #1841

## Test Plan

```tsx
import * as React from 'react';
import {SvgCss} from 'react-native-svg/css';

const Icon = () => (
  <SvgCss
    xml={`
      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
        <style>.secondary{opacity:.4}</style>
        <g id="root">
          <path id="primary" d="M256 512C114.6 512 0 397.4 0 256C0 114.6 114.6 0 256 0V512z"/>
          <path class="secondary" d="M256 0C397.4 0 512 114.6 512 256C512 397.4 397.4 512 256 512V0z"/>
        </g>
      </svg>`}
    // =================================== String ===================================
    stylesheet={`
      #root {
        color: #0f0;
      }
      #primary {
        fill: #f00;
      }
      .secondary {
        fill: currentColor;
      }
    `}
    // =================================== Object ===================================
    stylesheet={{
      '#root': {
        fill: '#f00',
      },
      '#primary': {
        fill: '#f00',
      },
      '.secondary': {
        fill: 'currentColor',
      },
    }}
  />
);
export default Icon;
```

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [x] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
