### PR TITLE
fix: remove package from AndroidManifest.xml

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -81,10 +81,8 @@ def FRESCO_VERSION = getFrescoVersion()
 
 android {
     compileSdkVersion safeExtGet('compileSdkVersion', 28)
+    namespace "com.horcrux.svg"
     def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
-    if (agpVersion.tokenize('.')[0].toInteger() >= 7) {
-        namespace "com.horcrux.svg"
-    }
     if (agpVersion.tokenize('.')[0].toInteger() >= 8) {
         buildFeatures {
             buildConfig = true

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,2 +1,1 @@
-<manifest package="com.horcrux.svg">
-</manifest>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"/>


### PR DESCRIPTION
# Summary

Fixes #2599 

Starting with `v15.8.0`, we support `react-native@0.73+`, which eliminates the need to worry about AGP versions below 7. Consequently, the `package` attribute in `AndroidManifest.xml` can be safely removed, along with the corresponding check in `build.gradle`.

## Test Plan

Build the app on all supported versions

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| Android |    ✅      |
