### PR TITLE
fix: CMake flags

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -104,13 +104,6 @@ android {
         buildConfigField "boolean", "IS_NEW_ARCHITECTURE_ENABLED", isNewArchitectureEnabled().toString()
 
         consumerProguardFiles 'proguard-rules.pro'
-
-        buildConfigField("String", "REACT_NATIVE_MINOR_VERSION", "\"${REACT_NATIVE_MINOR_VERSION}\"")
-        externalNativeBuild {
-            cmake {
-                arguments "-DREACT_NATIVE_MINOR_VERSION=${REACT_NATIVE_MINOR_VERSION}"
-            }
-        }
     }
     lintOptions {
         abortOnError false

--- a/android/src/main/jni/CMakeLists.txt
+++ b/android/src/main/jni/CMakeLists.txt
@@ -10,7 +10,7 @@ set(RNS_GENERATED_REACT_DIR ${RNS_GENERATED_JNI_DIR}/react/renderer/components/r
 string(
   APPEND
   CMAKE_CXX_FLAGS
-  " -DREACT_NATIVE_MINOR_VERSION=321${REACT_NATIVE_MINOR_VERSION}")
+  " -DREACT_NATIVE_MINOR_VERSION=${ReactAndroid_VERSION_MINOR}")
 
 add_compile_options(
   -fexceptions


### PR DESCRIPTION
# Summary

Fix typo in CMakeLists.txt flags and use `ReactAndroid_VERSION_MINOR` instead of `REACT_NATIVE_MINOR_VERSION`

## Test Plan

Example apps should build without warnings/errors on 0.73+ as well as on 0.77.0-rc.6