### PR TITLE
fix: include `scripts/rnsvg_utils.rb` in release

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "RNSVG.podspec",
     "!android/build",
     "windows",
-    "react-native.config.js"
+    "react-native.config.js",
+    "scripts/rnsvg_utils.rb"
   ],
   "react-native-builder-bob": {
     "source": "src",


### PR DESCRIPTION
# Summary

Hotfix for #2606, where `RNSVG.podspec` imports `scripts/rnsvg_utils.rb` but `scripts` catalog is not included in the release.

Closes #2606

# Issue
```bash
❯ bundle exec pod install

[!] Invalid `Podfile` file:
[!] Invalid `RNSVG.podspec` file: cannot load such file -- /node_modules/react-native-svg/scripts/rnsvg_utils.

 #  from /node_modules/react-native-svg/RNSVG.podspec:2
 #  -------------------------------------------
 #  require 'json'
 >  require_relative './scripts/rnsvg_utils'
 #
 #  -------------------------------------------
```