### PR TITLE
fix: don't set zero dimensions on RNSVGGroup

### DIFF
--- a/common/cpp/react/renderer/components/rnsvg/RNSVGLayoutableShadowNode.cpp
+++ b/common/cpp/react/renderer/components/rnsvg/RNSVGLayoutableShadowNode.cpp
@@ -8,14 +8,18 @@ RNSVGLayoutableShadowNode::RNSVGLayoutableShadowNode(
     const ShadowNodeFamily::Shared &family,
     ShadowNodeTraits traits)
     : YogaLayoutableShadowNode(fragment, family, traits) {
-  setZeroDimensions();
+  if (std::strcmp(this->getComponentName(), "RNSVGGroup") != 0) {
+    setZeroDimensions();
+  }
 }
 
 RNSVGLayoutableShadowNode::RNSVGLayoutableShadowNode(
     const ShadowNode &sourceShadowNode,
     const ShadowNodeFragment &fragment)
     : YogaLayoutableShadowNode(sourceShadowNode, fragment) {
-  setZeroDimensions();
+  if (std::strcmp(this->getComponentName(), "RNSVGGroup") != 0) {
+    setZeroDimensions();
+  }
 }
 
 void RNSVGLayoutableShadowNode::setZeroDimensions() {


### PR DESCRIPTION
# Summary

Fixes #2610

It's more of a hack than the best fix for that; however, it's a regression that we should address.

## Test Plan
Test case provided in #2610