### PR TITLE
fix: FeDropShadow results and import react

### DIFF
--- a/src/elements/filters/FeBlend.tsx
+++ b/src/elements/filters/FeBlend.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { NativeMethods } from 'react-native';
 import {
   extractFeBlend,

--- a/src/elements/filters/FeColorMatrix.tsx
+++ b/src/elements/filters/FeColorMatrix.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { NativeMethods } from 'react-native';
 import RNSVGFeColorMatrix from '../../fabric/FeColorMatrixNativeComponent';
 import {

--- a/src/elements/filters/FeComponentTransfer.tsx
+++ b/src/elements/filters/FeComponentTransfer.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import FilterPrimitive from './FilterPrimitive';
 import { warnUnimplementedFilter } from '../../lib/util';
 

--- a/src/elements/filters/FeComponentTransferFunction.tsx
+++ b/src/elements/filters/FeComponentTransferFunction.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { NumberArray, NumberProp } from '../../lib/extract/types';
 import { warnUnimplementedFilter } from '../../lib/util';
 import FilterPrimitive from './FilterPrimitive';

--- a/src/elements/filters/FeComposite.tsx
+++ b/src/elements/filters/FeComposite.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { NativeMethods } from 'react-native';
 import RNSVGFeComposite from '../../fabric/FeCompositeNativeComponent';
 import {

--- a/src/elements/filters/FeDropShadow.tsx
+++ b/src/elements/filters/FeDropShadow.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { ColorValue } from 'react-native';
 import { NumberArray, NumberProp } from '../../lib/extract/types';
 import FeFlood from './FeFlood';
@@ -25,9 +26,15 @@ export default class FeDropShadow extends FilterPrimitive<FeDropShadowProps> {
   };
 
   render() {
-    const { stdDeviation, in: in1 = 'SourceGraphic', dx, dy } = this.props;
+    const {
+      stdDeviation,
+      in: in1 = 'SourceGraphic',
+      dx,
+      dy,
+      result,
+    } = this.props;
     return (
-      <>
+      <React.Fragment>
         <FeGaussianBlur in={in1} stdDeviation={stdDeviation} />
         <FeOffset dx={dx} dy={dy} result="offsetblur" />
         <FeFlood
@@ -35,11 +42,11 @@ export default class FeDropShadow extends FilterPrimitive<FeDropShadowProps> {
           floodOpacity={this.props.floodOpacity}
         />
         <FeComposite in2="offsetblur" operator="in" />
-        <FeMerge>
+        <FeMerge result={result}>
           <FeMergeNode />
           <FeMergeNode in={in1} />
         </FeMerge>
-      </>
+      </React.Fragment>
     );
   }
 }

--- a/src/elements/filters/FeFlood.tsx
+++ b/src/elements/filters/FeFlood.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { ColorValue, NativeMethods } from 'react-native';
 import RNSVGFeFlood from '../../fabric/FeFloodNativeComponent';
 import extractFeFlood, { extractFilter } from '../../lib/extract/extractFilter';

--- a/src/elements/filters/FeGaussianBlur.tsx
+++ b/src/elements/filters/FeGaussianBlur.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { NativeMethods } from 'react-native';
 import RNSVGFeGaussianBlur from '../../fabric/FeGaussianBlurNativeComponent';
 import {

--- a/src/elements/filters/FeMerge.tsx
+++ b/src/elements/filters/FeMerge.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { NativeMethods } from 'react-native';
 import RNSVGFeMerge from '../../fabric/FeMergeNativeComponent';
 import { extractFeMerge, extractFilter } from '../../lib/extract/extractFilter';

--- a/src/elements/filters/FeMergeNode.tsx
+++ b/src/elements/filters/FeMergeNode.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import FilterPrimitive from './FilterPrimitive';
 
 export interface FeMergeNodeProps {

--- a/src/elements/filters/FeOffset.tsx
+++ b/src/elements/filters/FeOffset.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { NativeMethods } from 'react-native';
 import RNSVGFeOffset from '../../fabric/FeOffsetNativeComponent';
 import { extractFilter, extractIn } from '../../lib/extract/extractFilter';

--- a/src/elements/filters/Filter.tsx
+++ b/src/elements/filters/Filter.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { NativeMethods } from 'react-native';
 import RNSVGFilter from '../../fabric/FilterNativeComponent';
 import { NumberProp, Units } from '../../lib/extract/types';


### PR DESCRIPTION
# Summary

* Add results alias in `FeDropShadow`
* Import React in every tsx filter file to satisfy typescript/eslint
* Replace `<>` with `<React.Fragment>` in `FeDropShadow`

