### PR TITLE
Fixing crashing iOS on the production mode

### DIFF
--- a/apple/Text/RNSVGFontData.mm
+++ b/apple/Text/RNSVGFontData.mm
@@ -184,7 +184,7 @@ int lighter(int inherited)
   id letterSpacing = [font objectForKey:LETTER_SPACING];
   if ([letterSpacing isKindOfClass:NSNumber.class]) {
     NSNumber *ls = letterSpacing;
-    data->wordSpacing = (CGFloat)[ls doubleValue];
+    data->letterSpacing = (CGFloat)[ls doubleValue];
   } else {
     data->letterSpacing =
         letterSpacing ? [RNSVGFontData toAbsoluteWithNSString:letterSpacing fontSize:fontSize] : parent->letterSpacing;

--- a/apple/Text/RNSVGFontData.mm
+++ b/apple/Text/RNSVGFontData.mm
@@ -19,13 +19,14 @@ static NSString *TEXT_DECORATION = @"textDecoration";
 static NSString *FONT_FEATURE_SETTINGS = @"fontFeatureSettings";
 static NSString *FONT_VARIANT_LIGATURES = @"fontVariantLigatures";
 
-RNSVGFontData *RNSVGFontData_Defaults;
+static RNSVGFontData *RNSVGFontData_Defaults;
 
 @implementation RNSVGFontData
 
 + (instancetype)Defaults
 {
-  if (!RNSVGFontData_Defaults) {
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
     RNSVGFontData *self = [RNSVGFontData alloc];
     self->fontData = nil;
     self->fontFamily = @"";
@@ -42,7 +43,7 @@ RNSVGFontData *RNSVGFontData_Defaults;
     self->wordSpacing = RNSVG_DEFAULT_WORD_SPACING;
     self->letterSpacing = RNSVG_DEFAULT_LETTER_SPACING;
     RNSVGFontData_Defaults = self;
-  }
+  });
   return RNSVGFontData_Defaults;
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged

  Wrong assignment for `letterSpacing`
  Crashing on iOS when wants to render SVG on the production mode
 
For example, showing the following `SendIcon` component in the app:

```tsx
//SendIcon.tsx

import * as React from 'react';
import RootSvg from './RootSvg';
import {SvgIconProps} from './type';
import {Path} from 'react-native-svg';
import {APP_COLOR} from '@/core/constants';

const SendIcon: React.FC<SvgIconProps> = props => (
  <RootSvg viewBox="0 0 48 48" color={APP_COLOR} {...props}>
    <Path d="M4.02 42 46 24 4.02 6 4 20l30 4-30 4z" />
    <Path fill="none" d="M0 0h48v48H0z" />
  </RootSvg>
);

export default SendIcon;
```

```tsx
//RootSvg.tsx

import React from 'react';
import {View} from 'react-native';
import {Svg} from 'react-native-svg';
import type {SvgIconProps} from './type';
import {useRStyle} from 'react-native-full-responsive';

const ICON_SIZE = 24;

const RootSvg = React.forwardRef<any, SvgIconProps>(
  ({style, children, size = ICON_SIZE, color = '#000000', ...rest}, ref) => {
    const svgStyle = useRStyle(() => {
      return {
        svg: {
          width: `${size}rs`,
          height: `${size}rs`,
        },
      };
    }, [size]).svg;

    return (
      <View style={[svgStyle, style]}>
        <Svg
          ref={ref}
          role="img"
          fill={color}
          width="100%"
          height="100%"
          viewBox="0 0 24 24"
          accessibilityRole="image"
          {...rest}>
          {children}
        </Svg>
      </View>
    );
  },
);

export default RootSvg;
```

RN version: `0.77.1`
Env: physical device
Test: building and rendering successfully the SVG on both the simulator and the physical device

* What is the feature? (if applicable)

This isn’t a new feature but rather a bug fix to ensure thread-safe initialization of a static variable `RNSVGFontData_Defaults` in the `RNSVGFontData` class. This class manages font-related properties for SVG text rendering. The fix addresses a crash in production mode caused by race conditions during the initialization of this singleton object.

* How did you implement the solution?

The solution was implemented by replacing the original, non-thread-safe initialization logic with `dispatch_once`

* What areas of the library does it impact?

## Test Plan

Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅      |
| MacOS   |    ❌      |
| Android |    ❌      |
| Web     |    ❌      |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [ ] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
