### PR TITLE
fix: animating single strokeDasharray on Android

### DIFF
--- a/android/src/main/java/com/horcrux/svg/RenderableView.java
+++ b/android/src/main/java/com/horcrux/svg/RenderableView.java
@@ -285,6 +285,9 @@ public abstract class RenderableView extends VirtualView implements ReactHitSlop
   public void setStrokeDasharray(Dynamic dynamicStrokeDasharray) {
     ArrayList<SVGLength> arrayList = SVGLength.arrayFrom(dynamicStrokeDasharray);
     if (arrayList != null) {
+      if (arrayList.size() % 2 == 1) {
+        arrayList.addAll(arrayList);
+      }
       this.strokeDasharray = arrayList.toArray(new SVGLength[0]);
     } else {
       this.strokeDasharray = null;


### PR DESCRIPTION
# Summary

When animating a strokeDasharray, JS parsing is bypassed, which results in an incorrect array length when only one element is animated. This fix prevents Android's illegal state with odd array length.

## Test Plan

This component should not crash:

```tsx
import React from 'react';
import {Button} from 'react-native';
import Animated, {
  Easing,
  useAnimatedProps,
  useSharedValue,
  withTiming,
} from 'react-native-reanimated';
import {Path, Svg} from 'react-native-svg';

const AnimatedPath = Animated.createAnimatedComponent(Path);
const AnimatedImplementation = ({isFocused = false}: {isFocused: boolean}) => {
  const progress = useSharedValue(isFocused ? 30 : 0);

  React.useEffect(() => {
    progress.value = withTiming(isFocused ? 30 : 0, {
      duration: isFocused ? 400 : 300,
      easing: Easing.inOut(Easing.ease),
    });
  }, [isFocused, progress]);

  const whitePathProps = useAnimatedProps(() => {
    'worklet';
    return {
      strokeDasharray: progress.value,
    };
  });

  return (
    <Svg width={100} height={100}>
      <AnimatedPath
        d="M 10 10 H 90 V 90 H 10 L 10 10"
        stroke="black"
        strokeWidth={2}
        fill="none"
        animatedProps={whitePathProps}
      />
    </Svg>
  );
};

function EmptyExample() {
  const [isFocused, setIsFocused] = React.useState(false);
  return (
    <>
      <AnimatedImplementation isFocused={isFocused} />
      <Button title="Toggle" onPress={() => setIsFocused(prev => !prev)} />
    </>
  );
}
```

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| Android |    ✅      |
