### PR TITLE
fix: types to support react 19

### DIFF
--- a/src/web/WebShape.ts
+++ b/src/web/WebShape.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { type JSX } from 'react';
 import {
   GestureResponderEvent,
   // @ts-ignore it is not seen in exports

--- a/src/xml.tsx
+++ b/src/xml.tsx
@@ -1,4 +1,4 @@
-import type { ComponentType, ComponentProps } from 'react';
+import type { ComponentType, ComponentProps, JSX } from 'react';
 import * as React from 'react';
 import { Component, useEffect, useMemo, useState } from 'react';
 import { fetchText } from './utils/fetchData';


### PR DESCRIPTION
# Summary

Fixed the types when building with React Native 0.78+ and React 19+ as mentioned [here](https://react.dev/blog/2024/04/25/react-19-upgrade-guide#the-jsx-namespace-in-typescript). None of the changes should impact production code since this is just updating types.

## Test Plan

Run `yarn bob` using React 18 and React 19. It should compile without any type errors (CI/CD should also cover this).

### What's required for testing (prerequisites)?

Install react-native-svg in a project running React Native 0.78 and React 19 and set `skipLibCheck` to `false` (or simply upgrade React types to 19 in the example apps).

### What are the steps to reproduce (after prerequisites)?

Compile the typescript code.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅      |
| MacOS   |    ✅      |
| Android |    ✅      |
| Web     |    ✅      |

## Checklist

- [X] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [X] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
