### PR TITLE
adding buffer as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "react-native": "*"
   },
   "dependencies": {
+    "buffer": "^6.0.3",
     "css-select": "^5.1.0",
     "css-tree": "^1.1.3",
     "warn-once": "0.1.1"


### PR DESCRIPTION
```
react-native-svg/src/utils/fetchData.ts: buffer could not be found within the project
```

Since `buffer` is required to build the library, it should be specified in dependencies.