### PR TITLE
Remove explicit value for `usesMapBufferForStateData` template parameter

### DIFF
--- a/common/cpp/react/renderer/components/rnsvg/RNSVGConcreteShadowNode.h
+++ b/common/cpp/react/renderer/components/rnsvg/RNSVGConcreteShadowNode.h
@@ -20,8 +20,7 @@ class RNSVGConcreteShadowNode : public ConcreteShadowNode<
       RNSVGLayoutableShadowNode,
       PropsT,
       ViewEventEmitter,
-      StateData,
-      false>;
+      StateData>;
 
   using ConcreteViewProps = PropsT;
 

--- a/common/cpp/react/renderer/components/rnsvg/RNSVGConcreteShadowNode.h
+++ b/common/cpp/react/renderer/components/rnsvg/RNSVGConcreteShadowNode.h
@@ -13,8 +13,7 @@ class RNSVGConcreteShadowNode : public ConcreteShadowNode<
                                     RNSVGLayoutableShadowNode,
                                     PropsT,
                                     ViewEventEmitter,
-                                    StateData,
-                                    false> {
+                                    StateData> {
  public:
   using BaseShadowNode = ConcreteShadowNode<
       concreteComponentName,


### PR DESCRIPTION
# Summary

This wasn't present in older versions of React Native, and is removed from newer versions. It was kind of meant to be hidden, with the default value used, but was fully public. Let's rely on the default `false` instead of specifying an explicit value, for compatibility of versions of RN without it.

## Test Plan

GitHub Actions building the project
