### PR TITLE
fix: update extended component for DefsView

### DIFF
--- a/android/src/main/java/com/horcrux/svg/DefsView.java
+++ b/android/src/main/java/com/horcrux/svg/DefsView.java
@@ -9,14 +9,25 @@
 package com.horcrux.svg;
 
 import android.annotation.SuppressLint;
+import android.graphics.Canvas;
+import android.graphics.Paint;
+import android.graphics.Path;
 import android.view.View;
 import com.facebook.react.bridge.ReactContext;
 
 @SuppressLint("ViewConstructor")
-class DefsView extends GroupView {
+class DefsView extends RenderableView {
 
   public DefsView(ReactContext reactContext) {
     super(reactContext);
+  }
+
+  @Override
+  void draw(Canvas canvas, Paint paint, float opacity) {}
+
+  @Override
+  Path getPath(Canvas canvas, Paint paint) {
+    return null;
   }
 
   void saveDefinition() {

--- a/android/src/main/java/com/horcrux/svg/DefsView.java
+++ b/android/src/main/java/com/horcrux/svg/DefsView.java
@@ -9,20 +9,15 @@
 package com.horcrux.svg;
 
 import android.annotation.SuppressLint;
-import android.graphics.Canvas;
-import android.graphics.Paint;
 import android.view.View;
 import com.facebook.react.bridge.ReactContext;
 
 @SuppressLint("ViewConstructor")
-class DefsView extends DefinitionView {
+class DefsView extends GroupView {
 
   public DefsView(ReactContext reactContext) {
     super(reactContext);
   }
-
-  @Override
-  void draw(Canvas canvas, Paint paint, float opacity) {}
 
   void saveDefinition() {
     for (int i = 0; i < getChildCount(); i++) {

--- a/apps/common/test/Test2615.tsx
+++ b/apps/common/test/Test2615.tsx
@@ -1,0 +1,24 @@
+import {Svg, Defs, Pattern, Path, Rect} from 'react-native-svg';
+
+export default function Test2615() {
+  return (
+    <Svg color={'red'}>
+      <Defs>
+        <Pattern
+          id={'pattern'}
+          patternUnits="userSpaceOnUse"
+          width={9}
+          height={9}>
+          <Path d="M -1,2 l 6,0" stroke="currentColor" strokeWidth={3} />
+        </Pattern>
+      </Defs>
+      <Rect
+        x={0}
+        y={0}
+        width="100%"
+        height="100%"
+        fill={`url(#${'pattern'})`}
+      />
+    </Svg>
+  );
+}

--- a/apps/common/test/Test2616.tsx
+++ b/apps/common/test/Test2616.tsx
@@ -1,0 +1,28 @@
+import {Defs, G, Path, Pattern, Rect, Svg} from 'react-native-svg';
+
+export default function IconWithHexAlpha() {
+  return (
+    <Svg height={'50'}>
+      <Defs>
+        <Pattern
+          id={'pattern'}
+          patternUnits="userSpaceOnUse"
+          width={9}
+          height={9}>
+          <G stroke="#00000030" strokeWidth={3}>
+            <Path d="M0,9 l9,-9" />
+            <Path d="M-1,1 l2,-2" />
+            <Path d="M8,10 l2,-2" />
+          </G>
+        </Pattern>
+      </Defs>
+      <Rect
+        x={0}
+        y={0}
+        width="100%"
+        height="100%"
+        fill={`url(#${'pattern'})`}
+      />
+    </Svg>
+  );
+}

--- a/apps/common/test/Test2616.tsx
+++ b/apps/common/test/Test2616.tsx
@@ -2,7 +2,7 @@ import {Defs, G, Path, Pattern, Rect, Svg} from 'react-native-svg';
 
 export default function IconWithHexAlpha() {
   return (
-    <Svg height={'50'}>
+    <Svg height={'500'} width={'500'}>
       <Defs>
         <Pattern
           id={'pattern'}

--- a/apps/common/test/index.tsx
+++ b/apps/common/test/index.tsx
@@ -35,6 +35,8 @@ import Test2417 from './Test2417';
 import Test2455 from './Test2455';
 import Test2471 from './Test2471';
 import Test2520 from './Test2520';
+import Test2615 from './Test2615';
+import Test2616 from './Test2616';
 
 export default function App() {
   return <ColorTest />;


### PR DESCRIPTION
That problem occurred only on the Android platform because we missed the correct implementation for the Defs component.

# Summary
`Defs` should extend from `RenderableView` and should have base methods. Previously, `DefsView` was extended by `DefinitionView`

Fixed issues:
#2615 
#2616 

## Test Plan

You can easily run an example application with Test2615 and Test2616, which I've created.

### What's required for testing (prerequisites)?
The app shouldn't crash.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| Android |    ✅      |

