### PR TITLE
fix: use `providers.exec` to enable `configuration-cache`

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -44,7 +44,12 @@ def resolveReactNativeDirectory() {
   }
 
   // Fallback to node resolver for custom directory structures like monorepos.
-  def reactNativePackage = file(["node", "--print", "require.resolve('react-native/package.json')"].execute(null, rootDir).text.trim())
+  def reactNativePackage = file(
+      providers.exec {
+          workingDir(rootDir)
+          commandLine("node", "--print", "require.resolve('react-native/package.json')")
+      }.standardOutput.asText.get().trim()
+  )
   if (reactNativePackage.exists()) {
     return reactNativePackage.parentFile
   }


### PR DESCRIPTION
## Description

Fixes:
```
Starting an external process 'node --print require.resolve('react-native/package.json')' during configuration time is unsupported
``` 
when `configuration-cache` is enabled.

## Changes

Replace `execute` with `providers.exec`. You can read more about it here: https://docs.gradle.org/8.13/userguide/configuration_cache.html#config_cache:requirements:external_processes. 

## Test code and steps to reproduce

- build project with `configuration-cache` flag ✅ 