### PR TITLE
chore: silence irrelevant codegen warnings

### DIFF
--- a/android/src/main/jni/CMakeLists.txt
+++ b/android/src/main/jni/CMakeLists.txt
@@ -19,6 +19,7 @@ add_compile_options(
   -Wall
   -Wpedantic
   -Wno-gnu-zero-variadic-macro-arguments
+  -Wno-dollar-in-identifier-extension
 )
 
 file(GLOB rnsvg_SRCS CONFIGURE_DEPENDS *.cpp ${RNS_COMMON_DIR}/react/renderer/components/rnsvg/*.cpp)


### PR DESCRIPTION
# Summary

Silencing warnings generated by generated codegen code. Analogous PR to https://github.com/software-mansion/react-native-screens/pull/2707

Fixes

![Screenshot 2025-05-08 at 17 17 43](https://github.com/user-attachments/assets/3e6cf2b0-1370-4ff2-8656-844082aec9d1)


## Test Plan

🚀 
