### PR TITLE
fix: nullPointerException in GroupView when drawing bitmap on Android 10 and older

### DIFF
--- a/android/src/main/java/com/horcrux/svg/GroupView.java
+++ b/android/src/main/java/com/horcrux/svg/GroupView.java
@@ -165,7 +165,9 @@ class GroupView extends RenderableView {
       int saveCount = canvas.save();
       canvas.setMatrix(null);
       mLayerPaint.setAlpha((int) (mOpacity * 255));
-      canvas.drawBitmap(mLayerBitmap, 0, 0, mLayerPaint);
+      if (mLayerBitmap != null) {
+        canvas.drawBitmap(mLayerBitmap, 0, 0, mLayerPaint);
+      }
       canvas.restoreToCount(saveCount);
     }
     this.setClientRect(groupRect);


### PR DESCRIPTION
# Summary

Open Issue: [isRecycled() on a null object reference](https://github.com/software-mansion/react-native-svg/issues/2609) 

This PR addresses a sporadic crash that occurs specifically on Android 10 (API 29) and older when rendering SVGs.

* Although the code already handles the mLayerBitmap being null in an earlier section, the bitmap can still become null on Android 10 and below due to memory pressure or race conditions, ultimately leading to a crash.

* Differences in how Bitmap memory handled and Canvas drawing operations are handled in these versions, make them more susceptible to this issue.)
[Reference: Android Bitmap Memory Management](https://developer.android.com/topic/performance/graphics/manage-memory#recycle)

## Test Plan

Unfortunately, it is bit hard to recreate this behaviour and it is very sporadic.
I have patched this change in my app, and it has produced positive results. both for me and for some other users as well.
(https://github.com/software-mansion/react-native-svg/issues/2609#issuecomment-2648320909)

### What's required for testing (prerequisites)?
-

### What are the steps to reproduce (after prerequisites)?
-

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| Android |    ✅      |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [ ] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
