### PR TITLE
Add buffer as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "react-native": "*"
   },
   "dependencies": {
+    "buffer": "^5.5.0",
     "css-select": "^5.1.0",
     "css-tree": "^1.1.3",
     "warn-once": "0.1.1"


### PR DESCRIPTION
# Summary

buffer is used here https://github.com/software-mansion/react-native-svg/blame/15536f737388d66baf0d779dcbc7c2afc7ba1caa/src/utils/fetchData.ts#L2, but not declared as a dependency.

Fixes #2701 
