### PR TITLE
fix: handle error if clipPath is nil

### DIFF
--- a/apple/Elements/RNSVGClipPath.mm
+++ b/apple/Elements/RNSVGClipPath.mm
@@ -58,8 +58,12 @@ using namespace facebook::react;
 
 - (void)parseReference
 {
-  self.dirty = false;
-  [self.svgView defineClipPath:self clipPathName:self.name];
+  @try {
+    self.dirty = false;
+    [self.svgView defineClipPath:self clipPathName:self.name];
+  } @catch (NSException *exception) {
+    NSLog(@"Exception occurred: %@ - %@", exception.name, exception.reason);
+  }
 }
 
 - (BOOL)isSimpleClipPath

--- a/apps/common/test/Test2715.tsx
+++ b/apps/common/test/Test2715.tsx
@@ -1,0 +1,23 @@
+import {SafeAreaView, StyleSheet} from 'react-native';
+import {SvgUri} from 'react-native-svg';
+
+export default function Test2715() {
+  return (
+    <SafeAreaView style={styles.container}>
+      <SvgUri
+        uri="https://www.healthcoachinstitute.com/wp-content/uploads/2021/03/HCI-logo-symbol-color.svg"
+        width="100%"
+        height="100%"
+      />
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    backgroundColor: '#ecf0f1',
+    padding: 8,
+  },
+});

--- a/apps/common/test/index.tsx
+++ b/apps/common/test/index.tsx
@@ -36,6 +36,7 @@ import Test2455 from './Test2455';
 import Test2471 from './Test2471';
 import Test2520 from './Test2520';
 import Test2670 from './Test2670';
+import Test2715 from './Test2715';
 
 export default function App() {
   return <ColorTest />;


### PR DESCRIPTION
# Summary

That PR helped to solve issue #2715 

This issue occurs on the iOS platform because ``NSMutableDictionary<NSString *, RNSVGNode *>`` does not allow nil keys or values. In contrast, on Android, the ``Map<String, VirtualView>`` implementation permits null as a key, which prevents the same problem from occurring.

## Test Plan

You can easily test that solution by running the ``Test2715``

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅      |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [ ] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
