### PR TITLE
chore: turn off Hermes in paper-macos-example

### DIFF
--- a/apps/paper-macos-example/macos/Podfile
+++ b/apps/paper-macos-example/macos/Podfile
@@ -14,7 +14,7 @@ target 'PaperMacOSExample-macOS' do
 
   use_react_native!(
     :path => '../node_modules/react-native-macos',
-    :hermes_enabled => true,
+    :hermes_enabled => false,
     :fabric_enabled => false,
     # Flipper is not compatible w/ macOS
     :flipper_configuration => FlipperConfiguration.disabled,


### PR DESCRIPTION
# Summary

Turning off Hermes in the Podfile tends to crash the installation pods
Analogous changes in [react-native-reanimated](https://github.com/software-mansion/react-native-reanimated/blob/main/apps/macos-example/macos/Podfile#L16)

## Test Plan

``cd apps/paper-macos-example/macos/ && bundle exec pod install && bundle exec pod install``



## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| MacOS   |    ✅      |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [ ] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
