### PR TITLE
fix: dynamic node path resolution for Gradle sync in Android Studio

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -57,7 +57,6 @@ def resolveReactNativeDirectory() {
     }
   }
 
-    // Fallback to node resolver for custom directory structures like monorepos.
   def reactNativePackage = file(
       providers.exec {
           workingDir(rootDir)

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -43,11 +43,25 @@ def resolveReactNativeDirectory() {
     return file(reactNativeLocation)
   }
 
-  // Fallback to node resolver for custom directory structures like monorepos.
+  // Look up the node executable
+  def nodeExecutable = "node"
+  if (System.getenv("PATH") != null) {
+    def paths = System.getenv("PATH").split(File.pathSeparator)
+
+    for (path in paths) {
+      def candidate = new File(path, "node")
+      if (candidate.exists() && candidate.canExecute()) {
+        nodeExecutable = candidate.getAbsolutePath()
+        break
+      }
+    }
+  }
+
+    // Fallback to node resolver for custom directory structures like monorepos.
   def reactNativePackage = file(
       providers.exec {
           workingDir(rootDir)
-          commandLine("node", "--print", "require.resolve('react-native/package.json')")
+          commandLine(nodeExecutable, "--print", "require.resolve('react-native/package.json')")
       }.standardOutput.asText.get().trim()
   )
   if (reactNativePackage.exists()) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Print with the sync error. `A problem occurred starting process command node`
<img width="1475" height="735" alt="Captura de Tela 2025-07-25 às 16 59 03" src="https://github.com/user-attachments/assets/86096b35-02b4-45fc-8851-b9dd2424f757" />


This PR fixes a sync error that occurs when opening the app in Android Studio from the UI..

- Dynamic node path resolution in build.gradle


## Test Plan
- Open the app in Android Studio and sync successfully.

### What's required for testing (prerequisites)?
- 
### What are the steps to reproduce (after prerequisites)?
- 
## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌      |
| MacOS   |    ❌      |
| Android |    ✅      |
| Web     |    ❌      |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [ ] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
