### PR TITLE
fix: invalidate child SVG nodes on layout change

### DIFF
--- a/apps/common/test/Test2671.tsx
+++ b/apps/common/test/Test2671.tsx
@@ -1,0 +1,108 @@
+import {useState} from 'react';
+import {View, Button, Text, Dimensions, StyleSheet} from 'react-native';
+import Svg, {Line, Rect} from 'react-native-svg';
+
+const initialWidth = 150;
+
+const deviceHeight = Dimensions.get('window').height;
+
+export default function Test2671() {
+  const [width, setWidth] = useState(initialWidth);
+
+  const lineContainerStyles = {
+    width,
+    paddingTop: 40,
+  };
+  return (
+    <View style={styles.container}>
+      <Button
+        title={'Change width to ' + width}
+        onPress={() =>
+          setWidth(prev =>
+            prev === initialWidth ? initialWidth * 2 : initialWidth,
+          )
+        }
+      />
+      {/* NOT WORKING EXAMPLE */}
+      <View style={lineContainerStyles}>
+        <Text>Not working</Text>
+        <Svg height={4} width="100%" style={styles.dashedLineContainer}>
+          <Line
+            x2="100%"
+            x1="0"
+            stroke="red"
+            strokeWidth={4}
+            strokeDasharray="5, 2"
+          />
+        </Svg>
+      </View>
+      {/* NOT WORKING EXAMPLE */}
+      <View style={lineContainerStyles}>
+        <Text>Not working</Text>
+        <Svg height={50} width="100%">
+          <Rect
+            x="0"
+            y="0"
+            width="100%"
+            height={50}
+            stroke="red"
+            strokeWidth="1"
+            fill="yellow"
+          />
+        </Svg>
+      </View>
+      {/*
+       * WORKING EXAMPLE
+       * Difference
+       * - Svg -> overflow: "hidden"
+       * - Line -> x2={deviceHeight} (before there was 100%)
+       */}
+      <View style={lineContainerStyles}>
+        <Text>Working</Text>
+        <Svg
+          height={4}
+          width="100%"
+          style={[
+            {
+              overflow: 'hidden',
+            },
+            styles.dashedLineContainer,
+          ]}>
+          <Line
+            x2={deviceHeight}
+            x1="0"
+            stroke="red"
+            strokeWidth={4}
+            strokeDasharray="5, 2"
+          />
+        </Svg>
+      </View>
+      {/* WORKING EXAMPLE - ?? */}
+      <View style={lineContainerStyles}>
+        <Text>Not working</Text>
+        <Svg height={50} width="100%">
+          <Rect
+            x="0"
+            y="0"
+            width={deviceHeight}
+            height={50}
+            stroke="red"
+            strokeWidth="1"
+            fill="yellow"
+          />
+        </Svg>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    paddingTop: 300,
+  },
+  dashedLineContainer: {
+    bottom: -2,
+    height: 4,
+    position: 'absolute',
+  },
+});

--- a/apps/common/test/index.tsx
+++ b/apps/common/test/index.tsx
@@ -37,6 +37,7 @@ import Test2455 from './Test2455';
 import Test2471 from './Test2471';
 import Test2520 from './Test2520';
 import Test2670 from './Test2670';
+import Test2671 from './Test2671';
 
 export default function App() {
   return <ColorTest />;


### PR DESCRIPTION
# Summary
Fix the issue #2671 

Previously, the issue was that when the parent <View>’s width is changed at runtime (via useState or other dynamic styling), the <Line> | <Rect> inside an <Svg> with width="100%" does not redraw to fill the new width. Instead, it remains at the width it had when first mounted. 

This commit adds layout tracking via `_lastBounds` and triggers a recursive invalidation of all `RNSVGNode` subviews during `layoutSubviews` only when the bounds change.

## Test Plan

You can easily test that solution by running the `Test2671`

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅      |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [ ] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
