### PR TITLE
feat: add handling pod install failure in apple CI

### DIFF
--- a/.github/workflows/e2e-ios.yml
+++ b/.github/workflows/e2e-ios.yml
@@ -62,6 +62,20 @@ jobs:
             ${{ runner.os }}-pods-${{ matrix.working-directory }}-
 
       - name: Install Pods
+        id: install_pods
+        continue-on-error: true
+        working-directory: apps/${{ matrix.working-directory }}/ios
+        run: bundle install && bundle exec pod install
+
+      - if: steps.install_pods.outcome == 'failure'
+        id: remove_pods
+        name: Remove pods
+        working-directory: apps/${{ matrix.working-directory }}/ios
+        run: rm -rf build Pods Podfile.lock
+
+      - if: steps.remove_pods.outcome == 'success'
+        id: reinstall_pods
+        name: Reinstall pods
         working-directory: apps/${{ matrix.working-directory }}/ios
         run: bundle install && bundle exec pod install
 

--- a/.github/workflows/ios-build-test.yml
+++ b/.github/workflows/ios-build-test.yml
@@ -65,6 +65,20 @@ jobs:
             ${{ runner.os }}-pods-${{ matrix.working-directory }}-
 
       - name: Install Pods
+        id: install_pods
+        continue-on-error: true
+        working-directory: apps/${{ matrix.working-directory }}/ios
+        run: bundle install && bundle exec pod install
+
+      - if: steps.install_pods.outcome == 'failure'
+        id: remove_pods
+        name: Remove pods
+        working-directory: apps/${{ matrix.working-directory }}/ios
+        run: rm -rf build Pods Podfile.lock
+
+      - if: steps.remove_pods.outcome == 'success'
+        id: reinstall_pods
+        name: Reinstall pods
         working-directory: apps/${{ matrix.working-directory }}/ios
         run: bundle install && bundle exec pod install
 

--- a/.github/workflows/macos-build-test.yml
+++ b/.github/workflows/macos-build-test.yml
@@ -65,6 +65,20 @@ jobs:
             ${{ runner.os }}-pods-${{ matrix.working-directory }}-
 
       - name: Install Pods
+        id: install_pods
+        continue-on-error: true
+        working-directory: apps/${{ matrix.working-directory }}/macos
+        run: bundle install && bundle exec pod install
+
+      - if: steps.install_pods.outcome == 'failure'
+        id: remove_pods
+        name: Remove pods
+        working-directory: apps/${{ matrix.working-directory }}/macos
+        run: rm -rf build Pods Podfile.lock
+
+      - if: steps.remove_pods.outcome == 'success'
+        id: reinstall_pods
+        name: Reinstall pods
         working-directory: apps/${{ matrix.working-directory }}/macos
         run: bundle install && bundle exec pod install
 


### PR DESCRIPTION
# Summary

This PR improve `Example iOS check`, `E2E iOS` and `Example macOS check` CI workflows by adding to them extra steps: 
- remove pods if `Install Pods` step failed
- reinstall pods if `Remove pods` step was successful

## Test Plan

Run `Example iOS check`, `E2E iOS` and `Example macOS check` CI workflows.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅      |
| MacOS   |    ✅      |
| Android |    ❌      |
| Web     |    ❌      |
