### PR TITLE
fix: setting strokeMiterLimit prop

### DIFF
--- a/android/src/main/java/com/horcrux/svg/RenderableView.java
+++ b/android/src/main/java/com/horcrux/svg/RenderableView.java
@@ -604,7 +604,7 @@ public abstract class RenderableView extends VirtualView implements ReactHitSlop
     paint.setStyle(Paint.Style.STROKE);
     paint.setStrokeCap(strokeLinecap);
     paint.setStrokeJoin(strokeLinejoin);
-    paint.setStrokeMiter(strokeMiterlimit * mScale);
+    paint.setStrokeMiter(strokeMiterlimit);
     paint.setStrokeWidth((float) strokeWidth);
     setupPaint(paint, opacity, stroke);
 

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGCircleManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGCircleManagerDelegate.java
@@ -95,7 +95,7 @@ public class RNSVGCircleManagerDelegate<T extends View, U extends BaseViewManage
         mViewManager.setStrokeDashoffset(view, value == null ? 0f : ((Double) value).floatValue());
         break;
       case "strokeMiterlimit":
-        mViewManager.setStrokeMiterlimit(view, value == null ? 0f : ((Double) value).floatValue());
+        mViewManager.setStrokeMiterlimit(view, value == null ? 4f : ((Double) value).floatValue());
         break;
       case "vectorEffect":
         mViewManager.setVectorEffect(view, value == null ? 0 : ((Double) value).intValue());

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGClipPathManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGClipPathManagerDelegate.java
@@ -95,7 +95,7 @@ public class RNSVGClipPathManagerDelegate<T extends View, U extends BaseViewMana
         mViewManager.setStrokeDashoffset(view, value == null ? 0f : ((Double) value).floatValue());
         break;
       case "strokeMiterlimit":
-        mViewManager.setStrokeMiterlimit(view, value == null ? 0f : ((Double) value).floatValue());
+        mViewManager.setStrokeMiterlimit(view, value == null ? 4f : ((Double) value).floatValue());
         break;
       case "vectorEffect":
         mViewManager.setVectorEffect(view, value == null ? 0 : ((Double) value).intValue());

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGEllipseManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGEllipseManagerDelegate.java
@@ -95,7 +95,7 @@ public class RNSVGEllipseManagerDelegate<T extends View, U extends BaseViewManag
         mViewManager.setStrokeDashoffset(view, value == null ? 0f : ((Double) value).floatValue());
         break;
       case "strokeMiterlimit":
-        mViewManager.setStrokeMiterlimit(view, value == null ? 0f : ((Double) value).floatValue());
+        mViewManager.setStrokeMiterlimit(view, value == null ? 4f : ((Double) value).floatValue());
         break;
       case "vectorEffect":
         mViewManager.setVectorEffect(view, value == null ? 0 : ((Double) value).intValue());

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGForeignObjectManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGForeignObjectManagerDelegate.java
@@ -95,7 +95,7 @@ public class RNSVGForeignObjectManagerDelegate<T extends View, U extends BaseVie
         mViewManager.setStrokeDashoffset(view, value == null ? 0f : ((Double) value).floatValue());
         break;
       case "strokeMiterlimit":
-        mViewManager.setStrokeMiterlimit(view, value == null ? 0f : ((Double) value).floatValue());
+        mViewManager.setStrokeMiterlimit(view, value == null ? 4f : ((Double) value).floatValue());
         break;
       case "vectorEffect":
         mViewManager.setVectorEffect(view, value == null ? 0 : ((Double) value).intValue());

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGGroupManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGGroupManagerDelegate.java
@@ -95,7 +95,7 @@ public class RNSVGGroupManagerDelegate<T extends View, U extends BaseViewManager
         mViewManager.setStrokeDashoffset(view, value == null ? 0f : ((Double) value).floatValue());
         break;
       case "strokeMiterlimit":
-        mViewManager.setStrokeMiterlimit(view, value == null ? 0f : ((Double) value).floatValue());
+        mViewManager.setStrokeMiterlimit(view, value == null ? 4f : ((Double) value).floatValue());
         break;
       case "vectorEffect":
         mViewManager.setVectorEffect(view, value == null ? 0 : ((Double) value).intValue());

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGImageManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGImageManagerDelegate.java
@@ -96,7 +96,7 @@ public class RNSVGImageManagerDelegate<T extends View, U extends BaseViewManager
         mViewManager.setStrokeDashoffset(view, value == null ? 0f : ((Double) value).floatValue());
         break;
       case "strokeMiterlimit":
-        mViewManager.setStrokeMiterlimit(view, value == null ? 0f : ((Double) value).floatValue());
+        mViewManager.setStrokeMiterlimit(view, value == null ? 4f : ((Double) value).floatValue());
         break;
       case "vectorEffect":
         mViewManager.setVectorEffect(view, value == null ? 0 : ((Double) value).intValue());

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGLineManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGLineManagerDelegate.java
@@ -95,7 +95,7 @@ public class RNSVGLineManagerDelegate<T extends View, U extends BaseViewManager<
         mViewManager.setStrokeDashoffset(view, value == null ? 0f : ((Double) value).floatValue());
         break;
       case "strokeMiterlimit":
-        mViewManager.setStrokeMiterlimit(view, value == null ? 0f : ((Double) value).floatValue());
+        mViewManager.setStrokeMiterlimit(view, value == null ? 4f : ((Double) value).floatValue());
         break;
       case "vectorEffect":
         mViewManager.setVectorEffect(view, value == null ? 0 : ((Double) value).intValue());

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGMarkerManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGMarkerManagerDelegate.java
@@ -95,7 +95,7 @@ public class RNSVGMarkerManagerDelegate<T extends View, U extends BaseViewManage
         mViewManager.setStrokeDashoffset(view, value == null ? 0f : ((Double) value).floatValue());
         break;
       case "strokeMiterlimit":
-        mViewManager.setStrokeMiterlimit(view, value == null ? 0f : ((Double) value).floatValue());
+        mViewManager.setStrokeMiterlimit(view, value == null ? 4f : ((Double) value).floatValue());
         break;
       case "vectorEffect":
         mViewManager.setVectorEffect(view, value == null ? 0 : ((Double) value).intValue());

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGMaskManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGMaskManagerDelegate.java
@@ -95,7 +95,7 @@ public class RNSVGMaskManagerDelegate<T extends View, U extends BaseViewManager<
         mViewManager.setStrokeDashoffset(view, value == null ? 0f : ((Double) value).floatValue());
         break;
       case "strokeMiterlimit":
-        mViewManager.setStrokeMiterlimit(view, value == null ? 0f : ((Double) value).floatValue());
+        mViewManager.setStrokeMiterlimit(view, value == null ? 4f : ((Double) value).floatValue());
         break;
       case "vectorEffect":
         mViewManager.setVectorEffect(view, value == null ? 0 : ((Double) value).intValue());

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGPathManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGPathManagerDelegate.java
@@ -95,7 +95,7 @@ public class RNSVGPathManagerDelegate<T extends View, U extends BaseViewManager<
         mViewManager.setStrokeDashoffset(view, value == null ? 0f : ((Double) value).floatValue());
         break;
       case "strokeMiterlimit":
-        mViewManager.setStrokeMiterlimit(view, value == null ? 0f : ((Double) value).floatValue());
+        mViewManager.setStrokeMiterlimit(view, value == null ? 4f : ((Double) value).floatValue());
         break;
       case "vectorEffect":
         mViewManager.setVectorEffect(view, value == null ? 0 : ((Double) value).intValue());

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGPatternManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGPatternManagerDelegate.java
@@ -95,7 +95,7 @@ public class RNSVGPatternManagerDelegate<T extends View, U extends BaseViewManag
         mViewManager.setStrokeDashoffset(view, value == null ? 0f : ((Double) value).floatValue());
         break;
       case "strokeMiterlimit":
-        mViewManager.setStrokeMiterlimit(view, value == null ? 0f : ((Double) value).floatValue());
+        mViewManager.setStrokeMiterlimit(view, value == null ? 4f : ((Double) value).floatValue());
         break;
       case "vectorEffect":
         mViewManager.setVectorEffect(view, value == null ? 0 : ((Double) value).intValue());

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGRectManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGRectManagerDelegate.java
@@ -95,7 +95,7 @@ public class RNSVGRectManagerDelegate<T extends View, U extends BaseViewManager<
         mViewManager.setStrokeDashoffset(view, value == null ? 0f : ((Double) value).floatValue());
         break;
       case "strokeMiterlimit":
-        mViewManager.setStrokeMiterlimit(view, value == null ? 0f : ((Double) value).floatValue());
+        mViewManager.setStrokeMiterlimit(view, value == null ? 4f : ((Double) value).floatValue());
         break;
       case "vectorEffect":
         mViewManager.setVectorEffect(view, value == null ? 0 : ((Double) value).intValue());

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGSymbolManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGSymbolManagerDelegate.java
@@ -95,7 +95,7 @@ public class RNSVGSymbolManagerDelegate<T extends View, U extends BaseViewManage
         mViewManager.setStrokeDashoffset(view, value == null ? 0f : ((Double) value).floatValue());
         break;
       case "strokeMiterlimit":
-        mViewManager.setStrokeMiterlimit(view, value == null ? 0f : ((Double) value).floatValue());
+        mViewManager.setStrokeMiterlimit(view, value == null ? 4f : ((Double) value).floatValue());
         break;
       case "vectorEffect":
         mViewManager.setVectorEffect(view, value == null ? 0 : ((Double) value).intValue());

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGTSpanManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGTSpanManagerDelegate.java
@@ -95,7 +95,7 @@ public class RNSVGTSpanManagerDelegate<T extends View, U extends BaseViewManager
         mViewManager.setStrokeDashoffset(view, value == null ? 0f : ((Double) value).floatValue());
         break;
       case "strokeMiterlimit":
-        mViewManager.setStrokeMiterlimit(view, value == null ? 0f : ((Double) value).floatValue());
+        mViewManager.setStrokeMiterlimit(view, value == null ? 4f : ((Double) value).floatValue());
         break;
       case "vectorEffect":
         mViewManager.setVectorEffect(view, value == null ? 0 : ((Double) value).intValue());

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGTextManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGTextManagerDelegate.java
@@ -95,7 +95,7 @@ public class RNSVGTextManagerDelegate<T extends View, U extends BaseViewManager<
         mViewManager.setStrokeDashoffset(view, value == null ? 0f : ((Double) value).floatValue());
         break;
       case "strokeMiterlimit":
-        mViewManager.setStrokeMiterlimit(view, value == null ? 0f : ((Double) value).floatValue());
+        mViewManager.setStrokeMiterlimit(view, value == null ? 4f : ((Double) value).floatValue());
         break;
       case "vectorEffect":
         mViewManager.setVectorEffect(view, value == null ? 0 : ((Double) value).intValue());

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGTextPathManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGTextPathManagerDelegate.java
@@ -95,7 +95,7 @@ public class RNSVGTextPathManagerDelegate<T extends View, U extends BaseViewMana
         mViewManager.setStrokeDashoffset(view, value == null ? 0f : ((Double) value).floatValue());
         break;
       case "strokeMiterlimit":
-        mViewManager.setStrokeMiterlimit(view, value == null ? 0f : ((Double) value).floatValue());
+        mViewManager.setStrokeMiterlimit(view, value == null ? 4f : ((Double) value).floatValue());
         break;
       case "vectorEffect":
         mViewManager.setVectorEffect(view, value == null ? 0 : ((Double) value).intValue());

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGUseManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNSVGUseManagerDelegate.java
@@ -95,7 +95,7 @@ public class RNSVGUseManagerDelegate<T extends View, U extends BaseViewManager<T
         mViewManager.setStrokeDashoffset(view, value == null ? 0f : ((Double) value).floatValue());
         break;
       case "strokeMiterlimit":
-        mViewManager.setStrokeMiterlimit(view, value == null ? 0f : ((Double) value).floatValue());
+        mViewManager.setStrokeMiterlimit(view, value == null ? 4f : ((Double) value).floatValue());
         break;
       case "vectorEffect":
         mViewManager.setVectorEffect(view, value == null ? 0 : ((Double) value).intValue());

--- a/apple/RNSVGRenderable.mm
+++ b/apple/RNSVGRenderable.mm
@@ -45,6 +45,7 @@ static RNSVGRenderable *_contextElement;
     _strokeOpacity = 1;
     _strokeWidth = [RNSVGLength lengthWithNumber:1];
     _fillRule = kRNSVGCGFCRuleNonzero;
+    _strokeMiterlimit = 4.0;
   }
   return self;
 }
@@ -236,7 +237,7 @@ static RNSVGRenderable *_contextElement;
   _stroke = nil;
   _strokeLinecap = kCGLineCapButt;
   _strokeLinejoin = kCGLineJoinMiter;
-  _strokeMiterlimit = 0;
+  _strokeMiterlimit = 4.0;
   _strokeDasharray = nil;
   _strokeDashoffset = 0;
   _vectorEffect = kRNSVGVectorEffectDefault;
@@ -585,6 +586,9 @@ UInt32 saturate(CGFloat value)
     CGContextSetLineWidth(context, width);
     CGContextSetLineCap(context, self.strokeLinecap);
     CGContextSetLineJoin(context, self.strokeLinejoin);
+    if (self.strokeLinejoin == kCGLineJoinMiter) {
+      CGContextSetMiterLimit(context, self.strokeMiterlimit);
+    }
     NSArray<RNSVGLength *> *strokeDasharray = self.strokeDasharray;
     NSUInteger count = strokeDasharray.count;
 

--- a/apps/fabric-example/ios/Podfile.lock
+++ b/apps/fabric-example/ios/Podfile.lock
@@ -1954,7 +1954,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNSVG (15.12.0):
+  - RNSVG (15.12.1):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1977,9 +1977,9 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNSVG/common (= 15.12.0)
+    - RNSVG/common (= 15.12.1)
     - Yoga
-  - RNSVG/common (15.12.0):
+  - RNSVG/common (15.12.1):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2324,7 +2324,7 @@ SPEC CHECKSUMS:
   RNGestureHandler: 5d8431415d4b8518e86e289e9ad5bb9be78f6dba
   RNReanimated: 8b24b49fc13fce9a6e1729ccff645a63d2b7a6d1
   RNScreens: c5c07a86e4088ce92f0d3854082250dfa9c61f75
-  RNSVG: 50819276c95d91ccd8fbe5cfea7e09a416c9beaa
+  RNSVG: ab2249cc665e5d0b2d30657a766a86c99a649a65
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: c758bfb934100bb4bf9cbaccb52557cee35e8bdf
 

--- a/apps/paper-example/ios/Podfile.lock
+++ b/apps/paper-example/ios/Podfile.lock
@@ -1645,7 +1645,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNSVG (15.10.0):
+  - RNSVG (15.12.1):
     - React-Core
   - SocketRocket (0.7.1)
   - Yoga (0.0.0)
@@ -1940,7 +1940,7 @@ SPEC CHECKSUMS:
   RNGestureHandler: 511250b190a284388f9dd0d2e56c1df76f14cfb8
   RNReanimated: 3e6072b3d49d4fc687b8f1ba3022f0fdc0b43969
   RNScreens: c7ceced6a8384cb9be5e7a5e88e9e714401fd958
-  RNSVG: 58bad41c581b62cac6265c2899f8f943db527159
+  RNSVG: 61b5de449d8daa7b75da111990fee37baeb4a6f2
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: f8ec45ce98bba1bc93dd28f2ee37215180e6d2b6
 

--- a/src/fabric/CircleNativeComponent.ts
+++ b/src/fabric/CircleNativeComponent.ts
@@ -43,7 +43,7 @@ interface SvgRenderableCommonProps {
   strokeLinejoin?: WithDefault<Int32, 0>;
   strokeDasharray?: UnsafeMixed<ReadonlyArray<NumberProp> | NumberProp>;
   strokeDashoffset?: Float;
-  strokeMiterlimit?: Float;
+  strokeMiterlimit?: WithDefault<Float, 4.0>;
   vectorEffect?: WithDefault<Int32, 0>;
   propList?: ReadonlyArray<string>;
   filter?: string;

--- a/src/fabric/ClipPathNativeComponent.ts
+++ b/src/fabric/ClipPathNativeComponent.ts
@@ -43,7 +43,7 @@ interface SvgRenderableCommonProps {
   strokeLinejoin?: WithDefault<Int32, 0>;
   strokeDasharray?: UnsafeMixed<ReadonlyArray<NumberProp> | NumberProp>;
   strokeDashoffset?: Float;
-  strokeMiterlimit?: Float;
+  strokeMiterlimit?: WithDefault<Float, 4.0>;
   vectorEffect?: WithDefault<Int32, 0>;
   propList?: ReadonlyArray<string>;
   filter?: string;

--- a/src/fabric/EllipseNativeComponent.ts
+++ b/src/fabric/EllipseNativeComponent.ts
@@ -43,7 +43,7 @@ interface SvgRenderableCommonProps {
   strokeLinejoin?: WithDefault<Int32, 0>;
   strokeDasharray?: UnsafeMixed<ReadonlyArray<NumberProp> | NumberProp>;
   strokeDashoffset?: Float;
-  strokeMiterlimit?: Float;
+  strokeMiterlimit?: WithDefault<Float, 4.0>;
   vectorEffect?: WithDefault<Int32, 0>;
   propList?: ReadonlyArray<string>;
   filter?: string;

--- a/src/fabric/ForeignObjectNativeComponent.ts
+++ b/src/fabric/ForeignObjectNativeComponent.ts
@@ -43,7 +43,7 @@ interface SvgRenderableCommonProps {
   strokeLinejoin?: WithDefault<Int32, 0>;
   strokeDasharray?: UnsafeMixed<ReadonlyArray<NumberProp> | NumberProp>;
   strokeDashoffset?: Float;
-  strokeMiterlimit?: Float;
+  strokeMiterlimit?: WithDefault<Float, 4.0>;
   vectorEffect?: WithDefault<Int32, 0>;
   propList?: ReadonlyArray<string>;
   filter?: string;

--- a/src/fabric/GroupNativeComponent.ts
+++ b/src/fabric/GroupNativeComponent.ts
@@ -43,7 +43,7 @@ interface SvgRenderableCommonProps {
   strokeLinejoin?: WithDefault<Int32, 0>;
   strokeDasharray?: UnsafeMixed<ReadonlyArray<NumberProp> | NumberProp>;
   strokeDashoffset?: Float;
-  strokeMiterlimit?: Float;
+  strokeMiterlimit?: WithDefault<Float, 4.0>;
   vectorEffect?: WithDefault<Int32, 0>;
   propList?: ReadonlyArray<string>;
   filter?: string;

--- a/src/fabric/ImageNativeComponent.ts
+++ b/src/fabric/ImageNativeComponent.ts
@@ -56,7 +56,7 @@ interface SvgRenderableCommonProps {
   strokeLinejoin?: WithDefault<Int32, 0>;
   strokeDasharray?: UnsafeMixed<ReadonlyArray<NumberProp> | NumberProp>;
   strokeDashoffset?: Float;
-  strokeMiterlimit?: Float;
+  strokeMiterlimit?: WithDefault<Float, 4.0>;
   vectorEffect?: WithDefault<Int32, 0>;
   propList?: ReadonlyArray<string>;
   filter?: string;

--- a/src/fabric/LineNativeComponent.ts
+++ b/src/fabric/LineNativeComponent.ts
@@ -43,7 +43,7 @@ interface SvgRenderableCommonProps {
   strokeLinejoin?: WithDefault<Int32, 0>;
   strokeDasharray?: UnsafeMixed<ReadonlyArray<NumberProp> | NumberProp>;
   strokeDashoffset?: Float;
-  strokeMiterlimit?: Float;
+  strokeMiterlimit?: WithDefault<Float, 4.0>;
   vectorEffect?: WithDefault<Int32, 0>;
   propList?: ReadonlyArray<string>;
   filter?: string;

--- a/src/fabric/MarkerNativeComponent.ts
+++ b/src/fabric/MarkerNativeComponent.ts
@@ -43,7 +43,7 @@ interface SvgRenderableCommonProps {
   strokeLinejoin?: WithDefault<Int32, 0>;
   strokeDasharray?: UnsafeMixed<ReadonlyArray<NumberProp> | NumberProp>;
   strokeDashoffset?: Float;
-  strokeMiterlimit?: Float;
+  strokeMiterlimit?: WithDefault<Float, 4.0>;
   vectorEffect?: WithDefault<Int32, 0>;
   propList?: ReadonlyArray<string>;
   filter?: string;

--- a/src/fabric/MaskNativeComponent.ts
+++ b/src/fabric/MaskNativeComponent.ts
@@ -43,7 +43,7 @@ interface SvgRenderableCommonProps {
   strokeLinejoin?: WithDefault<Int32, 0>;
   strokeDasharray?: UnsafeMixed<ReadonlyArray<NumberProp> | NumberProp>;
   strokeDashoffset?: Float;
-  strokeMiterlimit?: Float;
+  strokeMiterlimit?: WithDefault<Float, 4.0>;
   vectorEffect?: WithDefault<Int32, 0>;
   propList?: ReadonlyArray<string>;
   filter?: string;

--- a/src/fabric/PathNativeComponent.ts
+++ b/src/fabric/PathNativeComponent.ts
@@ -43,7 +43,7 @@ interface SvgRenderableCommonProps {
   strokeLinejoin?: WithDefault<Int32, 0>;
   strokeDasharray?: UnsafeMixed<ReadonlyArray<NumberProp> | NumberProp>;
   strokeDashoffset?: Float;
-  strokeMiterlimit?: Float;
+  strokeMiterlimit?: WithDefault<Float, 4.0>;
   vectorEffect?: WithDefault<Int32, 0>;
   propList?: ReadonlyArray<string>;
   filter?: string;

--- a/src/fabric/PatternNativeComponent.ts
+++ b/src/fabric/PatternNativeComponent.ts
@@ -43,7 +43,7 @@ interface SvgRenderableCommonProps {
   strokeLinejoin?: WithDefault<Int32, 0>;
   strokeDasharray?: UnsafeMixed<ReadonlyArray<NumberProp> | NumberProp>;
   strokeDashoffset?: Float;
-  strokeMiterlimit?: Float;
+  strokeMiterlimit?: WithDefault<Float, 4.0>;
   vectorEffect?: WithDefault<Int32, 0>;
   propList?: ReadonlyArray<string>;
   filter?: string;

--- a/src/fabric/RectNativeComponent.ts
+++ b/src/fabric/RectNativeComponent.ts
@@ -43,7 +43,7 @@ interface SvgRenderableCommonProps {
   strokeLinejoin?: WithDefault<Int32, 0>;
   strokeDasharray?: UnsafeMixed<ReadonlyArray<NumberProp> | NumberProp>;
   strokeDashoffset?: Float;
-  strokeMiterlimit?: Float;
+  strokeMiterlimit?: WithDefault<Float, 4.0>;
   vectorEffect?: WithDefault<Int32, 0>;
   propList?: ReadonlyArray<string>;
   filter?: string;

--- a/src/fabric/SymbolNativeComponent.ts
+++ b/src/fabric/SymbolNativeComponent.ts
@@ -43,7 +43,7 @@ interface SvgRenderableCommonProps {
   strokeLinejoin?: WithDefault<Int32, 0>;
   strokeDasharray?: UnsafeMixed<ReadonlyArray<NumberProp> | NumberProp>;
   strokeDashoffset?: Float;
-  strokeMiterlimit?: Float;
+  strokeMiterlimit?: WithDefault<Float, 4.0>;
   vectorEffect?: WithDefault<Int32, 0>;
   propList?: ReadonlyArray<string>;
   filter?: string;

--- a/src/fabric/TSpanNativeComponent.ts
+++ b/src/fabric/TSpanNativeComponent.ts
@@ -43,7 +43,7 @@ interface SvgRenderableCommonProps {
   strokeLinejoin?: WithDefault<Int32, 0>;
   strokeDasharray?: UnsafeMixed<ReadonlyArray<NumberProp> | NumberProp>;
   strokeDashoffset?: Float;
-  strokeMiterlimit?: Float;
+  strokeMiterlimit?: WithDefault<Float, 4.0>;
   vectorEffect?: WithDefault<Int32, 0>;
   propList?: ReadonlyArray<string>;
   filter?: string;

--- a/src/fabric/TextNativeComponent.ts
+++ b/src/fabric/TextNativeComponent.ts
@@ -43,7 +43,7 @@ interface SvgRenderableCommonProps {
   strokeLinejoin?: WithDefault<Int32, 0>;
   strokeDasharray?: UnsafeMixed<ReadonlyArray<NumberProp> | NumberProp>;
   strokeDashoffset?: Float;
-  strokeMiterlimit?: Float;
+  strokeMiterlimit?: WithDefault<Float, 4.0>;
   vectorEffect?: WithDefault<Int32, 0>;
   propList?: ReadonlyArray<string>;
   filter?: string;

--- a/src/fabric/TextPathNativeComponent.ts
+++ b/src/fabric/TextPathNativeComponent.ts
@@ -43,7 +43,7 @@ interface SvgRenderableCommonProps {
   strokeLinejoin?: WithDefault<Int32, 0>;
   strokeDasharray?: UnsafeMixed<ReadonlyArray<NumberProp> | NumberProp>;
   strokeDashoffset?: Float;
-  strokeMiterlimit?: Float;
+  strokeMiterlimit?: WithDefault<Float, 4.0>;
   vectorEffect?: WithDefault<Int32, 0>;
   propList?: ReadonlyArray<string>;
   filter?: string;

--- a/src/fabric/UseNativeComponent.ts
+++ b/src/fabric/UseNativeComponent.ts
@@ -43,7 +43,7 @@ interface SvgRenderableCommonProps {
   strokeLinejoin?: WithDefault<Int32, 0>;
   strokeDasharray?: UnsafeMixed<ReadonlyArray<NumberProp> | NumberProp>;
   strokeDashoffset?: Float;
-  strokeMiterlimit?: Float;
+  strokeMiterlimit?: WithDefault<Float, 4.0>;
   vectorEffect?: WithDefault<Int32, 0>;
   propList?: ReadonlyArray<string>;
   filter?: string;


### PR DESCRIPTION
# Summary

This PR fixes: #2746 

- Previously, the strokeMiterlimit prop had no effect on iOS because it wasn’t being applied to the drawing context.
- Applied `strokeMiterlimit` correctly by calling `CGContextSetMiterLimit`.
- Ensures the prop now works as expected when using strokeLinejoin="miter".
- Structured default behavior on all architectures so that when strokeMiterlimit is not specified, it falls back to 4.0 (matching old arch implementation).

## Test Plan

1. Run the example from issue #2746.
2. Add the `strokeMiterlimit` prop to <SvgText> (e.g. strokeMiterlimit={2}).
3. Verify that the number 2 renders without spikes when using strokeLinejoin="miter" (miter is strokeLinejoin default value).
4. Remove the prop and confirm the default value is applied (strokeMiterlimit=4).
5. Test also with strokeLinejoin="round" and "bevel" to confirm consistent behavior.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅      |
| MacOS   |   ✅       |
| Android |    ✅      |
| Web     |    ❌      |

## Checklist

- [X] I have tested this on a simulator