### PR TITLE
feat: add onLoad call in SvhWithCssUri component

### DIFF
--- a/src/css/css.tsx
+++ b/src/css/css.tsx
@@ -850,6 +850,7 @@ export class SvgWithCssUri extends Component<UriProps, UriState> {
   async fetch(uri: string | null) {
     try {
       this.setState({ xml: uri ? await fetchText(uri) : null });
+      this.props.onLoad?.();
     } catch (e) {
       this.props.onError ? this.props.onError(e as Error) : console.error(e);
     }


### PR DESCRIPTION
# Summary

This PR fixes issue: #2735 
 
Previously, the `SvgWithCssUri` component exposed an onLoad prop, but it was never invoked. This PR ensures that onLoad is called once the remote SVG  has been successfully fetched.

## Test Plan
Pass `onLoad` function to `SvgWithCssUri` component and Confirm that the onLoad callback is called once the SVG has successfully loaded.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌      |
| MacOS   |    ❌      |
| Android |    ❌      |
| Web     |    ✅❌      |
