### PR TITLE
fix: prevent parent expansion by skipping width/height setting to 100% on absolute SVG

### DIFF
--- a/src/elements/Svg.tsx
+++ b/src/elements/Svg.tsx
@@ -125,8 +125,13 @@ export default class Svg extends Shape<SvgProps> {
       strokeLinecap,
       strokeLinejoin,
       strokeMiterlimit,
+      position,
     } = stylesAndProps;
-    if (width === undefined && height === undefined) {
+    if (
+      width === undefined &&
+      height === undefined &&
+      position !== 'absolute'
+    ) {
       width = height = '100%';
     }
 


### PR DESCRIPTION
# Summary

This PR fixes issue: #2689 
In the SVG component when we do not pass `width` and `height` props, we set them to 100%. This caused problems when position is set to absolute because the SVG would expand beyond its parent. I added an extra check to only set width/height to 100% if `position !== 'absolute'`.

## Test Plan
Run the example from issue: #2689 and check if Views are filled properly

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅      |
| MacOS   |    ✅      |
| Android |    ✅      |
| Web     |    ✅      |

## Checklist
- [X] I have tested this on a device and a simulator
