### PR TITLE
fix: add proper handling of percentage lengths

### DIFF
--- a/android/src/main/java/com/horcrux/svg/SvgView.java
+++ b/android/src/main/java/com/horcrux/svg/SvgView.java
@@ -343,7 +343,7 @@ public class SvgView extends ReactViewGroup implements ReactCompoundView, ReactC
     }
   }
 
-  private RectF getViewBox() {
+  public RectF getViewBox() {
     return new RectF(
         mMinX * mScale, mMinY * mScale, (mMinX + mVbWidth) * mScale, (mMinY + mVbHeight) * mScale);
   }

--- a/android/src/main/java/com/horcrux/svg/VirtualView.java
+++ b/android/src/main/java/com/horcrux/svg/VirtualView.java
@@ -436,11 +436,29 @@ public abstract class VirtualView extends ReactViewGroup {
   }
 
   double relativeOnWidth(SVGLength length) {
-    return relativeOn(length, getCanvasWidth());
+    SvgView svg = getSvgView();
+    float width;
+
+    if (length.unit == SVGLength.UnitType.PERCENTAGE && svg != null && svg.getViewBox().width() != 0) {
+      width = svg.getViewBox().width();
+    } else {
+      width = getCanvasWidth();
+    }
+
+    return relativeOn(length, width);
   }
 
   double relativeOnHeight(SVGLength length) {
-    return relativeOn(length, getCanvasHeight());
+    SvgView svg = getSvgView();
+    float height;
+
+    if (length.unit == SVGLength.UnitType.PERCENTAGE && svg != null && svg.getViewBox().height() != 0) {
+      height = svg.getViewBox().height();
+    } else {
+      height = getCanvasHeight();
+    }
+
+    return relativeOn(length, height);
   }
 
   double relativeOnOther(SVGLength length) {

--- a/apple/RNSVGNode.mm
+++ b/apple/RNSVGNode.mm
@@ -478,11 +478,19 @@ CGFloat const RNSVG_DEFAULT_FONT_SIZE = 12;
 
 - (CGFloat)relativeOnWidth:(RNSVGLength *)length
 {
+  if (length.unit == SVG_LENGTHTYPE_PERCENTAGE && self.svgView.vbWidth != 0) {
+    return [self relativeOn:length relative:self.svgView.vbWidth];
+  }
+
   return [self relativeOn:length relative:[self getCanvasWidth]];
 }
 
 - (CGFloat)relativeOnHeight:(RNSVGLength *)length
 {
+  if (length.unit == SVG_LENGTHTYPE_PERCENTAGE && self.svgView.vbHeight != 0) {
+    return [self relativeOn:length relative:self.svgView.vbHeight];
+  }
+
   return [self relativeOn:length relative:[self getCanvasHeight]];
 }
 


### PR DESCRIPTION
# Summary
This PR fixes: #2330 

- Add calculating relative width based on viewBox width if length unit is percentage (`relativeOnWidth` function)
- Add calculating relative height based on viewBox height if length unit is percentage (`relativeOnHeight` function

## Test Plan
Run example from issue: #2330 and compare it with the SVG Viewer.
Run fabric-example and compare it with the example before that changes.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅      |
| MacOS   |    ✅      |
| Android |    ✅      |
| Web     |    ✅      |

## Checklist
- [X] I have tested this on a simulator
