### PR TITLE
fix: add inheritance for properties from parent into Mask and ClipPath

### DIFF
--- a/android/src/main/java/com/horcrux/svg/GroupView.java
+++ b/android/src/main/java/com/horcrux/svg/GroupView.java
@@ -116,7 +116,8 @@ class GroupView extends RenderableView {
     elements = new ArrayList<>();
     for (int i = 0; i < getChildCount(); i++) {
       View child = getChildAt(i);
-      if (child instanceof MaskView) {
+      if (child instanceof MaskView || child instanceof ClipPathView) {
+        ((RenderableView) child).mergeProperties(self);
         continue;
       }
       if (child instanceof VirtualView) {

--- a/apple/Elements/RNSVGGroup.mm
+++ b/apple/Elements/RNSVGGroup.mm
@@ -88,7 +88,7 @@ using namespace facebook::react;
 
   [self traverseSubviews:^(RNSVGView *node) {
     if ([node isKindOfClass:[RNSVGMask class]] || [node isKindOfClass:[RNSVGClipPath class]]) {
-      // no-op
+      [(RNSVGRenderable *)node mergeProperties:self];
     } else if ([node isKindOfClass:[RNSVGNode class]]) {
       RNSVGNode *svgNode = (RNSVGNode *)node;
       if (svgNode.display && [@"none" isEqualToString:svgNode.display]) {


### PR DESCRIPTION
# Summary

This PR fixes: #1985 

- Add inheritance for properties from parent into `Mask`
- Add inheritance for properties from parent into `ClipPath`

## Test Plan

- Run example from issue: #1985
- Run fabric-example test app

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅      |
| MacOS   |    ✅      |
| Android |    ✅      |
| Web     |    ❌      |

## Checklist

- [X] I have tested this on a simulator
- [ ] I added documentation in `README.md`
- [ ] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
