### PR TITLE
fix: default opacity value for apple

### DIFF
--- a/apple/RNSVGNode.mm
+++ b/apple/RNSVGNode.mm
@@ -633,7 +633,7 @@ CGFloat const RNSVG_DEFAULT_FONT_SIZE = 12;
 
   _name = nil;
   _display = nil;
-  _opacity = 0;
+  _opacity = 1;
   _clipRule = kRNSVGCGFCRuleEvenodd;
   _clipPath = nil;
   _mask = nil;


### PR DESCRIPTION
# Summary
This PR fixes: #2672 

Set default value for opacity as `1` inside `RNSVGNode`, previously was `0` which caused wrong behavior when setting opacity for `G` to `0`.

## Test Plan

- Run example from issue: #2672  
- Create `G` with some `Rect` inside it and set opacity for `G` to `0` (Content inside `G` should be invisible)


## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅      |
| MacOS   |    ✅      |
| Android |    ❌      |
| Web     |    ❌      |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [ ] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
