### PR TITLE
Fix "more restores than saves" exception

### DIFF
--- a/android/src/main/java/com/horcrux/svg/GroupView.java
+++ b/android/src/main/java/com/horcrux/svg/GroupView.java
@@ -95,6 +95,7 @@ class GroupView extends RenderableView {
     final GroupView self = this;
     final RectF groupRect = new RectF();
 
+    int layerCount = -1;
     if (mOpacity != 1) {
       if (mLayerBitmap == null) {
         mLayerBitmap =
@@ -107,7 +108,7 @@ class GroupView extends RenderableView {
         mLayerCanvas.setBitmap(mLayerBitmap);
       }
       // Copy current matrix from original canvas
-      mLayerCanvas.save();
+      layerCount = mLayerCanvas.save();
       mLayerCanvas.setMatrix(canvas.getMatrix());
     } else {
       mLayerCanvas = canvas;
@@ -161,7 +162,7 @@ class GroupView extends RenderableView {
 
     if (mOpacity != 1) {
       // Restore copied canvas and temporary reset original canvas matrix to draw bitmap 1:1
-      mLayerCanvas.restore();
+      if (layerCount > 0) mLayerCanvas.restoreToCount(layerCount);
       int saveCount = canvas.save();
       canvas.setMatrix(null);
       mLayerPaint.setAlpha((int) (mOpacity * 255));


### PR DESCRIPTION
# Summary

The following Android crash has been introduced in PR #2450 

java.lang.IllegalStateException: Underflow in restore - more restores than saves
 	at android.graphics.Canvas.restore(Canvas.java:664)
 	at com.horcrux.svg.GroupView.drawGroup(GroupView.java:164)
 	at com.horcrux.svg.GroupView.draw(GroupView.java:88)
 	at com.horcrux.svg.RenderableView.render(RenderableView.java:490)
 	at com.horcrux.svg.GroupView.drawGroup(GroupView.java:132)
 	at com.horcrux.svg.GroupView.draw(GroupView.java:88)
 	at com.horcrux.svg.RenderableView.render(RenderableView.java:490)
 	at com.horcrux.svg.SvgView.drawChildren(SvgView.java:336)
 	at com.horcrux.svg.SvgView.drawOutput(SvgView.java:282)
 	at com.horcrux.svg.SvgView.onDraw(SvgView.java:135)


## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| Android |    ✅      |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [ ] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
