### PR TITLE
fix: update supported RN versions in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ npx expo install react-native-svg
 | >=12.3.0         | >=0.64.0     |
 | >=15.0.0         | >=0.70.0     |
 | >=15.8.0         | >=0.73.0     |
+| >=15.13.0        | >=0.78.0     |
 
 ## Support for Fabric
 


### PR DESCRIPTION
# Summary

Update supported RN versions due to #2734 PR that removed support for RN versions **<0.78**

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅      |
| MacOS   |    ✅      |
| Android |    ✅      |
| Web     |    ✅      |
