### PR TITLE
fix: remove setting opacity with self keyword inside RNSVGNode

### DIFF
--- a/apple/RNSVGNode.mm
+++ b/apple/RNSVGNode.mm
@@ -41,7 +41,8 @@ CGFloat const RNSVG_DEFAULT_FONT_SIZE = 12;
 #if !TARGET_OS_OSX // On macOS, views are transparent by default
     self.opaque = false;
 #endif
-    self.matrix = CGAffineTransformIdentity;
+    _matrix = CGAffineTransformIdentity;
+    _invmatrix = CGAffineTransformIdentity;
     _opacity = 1;
     _merging = false;
     _dirty = false;
@@ -641,7 +642,6 @@ CGFloat const RNSVG_DEFAULT_FONT_SIZE = 12;
 #if !TARGET_OS_OSX // On macOS, views are transparent by default
   self.opaque = false;
 #endif
-  self.matrix = CGAffineTransformIdentity;
   _merging = false;
   _dirty = false;
 

--- a/apple/RNSVGNode.mm
+++ b/apple/RNSVGNode.mm
@@ -38,11 +38,11 @@ CGFloat const RNSVG_DEFAULT_FONT_SIZE = 12;
 - (instancetype)init
 {
   if (self = [super init]) {
-    self.opacity = 1;
 #if !TARGET_OS_OSX // On macOS, views are transparent by default
     self.opaque = false;
 #endif
-    self.matrix = CGAffineTransformIdentity;
+    _matrix = CGAffineTransformIdentity;
+    _opacity = 1;
     _merging = false;
     _dirty = false;
   }
@@ -638,11 +638,9 @@ CGFloat const RNSVG_DEFAULT_FONT_SIZE = 12;
 {
   [super prepareForRecycle];
 
-  self.opacity = 1;
 #if !TARGET_OS_OSX // On macOS, views are transparent by default
   self.opaque = false;
 #endif
-  self.matrix = CGAffineTransformIdentity;
   _merging = false;
   _dirty = false;
 

--- a/apple/RNSVGNode.mm
+++ b/apple/RNSVGNode.mm
@@ -41,7 +41,7 @@ CGFloat const RNSVG_DEFAULT_FONT_SIZE = 12;
 #if !TARGET_OS_OSX // On macOS, views are transparent by default
     self.opaque = false;
 #endif
-    _matrix = CGAffineTransformIdentity;
+    self.matrix = CGAffineTransformIdentity;
     _opacity = 1;
     _merging = false;
     _dirty = false;
@@ -641,6 +641,7 @@ CGFloat const RNSVG_DEFAULT_FONT_SIZE = 12;
 #if !TARGET_OS_OSX // On macOS, views are transparent by default
   self.opaque = false;
 #endif
+  self.matrix = CGAffineTransformIdentity;
   _merging = false;
   _dirty = false;
 


### PR DESCRIPTION
# Summary

Remove setting variables inside `RNSVGNode` with `self.` and use underscore `_` instead.

## Test Plan

- Example app -> TouchEvents
- Create `G` with some `Rect` inside it and set opacity for `G` to `0` (Content inside `G` should be invisible)

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅      |
| MacOS   |    ❌      |
| Android |    ❌      |
| Web     |    ❌      |

## Checklist

- [X] I have tested this on a device and a simulator
