### PR TITLE
fix: scalling width and height in marker on Android

### DIFF
--- a/android/src/main/java/com/horcrux/svg/MarkerView.java
+++ b/android/src/main/java/com/horcrux/svg/MarkerView.java
@@ -131,8 +131,8 @@ class MarkerView extends GroupView {
       markerTransform.preScale(strokeWidth / mScale, strokeWidth / mScale);
     }
 
-    double width = relativeOnWidth(mMarkerWidth) / mScale;
-    double height = relativeOnHeight(mMarkerHeight) / mScale;
+    double width = relativeOnWidth(mMarkerWidth);
+    double height = relativeOnHeight(mMarkerHeight);
     RectF eRect = new RectF(0, 0, (float) width, (float) height);
     if (mAlign != null) {
       RectF vbRect =


### PR DESCRIPTION
# Summary
This PR fixes: #1410 

Remove dividing by `mScale` when calculating marker width and height.
<img width="744" height="300" alt="image" src="https://github.com/user-attachments/assets/85369467-c952-469e-8054-8cec41677166" />

## Test Plan

Run example from issue: #1410, and check if markers are displayed properly.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| Android |    ✅      |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [ ] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
