### PR TITLE
fix: pointerEvents handling on iOS

### DIFF
--- a/apple/Elements/RNSVGSvgView.mm
+++ b/apple/Elements/RNSVGSvgView.mm
@@ -340,7 +340,11 @@ using namespace facebook::react;
   return CGRectContainsPoint(hitFrame, point);
 }
 
+#ifdef RCT_NEW_ARCH_ENABLED
+- (RNSVGPlatformView *)betterHitTest:(CGPoint)point withEvent:(UIEvent *)event
+#else
 - (RNSVGPlatformView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event
+#endif
 {
   if (point.x < 0 || point.y < 0 || point.x > self.bounds.size.width || point.y > self.bounds.size.height) {
     return nil;


### PR DESCRIPTION
# Summary
Fixes: #2784 
Fixes: #2690
Fixes: #2639

Rename `hitTest` to `betterHitTest` for new architecture to handle properly `PointerEvents` in SVG.
Before that change we override `hitTest` from [RCTViewComponentView.mm](https://github.com/facebook/react-native/blob/3766e58b9aa50021bff508e215dcc18efb921435/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm#L673) which cause incorrect handling of `pointerEvents`. 
With this change we override `betterHitTest` that `RCTViewComponentView.mm` use in `hitTest` based on `pointerEvents` which fix the issue connected to pointerEvents.

## Test Plan

Run example from issue: #2784 

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅      |
| MacOS   |    ✅      |
| Android |    ❌      |
| Web     |    ❌      |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [ ] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
