### PR TITLE
chore: upgrade macos workflows

### DIFF
--- a/.github/workflows/e2e-ios.yml
+++ b/.github/workflows/e2e-ios.yml
@@ -2,7 +2,7 @@ name: E2E iOS
 on:
   pull_request:
     paths:
-      - .github/workflows/ios-e2e.yml
+      - .github/workflows/e2e-ios.yml
       - apps/common/example/**
       - apple/**
       - src/**

--- a/.github/workflows/e2e-ios.yml
+++ b/.github/workflows/e2e-ios.yml
@@ -15,14 +15,14 @@ on:
 
 jobs:
   test:
-    runs-on: macos-14
+    runs-on: macos-26
     timeout-minutes: 60
     strategy:
       matrix:
         working-directory: [paper-example]
       fail-fast: false
     env:
-      DEVICE: iPhone 15 Pro
+      DEVICE: iPhone 17 Pro
     steps:
       - name: Checkout Git repository
         uses: actions/checkout@v4
@@ -30,7 +30,7 @@ jobs:
       - name: Use latest stable Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '16.1'
+          xcode-version: '26.0.1'
 
       - name: Get react-native-svg node_modules cache
         uses: actions/cache@v4

--- a/.github/workflows/ios-build-test.yml
+++ b/.github/workflows/ios-build-test.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-14
+    runs-on: macos-26
     strategy:
       matrix:
         working-directory: [paper-example, fabric-example]
@@ -33,7 +33,7 @@ jobs:
       - name: Use latest stable Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '16.1'
+          xcode-version: '26.0.1'
 
       - name: Get react-native-svg node_modules cache
         uses: actions/cache@v4

--- a/.github/workflows/macos-build-test.yml
+++ b/.github/workflows/macos-build-test.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   build:
     if: github.repository == 'software-mansion/react-native-svg'
-    runs-on: macos-14
+    runs-on: macos-latest
     strategy:
       matrix:
         working-directory: [paper-macos-example, fabric-macos-example]


### PR DESCRIPTION
# Summary

This PR upgrades Github workflows that `runs-on` macos

## Test Plan

This actions should complete:

- E2E iOS
- Example iOS check
- Example macOS check

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅      |
| MacOS   |    ✅      |
| Android |    ✅      |
| Web     |    ✅      |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [ ] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
