### PR TITLE
fix: preserve camelCase for specific attributes in setNativeProps

### DIFF
--- a/src/web/WebShape.ts
+++ b/src/web/WebShape.ts
@@ -8,7 +8,7 @@ import {
 import { BaseProps } from './types';
 import { prepare } from './utils/prepare';
 import { convertInt32ColorToRGBA } from './utils/convertInt32Color';
-import { camelCaseToDashed, remeasure } from './utils';
+import { getAttributeName, remeasure } from './utils';
 import { hasTouchableProperty } from './utils/hasProperty';
 import SvgTouchableMixin from '../lib/SvgTouchableMixin';
 
@@ -76,7 +76,7 @@ export class WebShape<
             // apply all other incoming prop updates as attributes on the node
             // same logic as in https://github.com/software-mansion/react-native-reanimated/blob/d04720c82f5941532991b235787285d36d717247/src/reanimated2/js-reanimated/index.ts#L38-L39
             // @ts-expect-error TODO: fix this
-            current.setAttribute(camelCaseToDashed(cleanAttribute), cleanValue);
+            current.setAttribute(getAttributeName(cleanAttribute), cleanValue);
             break;
         }
       }

--- a/src/web/utils/index.ts
+++ b/src/web/utils/index.ts
@@ -63,3 +63,41 @@ export function encodeSvg(svgString: string) {
     .replace(/>/g, '%3E')
     .replace(/\s+/g, ' ');
 }
+
+const KEEP_CAMEL_CASE = new Set([
+  'stdDeviation',
+  'edgeMode',
+  'kernelMatrix',
+  'kernelUnitLength',
+  'preserveAlpha',
+  'baseFrequency',
+  'targetX',
+  'targetY',
+  'numOctaves',
+  'stitchTiles',
+  'filterUnits',
+  'primitiveUnits',
+  'pathLength',
+  'gradientUnits',
+  'gradientTransform',
+  'spreadMethod',
+  'markerHeight',
+  'markerUnits',
+  'markerWidth',
+  'viewBox',
+  'refX',
+  'refY',
+  'maskContentUnits',
+  'maskUnits',
+  'patternContentUnits',
+  'patternTransform',
+  'patternUnits',
+  'textLength',
+  'lengthAdjust',
+  'startOffset',
+  'clipPathUnits',
+]);
+
+export const getAttributeName = (attr: string) => {
+  return KEEP_CAMEL_CASE.has(attr) ? attr : camelCaseToDashed(attr);
+};


### PR DESCRIPTION
# Summary
Fixes: #2790 

In `setNativeProps` all attributes except `fill`, `stroke` and `style` were passed through `camelCaseToDashed`. While this is correct for presentation attributes (e.g. `strokeWidth → stroke-width`) it breaks SVG attributes that are only valid in camelCase.

- Added a whitelist (`KEEP_CAMEL_CASE`) of SVG attributes that must remain camelCase.
- Updated `setNativeProps` to skip `camelCaseToDashed` for these attributes.

## Test Plan

Run example from issue: #2790.
`FeGaussianBlur` animation should work properly.


## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌      |
| MacOS   |    ❌      |
| Android |    ❌      |
| Web     |    ✅     |

## Checklist

- [X] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [ ] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
