### PR TITLE
fix: null object reference inside group getPath

### DIFF
--- a/android/src/main/java/com/horcrux/svg/GroupView.java
+++ b/android/src/main/java/com/horcrux/svg/GroupView.java
@@ -200,7 +200,11 @@ class GroupView extends RenderableView {
       if (node instanceof VirtualView) {
         VirtualView n = (VirtualView) node;
         Matrix transform = n.mMatrix;
-        mPath.addPath(n.getPath(canvas, paint), transform);
+        Path path = n.getPath(canvas, paint);
+
+        if (path != null) {
+          mPath.addPath(path, transform);
+        }
       }
     }
 


### PR DESCRIPTION
# Summary
Fixes: #2799

This PR adds a null check before adding the child’s path.
`if (path != null) {
  	mPath.addPath(path, transform);
}`
This ensures that only valid paths are added to the group’s path, preventing crashes when a child node return null from `getPath`.

## Test Plan

Run example from issue: #2799

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌      |
| MacOS   |    ❌      |
| Android |    ✅      |
| Web     |    ❌      |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [ ] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
