### PR TITLE
fix: CMake project name

### DIFF
--- a/android/src/main/jni/CMakeLists.txt
+++ b/android/src/main/jni/CMakeLists.txt
@@ -63,7 +63,7 @@ target_link_libraries(
 )
 
 target_include_directories(
-  ${CMAKE_PROJECT_NAME}
+  react_codegen_rnsvg
   PUBLIC
   ${CMAKE_CURRENT_SOURCE_DIR}
 )


### PR DESCRIPTION
# Summary

Unify CMake project names by replacing `${CMAKE_PROJECT_NAME}` with `react_codegen_rnsvg`