### PR TITLE
feat: Add 16kb page size support to CMake

### DIFF
--- a/android/src/main/jni/CMakeLists.txt
+++ b/android/src/main/jni/CMakeLists.txt
@@ -26,6 +26,9 @@ target_include_directories(
   ${RNSVG_GENERATED_REACT_DIR}
 )
 
+# https://developer.android.com/guide/practices/page-sizes#cmake
+target_link_options(react_codegen_rnsvg PRIVATE "-Wl,-z,max-page-size=16384")
+
 find_package(ReactAndroid REQUIRED CONFIG)
 
 if(ReactAndroid_VERSION_MINOR GREATER_EQUAL 76)


### PR DESCRIPTION
# Summary

Add 16kb page size flags to CMake

## Test Plan

Android builds correctly and `libreact_codegen_rnsvg.so` is 16KB
