### PR TITLE
fix: setting letterSpacing prop

### DIFF
--- a/android/src/main/java/com/horcrux/svg/FontData.java
+++ b/android/src/main/java/com/horcrux/svg/FontData.java
@@ -136,7 +136,7 @@ class FontData {
       ReadableMap font, String prop, double scale, double fontSize, double relative) {
     ReadableType propType = font.getType(prop);
     if (propType == ReadableType.Number) {
-      return font.getDouble(prop);
+      return font.getDouble(prop) * scale;
     } else {
       String string = font.getString(prop);
       return PropHelper.fromRelative(string, relative, scale, fontSize);

--- a/apple/Text/RNSVGFontData.mm
+++ b/apple/Text/RNSVGFontData.mm
@@ -184,7 +184,7 @@ int lighter(int inherited)
   id letterSpacing = [font objectForKey:LETTER_SPACING];
   if ([letterSpacing isKindOfClass:NSNumber.class]) {
     NSNumber *ls = letterSpacing;
-    data->wordSpacing = (CGFloat)[ls doubleValue];
+    data->letterSpacing = (CGFloat)[ls doubleValue];
   } else {
     data->letterSpacing =
         letterSpacing ? [RNSVGFontData toAbsoluteWithNSString:letterSpacing fontSize:fontSize] : parent->letterSpacing;


### PR DESCRIPTION
# Summary

Fixes: #2806 

This PR fixes calculating `letterSpacing` for `Text` when `letterSpacing` prop type is `Number`.

## Test Plan

Run example from issue: #2806 

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅      |
| MacOS   |    ✅      |
| Android |    ✅      |
| Web     |    ❌      |

## Checklist

- [X] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [ ] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
