### PR TITLE
fix: invalidate ForeignObject to properly render Text component

### DIFF
--- a/apple/Elements/RNSVGForeignObject.mm
+++ b/apple/Elements/RNSVGForeignObject.mm
@@ -82,9 +82,9 @@ using namespace facebook::react;
 - (void)layoutSubviews
 {
   [super layoutSubviews];
-// We know layout is done, but the async text rendering is not.
-// We schedule the SVG redraw for the next runloop cycle.
-// This gives the text layout system time to finish its work.
+  // We know layout is done, but the async text rendering is not.
+  // We schedule the SVG redraw for the next runloop cycle.
+  // This gives the text layout system time to finish its work.
   dispatch_async(dispatch_get_main_queue(), ^{
     [self invalidate];
   });


### PR DESCRIPTION
# Summary
Fixes: #2733 (`Bug2`)
Fixes: #1357 

## Problem
When rendering a React Native `<Text>` component inside a `<ForeignObject>`, the text content is not visible on the initial render pass, particularly when capturing the view.

If a snapshot of the view is taken using `[layer renderInContext:]`, the view's backgroundColor (if set) is rendered correctly but the text content itself is missing.

## Solution
This PR fixes the race condition by 'waiting' for the asynchronous text render to complete before rendering the view.

It does this by wrapping the `[self invalidate]` call in a `dispatch_async(dispatch_get_main_queue(), ...)` block inside `layoutSubviews`. This schedules the `invalidate` call for the next "tick" of the main run loop.

By the time our block executes, the (already-scheduled) React Native text rendering pass has had time to complete and the `RCTParagraphComponentView` layer is fully populated with its text content.

This solution also fixes re-rendering issue inside `ForeignObject`: #1357

## Important
This solution is a workaround to win a known race condition.

The modern `[view drawViewHierarchyInRect:afterScreenUpdates:YES]` API is intended to solve this exact problem by deterministically waiting for screen updates. However, this approach was attempted and did not resolve the issue in this specific implementation.

An alternative, functionally identical workaround that also resolves the issue is to use `performSelector:afterDelay:0`, which similarly schedules the call for the next run loop cycle:
```objc
  [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(invalidate) object:nil];
  [self performSelector:@selector(invalidate) withObject:nil afterDelay:0 inModes:@[NSRunLoopCommonModes]];
```

## Test Plan
Run test case from issue: #2733, `Text` components should display its content on first render properly.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅      |
| MacOS   |    ✅      |
| Android |    ❌      |
| Web     |    ❌      |

## Checklist

- [X] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [ ] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
