### PR TITLE
fix: ForeignObject re-render on Android

### DIFF
--- a/android/src/main/java/com/horcrux/svg/ForeignObjectView.java
+++ b/android/src/main/java/com/horcrux/svg/ForeignObjectView.java
@@ -67,6 +67,16 @@ class ForeignObjectView extends GroupView {
     invalidate();
   }
 
+  @Override
+  public void invalidate() {
+    super.invalidate();
+    SvgView svgView = getSvgView();
+
+    if (svgView != null) {
+      svgView.invalidate();
+    }
+  }
+
   void drawGroup(final Canvas canvas, final Paint paint, final float opacity) {
     pushGlyphContext();
     final SvgView svg = getSvgView();


### PR DESCRIPTION
# Summary

Fixes: #1357

Add `invalidate` function for `ForeignObject` that invalidates SVG parent view to properly handle re-renders on Android. 
iOS fix is on this PR: https://github.com/software-mansion/react-native-svg/pull/2815

## Test Plan
Test example from issue: #1357 

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌      |
| MacOS   |    ❌      |
| Android |    ✅      |
| Web     |    ❌      |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [ ] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
