### PR TITLE
fix: ios breaking changes for RCTImage use-after-free crash

### DIFF
--- a/apple/Elements/RNSVGImage.mm
+++ b/apple/Elements/RNSVGImage.mm
@@ -27,6 +27,8 @@
 #import "RNSVGViewBox.h"
 
 #ifdef RCT_NEW_ARCH_ENABLED
+#import <memory>
+
 #import <React/RCTConversions.h>
 #import <React/RCTFabricComponentsPlugins.h>
 #import <React/RCTImageResponseObserverProxy.h>
@@ -45,7 +47,7 @@ using namespace facebook::react;
 
 #ifdef RCT_NEW_ARCH_ENABLED
   RNSVGImageShadowNode::ConcreteState::Shared _state;
-  RCTImageResponseObserverProxy _imageResponseObserverProxy;
+  std::shared_ptr<RCTImageResponseObserverProxy> _imageResponseObserverProxy;
 #endif // RCT_NEW_ARCH_ENABLED
 }
 #ifdef RCT_NEW_ARCH_ENABLED
@@ -62,7 +64,7 @@ using namespace facebook::react;
     static const auto defaultProps = std::make_shared<const RNSVGImageProps>();
     _props = defaultProps;
 
-    _imageResponseObserverProxy = RCTImageResponseObserverProxy(self);
+    _imageResponseObserverProxy = std::make_shared<RCTImageResponseObserverProxy>(self);
   }
   return self;
 }
@@ -99,6 +101,8 @@ using namespace facebook::react;
 
   setCommonRenderableProps(newProps, self);
   _props = std::static_pointer_cast<RNSVGImageProps const>(props);
+
+  [super updateProps:props oldProps:oldProps];
 }
 
 - (void)updateState:(State::Shared const &)state oldState:(State::Shared const &)oldState
@@ -118,14 +122,14 @@ using namespace facebook::react;
 {
   if (_state) {
     auto &observerCoordinator = _state->getData().getImageRequest().getObserverCoordinator();
-    observerCoordinator.removeObserver(_imageResponseObserverProxy);
+    observerCoordinator.removeObserver(*_imageResponseObserverProxy);
   }
 
   _state = state;
 
   if (_state) {
     auto &observerCoordinator = _state->getData().getImageRequest().getObserverCoordinator();
-    observerCoordinator.addObserver(_imageResponseObserverProxy);
+    observerCoordinator.addObserver(*_imageResponseObserverProxy);
   }
 }
 


### PR DESCRIPTION
# Summary

Adopts the [breaking change bug fix](https://github.com/facebook/react-native/commit/3b46755b3b2f4a53b79d0828ef4c0cfe319a34ac) in React Native RCTImage for iOS to fix a rare use-after-free race condition in the image progress observer. (See React Native PR for more details)

## Test Plan

Rerun nightly test suite and verify no more breakages.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅       |
| MacOS   |    n/a      |
| Android |    n/a      |
| Web     |    n/a      |

## Checklist

- [x] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [ ] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
