### PR TITLE
docs: remove sorn25 banner from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,4 @@
-<p align="center">
-  <img
-    src="https://user-images.githubusercontent.com/39658211/200319759-006c214f-941c-496c-a3c2-7de5b7ce33dc.png"
-    width="100%"
-    alt="React Native SVG at Software Mansion"
-  />
-  <a href="https://stateofreactnative.com/">
-    <img
-      src="https://github.com/user-attachments/assets/4ed1c474-548f-4fa9-a8c5-d669e85c83d8"
-      alt="State of React Native Survey"
-      width="100%"
-    />
-  </a>
-</p>
+<img src="https://user-images.githubusercontent.com/39658211/200319759-006c214f-941c-496c-a3c2-7de5b7ce33dc.png" width="100%" alt="React Native SVG at Software Mansion" >
 
 [![Version](https://img.shields.io/npm/v/react-native-svg.svg)](https://www.npmjs.com/package/react-native-svg)
 [![NPM](https://img.shields.io/npm/dm/react-native-svg.svg)](https://www.npmjs.com/package/react-native-svg)


### PR DESCRIPTION
# Summary

Removes a banner linking to the State of React Native Survey from readme.