### PR TITLE
fix: macOS UIImage build issues

### DIFF
--- a/apple/Elements/RNSVGImage.mm
+++ b/apple/Elements/RNSVGImage.mm
@@ -239,7 +239,7 @@ using namespace facebook::react;
 #if !TARGET_OS_OSX // [macOS]
                      callback:^(__unused NSError *error, UIImage *image) {
 #else // [macOS
-      callback:^(__unused NSError *error, NSImage *image) {
+                     callback:^(__unused NSError *error, NSImage *image) {
 #endif // macOS]
                        dispatch_async(dispatch_get_main_queue(), ^{
                          self->_image = CGImageRetain(image.CGImage);


### PR DESCRIPTION
# Summary

Really simple change to get skia running on macOS, I noticed this while testing BareExpo in the expo/expo repo. Just add a `!TARGET_OS_OSX` check and use `NSImage`

## Test Plan

Run fabric-macos-example on macOS

<img width="1392" height="864" alt="image" src="https://github.com/user-attachments/assets/199d860b-7722-4afd-90a7-9741d8fe9034" />


## Compatibility

| OS      | Implemented |
| ------- | :---------: | 
| MacOS   |    ✅      | 

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [ ] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
