### PR TITLE
fix: correct @ReactProp name for edgeMode

### DIFF
--- a/android/src/main/java/com/horcrux/svg/RenderableViewManager.java
+++ b/android/src/main/java/com/horcrux/svg/RenderableViewManager.java
@@ -1630,7 +1630,7 @@ class RenderableViewManager<T extends RenderableView> extends VirtualViewManager
       node.setStdDeviationY(stdDeviationY);
     }
 
-    @ReactProp(name = "values")
+    @ReactProp(name = "edgeMode")
     public void setEdgeMode(FeGaussianBlurView node, String edgeMode) {
       node.setEdgeMode(edgeMode);
     }


### PR DESCRIPTION
# Summary

This just fixes a copy/paste error or typo that I noticed. The `edgeMode` is not implemented anyway, so this has no real impact on anything.

## Test Plan

Since `edgeMode` is not implemented, this change has no actual effect.

I built the Paper and Fabric examples and verified that they still run

### What's required for testing (prerequisites)?

N/A

### What are the steps to reproduce (after prerequisites)?

N/A

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌      |
| MacOS   |    ❌      |
| Android |    ✅      |
| Web     |    ❌      |

## Checklist

- [x] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [ ] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
