### PR TITLE
Fix nightly builds

### DIFF
--- a/apple/Elements/RNSVGImage.mm
+++ b/apple/Elements/RNSVGImage.mm
@@ -122,14 +122,22 @@ using namespace facebook::react;
 {
   if (_state) {
     auto &observerCoordinator = _state->getData().getImageRequest().getObserverCoordinator();
+#if REACT_NATIVE_MINOR_VERSION > 84
+    observerCoordinator.removeObserver(_imageResponseObserverProxy);
+#else
     observerCoordinator.removeObserver(*_imageResponseObserverProxy);
+#endif
   }
 
   _state = state;
 
   if (_state) {
     auto &observerCoordinator = _state->getData().getImageRequest().getObserverCoordinator();
+#if REACT_NATIVE_MINOR_VERSION > 84
+    observerCoordinator.addObserver(_imageResponseObserverProxy);
+#else
     observerCoordinator.addObserver(*_imageResponseObserverProxy);
+#endif
   }
 }
 


### PR DESCRIPTION
# Summary

Fixes build issue with latest react-native nightlies by passing `std::shared_ptr<RCTImageResponseObserverProxy>` to the `observerCoordinator::removeObserver` and `observerCoordinator::addObserver`. Interfaces of these methods were changed in this [commit](https://github.com/facebook/react-native/commit/3b46755b3b2f4a53b79d0828ef4c0cfe319a34ac). The fix is backward compatible with older versions of react native.  

## Test Plan

Tested on latest react native nightly `0.85.0-nightly-20260218-51dc568d2`.


