### PR TITLE
Change rad2deg function to static

### DIFF
--- a/apple/Utils/RNSVGMarkerPosition.mm
+++ b/apple/Utils/RNSVGMarkerPosition.mm
@@ -49,7 +49,7 @@ static double BisectingAngle(double in_angle, double out_angle)
 
 static CGFloat RNSVG_radToDeg = 180 / (CGFloat)M_PI;
 
-double rad2deg(CGFloat rad)
+static double rad2deg(CGFloat rad)
 {
   return rad * RNSVG_radToDeg;
 }


### PR DESCRIPTION

# Summary

`rad2deg` is a very common utility function name and can easily cause **duplicate symbol definition errors** when linking against third-party static libraries (`.a` files) that happen to define a function with the same name.
`rad2deg` is only used within `RNSVGMarkerPosition.mm` itself, so there is no reason for it to have external linkage. Declaring it `static` restricts its visibility to the translation unit, which:
- Eliminates the risk of duplicate symbol linker errors with any external library that defines a function of the same name.
- Better communicates intent — the function is an internal implementation detail and should not be part of the public symbol table.
**Impacted area:** iOS/macOS marker rendering (`RNSVGMarkerPosition.mm`).

## Test Plan

### Prerequisites

- Xcode 15+ (reproduces with the new Apple linker, which is stricter about duplicate symbols)
- A project that links `react-native-svg` alongside a third-party static library that also defines `rad2deg`

### Steps to reproduce the original issue

1. Add a native static library (`.a`) that exports a `rad2deg(double)` symbol to your React Native iOS project.
2. Run `xcodebuild` — the build will fail with:
duplicate symbol 'rad2deg(double)' in: libRNSVG.a (RNSVGMarkerPosition.o) .a (...) ld: 1 duplicate symbols clang: error: linker command failed with exit code 1


### Verification after fix

1. Apply this patch.
2. Clean DerivedData and rebuild: `yarn ios --device`.
3. Build succeeds — no duplicate symbol error.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |      ✅      |
| MacOS   |      ✅      |
| Android |      ❌      |
| Web     |      ❌      |

> Android and Web are not affected — the change is confined to the `.mm` (Objective-C++) source file used only on Apple platforms.

## Checklist

- [x] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [ ] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder

- [ ] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [ ] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
