### PR TITLE
Fix clang-diagnostic-inconsistent-missing-override error in Imageview…

### DIFF
--- a/windows/RNSVG/Fabric/ImageView.cpp
+++ b/windows/RNSVG/Fabric/ImageView.cpp
@@ -69,7 +69,7 @@ struct ImageView : winrt::implements<ImageView, winrt::Windows::Foundation::IIns
   void UpdateProps(
       const winrt::Microsoft::ReactNative::ComponentView &view,
       const winrt::Microsoft::ReactNative::IComponentProps &newProps,
-      const winrt::Microsoft::ReactNative::IComponentProps &oldProps) noexcept {
+      const winrt::Microsoft::ReactNative::IComponentProps &oldProps) noexcept override {
     RenderableView::UpdateProps(view, newProps, oldProps);
 
     auto props = newProps.as<ImageProps>();


### PR DESCRIPTION
# Summary

Fixes a **clang-diagnostic-inconsistent-missing-override** warning/error when building react-native-svg for windows using clang.

## Test Plan

Just fixes a build warning, does not have any runtime impact.
