### PR TITLE
fix: render SVG on macOS Fabric by opting out of updateLayer

### DIFF
--- a/apple/Elements/RNSVGSvgView.mm
+++ b/apple/Elements/RNSVGSvgView.mm
@@ -34,6 +34,14 @@
   bool rendered;
 }
 
+#if TARGET_OS_OSX && defined(RCT_NEW_ARCH_ENABLED)
+// RCTViewComponentView opts into updateLayer; we render in drawRect:, so opt back out.
+- (BOOL)wantsUpdateLayer
+{
+  return NO;
+}
+#endif
+
 #ifdef RCT_NEW_ARCH_ENABLED
 using namespace facebook::react;
 #endif // RCT_NEW_ARCH_ENABLED


### PR DESCRIPTION
# Summary

Fixes SVG not rendering on macOS when the new arch is enabled. On macOS Fabric, `RNSVGSvgView` inherits from `RCTViewComponentView`, which returns `YES` for `-wantsUpdateLayer`. When `wantsUpdateLayer` is `YES`, AppKit calls `-updateLayer` to set the layer's contents and skips `-drawRect:` entirely. Since `RNSVGSvgView` renders all of its SVG content inside `-drawRect:` (via `drawToContext:withRect:`), nothing was being painted on macOS new arch — the view stayed blank.

## Test Plan

Verified that SVGs render correctly on a macOS app with `RCT_NEW_ARCH_ENABLED=1`. Without the fix the view paints nothing; with the fix `drawRect:` is called and SVG content is drawn as expected.

1. Build and run the `react-native-svg` example app on macOS with the New Architecture enabled.
2. Open any screen that renders an `<Svg>` (e.g. the basic shapes example).
3. **Before this PR:** the SVG area is blank.
4. **After this PR:** the SVG renders correctly, identical to the old-arch behavior.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    N/A      |
| MacOS   |     ✅      |
| Android |    N/A      |
| Web     |    N/A      |

## Checklist

- [x] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [ ] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
