### PR TITLE
Add RNRepo to ci builds

### DIFF
--- a/.github/workflows/android-build-test.yml
+++ b/.github/workflows/android-build-test.yml
@@ -68,4 +68,4 @@ jobs:
 
       - name: Build app
         working-directory: apps/${{ matrix.working-directory }}/android
-        run: ./gradlew assembleDebug --build-cache --console=plain -PreactNativeArchitectures=arm64-v8a
+        run: ./gradlew :app:assembleDebug --build-cache --console=plain -PreactNativeArchitectures=arm64-v8a

--- a/.github/workflows/e2e-android.yml
+++ b/.github/workflows/e2e-android.yml
@@ -95,7 +95,7 @@ jobs:
             E2E=true yarn --cwd apps/${{ env.WORKING_DIRECTORY }} start &> output.log &
 
             # Build the Android app      
-            cd apps/${{ env.WORKING_DIRECTORY }}/android && ./gradlew assembleDebug
+            cd apps/${{ env.WORKING_DIRECTORY }}/android && ./gradlew :app:assembleDebug
 
             # Install the app APK
             $ANDROID_HOME/platform-tools/adb install -r apps/${{ env.WORKING_DIRECTORY }}/android/app/build/outputs/apk/debug/app-debug.apk

--- a/apps/fabric-example/android/app/build.gradle
+++ b/apps/fabric-example/android/app/build.gradle
@@ -2,6 +2,21 @@ apply plugin: "com.android.application"
 apply plugin: "org.jetbrains.kotlin.android"
 apply plugin: "com.facebook.react"
 
+def isCIEnabled() {
+    return ["1", "true"].contains(System.getenv("CI")?.toLowerCase())
+}
+
+def isRNRepoEnabled() {
+    // return false // Uncomment to disable RNRepo locally
+    return System.getenv("DISABLE_RNREPO") == null
+}
+
+// Use RNRepo in CI builds. 
+// Set DISABLE_RNREPO to any value to disable RNRepo.
+if (isCIEnabled() && isRNRepoEnabled()) {
+    apply plugin: "org.rnrepo.tools.prebuilds-plugin"
+}
+
 /**
  * This is the configuration block to customize your React Native Android app.
  * By default you don't need to apply any configuration, just uncomment the lines you need.

--- a/apps/fabric-example/android/build.gradle
+++ b/apps/fabric-example/android/build.gradle
@@ -11,10 +11,22 @@ buildscript {
         google()
         mavenCentral()
     }
+    // RNRepo plugin classpath for CI builds (plugin applied in app/build.gradle).
+    // To disable RNRepo support, set DISABLE_RNREPO environment variable to ANY value.
+    def rnrepoClasspath = {
+        def rnrepoDir = new File(
+            providers.exec {
+                workingDir(rootDir)
+                commandLine("node", "--print", "require.resolve('@rnrepo/build-tools/package.json')")
+            }.standardOutput.asText.get().trim()
+        ).getParentFile().absolutePath
+        return fileTree(dir: "${rnrepoDir}/gradle-plugin/build/libs", include: ["prebuilds-plugin.jar"])
+    }
     dependencies {
         classpath("com.android.tools.build:gradle")
         classpath("com.facebook.react:react-native-gradle-plugin")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin")
+        classpath rnrepoClasspath()
     }
 }
 

--- a/apps/fabric-example/ios/Podfile
+++ b/apps/fabric-example/ios/Podfile
@@ -7,6 +7,24 @@ require Pod::Executable.execute_command('node', ['-p',
     {paths: [process.argv[1]]},
   )', __dir__]).strip
 
+def is_ci_enabled?
+  %w[1 true].include?(ENV['CI'].to_s.downcase)
+end
+
+# ENV['DISABLE_RNREPO'] = "1" # Uncomment to disable RNRepo even in CI
+def is_rnrepo_enabled?
+  ENV['DISABLE_RNREPO'].nil?
+end
+
+# Use RNRepo in CI builds. Set DISABLE_RNREPO to any value to disable RNRepo.
+if is_ci_enabled? && is_rnrepo_enabled?
+  require Pod::Executable.execute_command('node', ['-p',
+    'require.resolve(
+      "@rnrepo/build-tools/cocoapods-plugin/lib/plugin.rb",
+      {paths: [process.argv[1]]},
+    )', __dir__]).strip
+end
+
 platform :ios, min_ios_version_supported
 prepare_react_native_project!
 
@@ -26,6 +44,9 @@ target 'FabricExample' do
   )
 
   post_install do |installer|
+    if is_ci_enabled? && is_rnrepo_enabled?
+      rnrepo_post_install(installer)
+    end
     # https://github.com/facebook/react-native/blob/main/packages/react-native/scripts/react_native_pods.rb#L197-L202
     react_native_post_install(
       installer,

--- a/apps/fabric-example/package.json
+++ b/apps/fabric-example/package.json
@@ -36,6 +36,7 @@
     "@react-native/eslint-config": "0.81.4",
     "@react-native/metro-config": "0.81.4",
     "@react-native/typescript-config": "0.81.4",
+    "@rnrepo/build-tools": "~0.1.3-beta.0",
     "@types/jest": "^29.5.13",
     "@types/react": "^19.1.0",
     "@types/react-test-renderer": "^19.1.0",

--- a/apps/fabric-example/yarn.lock
+++ b/apps/fabric-example/yarn.lock
@@ -1828,6 +1828,11 @@
     "@react-navigation/elements" "^2.6.3"
     color "^4.2.3"
 
+"@rnrepo/build-tools@~0.1.3-beta.0":
+  version "0.1.3-beta.0"
+  resolved "https://registry.yarnpkg.com/@rnrepo/build-tools/-/build-tools-0.1.3-beta.0.tgz#07900af5347c05b60c7ec65bb4351b921f5df9e9"
+  integrity sha512-ifo8j/1+cnTVTz2Au/dDIgoj+1z8mbyeFCvk5l30EP3vVWDb0PUafMsPycKF7/nLrnDIJKlh7g7GpdnwnbM2yA==
+
 "@sideway/address@^4.1.5":
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/@sideway/address/-/address-4.1.5.tgz#4bc149a0076623ced99ca8208ba780d65a99b9d5"

--- a/rnrepo.config.json
+++ b/rnrepo.config.json
@@ -1,0 +1,6 @@
+{
+    "denyList": {
+        "android": ["react-native-svg"],
+        "ios": ["react-native-svg"]
+    }
+}


### PR DESCRIPTION
# Summary

Adds RNRepo build-tools integration to `fabric-example` so that CI builds can consume pre-built native dependencies instead of compiling them from scratch, speeding up CI.

The integration is guarded by `CI=true` / `ENV['CI']` environment variables, so local development is unaffected. `react-native-svg` itself is excluded from prebuilds via `rnrepo.config.json` so that CI always builds and tests the library from source.

## Test Plan

Builds in CI using RNRepo should speed up the CI process. Android sees ~38% improvement across the board. iOS builds are ~15% faster.

- https://github.com/software-mansion/react-native-svg/actions/runs/25438112937: 5min 
- without: 6-12min

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅      |
| MacOS   |    ❌      |
| Android |    ✅      |
| Web     |    ❌      |

## Checklist

- [ ] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [ ] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
