### PR TITLE
refactor: drop warn-once dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,8 +71,7 @@
   },
   "dependencies": {
     "css-select": "^5.1.0",
-    "css-tree": "^1.1.3",
-    "warn-once": "0.1.1"
+    "css-tree": "^1.1.3"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -1,5 +1,3 @@
-import warnOnce from 'warn-once';
-
 export function pickNotNil(object: { [prop: string]: unknown }) {
   const result: { [prop: string]: unknown } = {};
   for (const key in object) {
@@ -17,6 +15,22 @@ export const idPattern = /#([^)]+)'?\)?$/;
 
 export const getRandomNumber = () =>
   Math.floor(Math.random() * Math.floor(Math.random() * Date.now()));
+
+const DEV = process.env.NODE_ENV !== 'production';
+const warnings = new Set<string>();
+
+function warnOnce(condition: boolean, ...rest: unknown[]) {
+  if (DEV && condition) {
+    const key = rest.join(' ');
+
+    if (warnings.has(key)) {
+      return;
+    }
+
+    warnings.add(key);
+    console.warn(...rest);
+  }
+}
 
 export const warnUnimplementedFilter = () => {
   warnOnce(

--- a/yarn.lock
+++ b/yarn.lock
@@ -9932,11 +9932,6 @@ walker@^1.0.7, walker@^1.0.8:
   dependencies:
     makeerror "1.0.12"
 
-warn-once@0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/warn-once/-/warn-once-0.1.1.tgz#952088f4fb56896e73fd4e6a3767272a3fccce43"
-  integrity sha512-VkQZJbO8zVImzYFteBXvBOZEl1qL175WH8VmZcxF2fZAoudNhNDvHi+doCaAEdU2l2vtcIwa2zn0QK5+I1HQ3Q==
-
 wcwidth@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/wcwidth/-/wcwidth-1.0.1.tgz#f0b0dcf915bc5ff1528afadb2c0e17b532da2fe8"


### PR DESCRIPTION
# Summary
- Removed the external `warn-once` dependency from `package.json`
- Inlined once-per-message warning helper in `src/lib/util.ts`