### PR TITLE
ci: Setup publishing workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,59 @@
+name: Publish to npm
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version to publish. Must match package.json version.
+        required: true
+        type: string
+      release-type:
+        description: Type of release to publish.
+        default: stable
+        type: choice
+        options:
+          - stable
+      dry-run:
+        description: Run npm publish without publishing the package.
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Git repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: 'yarn'
+          registry-url: https://registry.npmjs.org/
+
+      - name: Validate release inputs
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          package_version="$(node -p "require('./package.json').version")"
+          if [ "$INPUT_VERSION" != "$package_version" ]; then
+            echo "Input version ($INPUT_VERSION) must match package.json version ($package_version)."
+            exit 1
+          fi
+
+      - name: Publish stable release
+        uses: software-mansion/npm-package-publish@22b6e632b4310c5c061a047bccc99d0cea88d2bb
+        with:
+          package-name: react-native-svg
+          package-json-path: package.json
+          release-type: ${{ inputs.release-type }}
+          version: ${{ inputs.version }}
+          dry-run: ${{ inputs.dry-run }}
+          perform-git-operations: false
+          install-dependencies-command: yarn install --frozen-lockfile

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,7 +65,8 @@ When you're sending a pull request:
 
 ## Commits and versioning
 
-All PRs are merged into the `main` branch and released with `release-it`.
+All PRs are merged into the `main` branch. Stable releases are published manually from the `Publish to npm` GitHub
+Actions workflow after the version bump merge.
 
 Most notably prefixes you'll see:
 
@@ -80,7 +81,12 @@ Most notably prefixes you'll see:
 
 ## Release process
 
-We use [release-it](https://github.com/release-it/release-it) to release new versions of library from `main` branch.
+Releases are published from `main` with npm Trusted Publishing.
+
+1. Bump `package.json` version in a pull request.
+2. Merge the pull request to `main`.
+3. Run the `Publish to npm` workflow from `main` with `release-type: stable` and the same `version` that is already
+   committed in `package.json`.
 
 ## Reporting issues
 


### PR DESCRIPTION
# Summary

Same as https://github.com/software-mansion/react-native-screens/pull/3898
Migrate the npm publishing flow to use the `software-mansion/npm-package-publish`
composite action, which provides OIDC-based trusted publishing, and `--provenance` builds.

## Changes

- Added `.github/workflows/publish.yml` using `software-mansion/npm-package-publish`
- OIDC permissions (`id-token: write`) for provenance-based publishing

## Test Plan

* Dry run publishing.
* Publish patch version with current changes.