### PR TITLE
fix(android): fix LinearGradient when enabling RN props 2.0

### DIFF
--- a/android/src/main/java/com/horcrux/svg/LinearGradientView.java
+++ b/android/src/main/java/com/horcrux/svg/LinearGradientView.java
@@ -25,7 +25,7 @@ class LinearGradientView extends DefinitionView {
   private SVGLength mX2;
   private SVGLength mY2;
   private ReadableArray mGradient;
-  private Brush.BrushUnits mGradientUnits;
+  private Brush.BrushUnits mGradientUnits = Brush.BrushUnits.OBJECT_BOUNDING_BOX;
 
   private static final float[] sRawMatrix =
       new float[] {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

This is a follow up after the following PR. Please read this PR first to understand the context:

- https://github.com/software-mansion/react-native-svg/pull/2948

This fixes the default value for `LinearGradient`, which is especially important when enabling props 2.0 diffing mode.

## Test Plan

### What's required for testing (prerequisites)?

Try to set the feature flags i mentioned and then observe the issues with linear gradient

### What are the steps to reproduce (after prerequisites)?

^

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌      |
| MacOS   |    ❌      |
| Android |    ✅      |
| Web     |    ❌      |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [x] I added documentation in `README.md`
- [x] I updated the typed files (typescript)
- [x] I added a test for the API in the `__tests__` folder
