### PR TITLE
fix: apply x and y props to nested Svg

### DIFF
--- a/__tests__/__snapshots__/svg.test.tsx.snap
+++ b/__tests__/__snapshots__/svg.test.tsx.snap
@@ -1,0 +1,114 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`applies x and y as a native view translation 1`] = `
+<RNSVGSvgView
+  bbHeight={100}
+  bbWidth={100}
+  focusable={false}
+  height={100}
+  style={
+    Array [
+      Object {
+        "backgroundColor": "transparent",
+        "borderWidth": 0,
+      },
+      Object {
+        "flex": 0,
+        "height": 100,
+        "width": 100,
+      },
+    ]
+  }
+  transform={
+    Array [
+      Object {
+        "translateX": 20,
+      },
+      Object {
+        "translateY": 30,
+      },
+    ]
+  }
+  width={100}
+>
+  <RNSVGGroup
+    fill={
+      Object {
+        "payload": 4278190080,
+        "type": 0,
+      }
+    }
+  >
+    <RNSVGRect
+      fill={
+        Object {
+          "payload": 4278190080,
+          "type": 0,
+        }
+      }
+      height={10}
+      width={10}
+      x={0}
+      y={0}
+    />
+  </RNSVGGroup>
+</RNSVGSvgView>
+`;
+
+exports[`keeps existing transforms when applying x and y 1`] = `
+<RNSVGSvgView
+  bbHeight={100}
+  bbWidth={100}
+  focusable={false}
+  height={100}
+  style={
+    Array [
+      Object {
+        "backgroundColor": "transparent",
+        "borderWidth": 0,
+      },
+      Object {
+        "flex": 0,
+        "height": 100,
+        "width": 100,
+      },
+    ]
+  }
+  transform={
+    Array [
+      Object {
+        "translateX": 20,
+      },
+      Object {
+        "translateY": 30,
+      },
+      Object {
+        "scale": 2,
+      },
+    ]
+  }
+  width={100}
+>
+  <RNSVGGroup
+    fill={
+      Object {
+        "payload": 4278190080,
+        "type": 0,
+      }
+    }
+  >
+    <RNSVGRect
+      fill={
+        Object {
+          "payload": 4278190080,
+          "type": 0,
+        }
+      }
+      height={10}
+      width={10}
+      x={0}
+      y={0}
+    />
+  </RNSVGGroup>
+</RNSVGSvgView>
+`;

--- a/__tests__/svg.test.tsx
+++ b/__tests__/svg.test.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+import renderer from 'react-test-renderer';
+import { Rect, Svg } from '../src/ReactNativeSVG';
+
+test('applies x and y as a native view translation', () => {
+  const tree = renderer
+    .create(
+      <Svg x={20} y={30} width={100} height={100}>
+        <Rect width={10} height={10} />
+      </Svg>
+    )
+    .toJSON();
+
+  expect(tree).toMatchSnapshot();
+});
+
+test('keeps existing transforms when applying x and y', () => {
+  const tree = renderer
+    .create(
+      <Svg x={20} y={30} width={100} height={100} transform={[{ scale: 2 }]}>
+        <Rect width={10} height={10} />
+      </Svg>
+    )
+    .toJSON();
+
+  expect(tree).toMatchSnapshot();
+});

--- a/src/elements/Svg.tsx
+++ b/src/elements/Svg.tsx
@@ -7,6 +7,7 @@ import type {
   MeasureOnSuccessCallback,
   NativeMethods,
   StyleProp,
+  TransformsStyle,
   ViewStyle,
 } from 'react-native';
 import { findNodeHandle, Platform, StyleSheet } from 'react-native';
@@ -35,6 +36,44 @@ const styles = StyleSheet.create({
   },
 });
 const defaultStyle = styles.svg;
+
+type Transform = TransformsStyle['transform'];
+
+function getTranslateValue(value: NumberProp | NumberProp[] | undefined) {
+  const firstValue = Array.isArray(value) ? value[0] : value;
+
+  if (firstValue == null) {
+    return 0;
+  }
+
+  const parsedValue =
+    typeof firstValue === 'number' ? firstValue : parseFloat(firstValue);
+
+  return Number.isFinite(parsedValue) ? parsedValue : 0;
+}
+
+function appendTranslate(
+  transform: Transform | undefined,
+  x: NumberProp | NumberProp[] | undefined,
+  y: NumberProp | NumberProp[] | undefined
+) {
+  const translateX = getTranslateValue(x);
+  const translateY = getTranslateValue(y);
+
+  if (!translateX && !translateY) {
+    return transform;
+  }
+
+  const translate = [];
+  if (translateX) {
+    translate.push({ translateX });
+  }
+  if (translateY) {
+    translate.push({ translateY });
+  }
+
+  return Array.isArray(transform) ? [...translate, ...transform] : translate;
+}
 
 export interface SvgProps extends GProps, ViewProps, HitSlop {
   width?: NumberProp;
@@ -100,6 +139,8 @@ export default class Svg extends Shape<SvgProps> {
       children,
       onLayout,
       preserveAspectRatio,
+      x: propsX,
+      y: propsY,
       ...extracted
     } = this.props;
     const stylesAndProps = {
@@ -111,6 +152,8 @@ export default class Svg extends Shape<SvgProps> {
       height,
       focusable,
       transform,
+      x = propsX,
+      y = propsY,
 
       // Inherited G properties
       font,
@@ -186,6 +229,7 @@ export default class Svg extends Shape<SvgProps> {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       props.transform = extractTransformSvgView(props as any);
     }
+    props.transform = appendTranslate(props.transform as Transform, x, y);
 
     const RNSVGSvg = Platform.OS === 'android' ? RNSVGSvgAndroid : RNSVGSvgIOS;
 


### PR DESCRIPTION
# Summary

Fixes #1283.

Nested `<Svg>` elements accepted `x` and `y` props, but those values did not affect the native SVG view position. This makes them behave like a view translation before any existing transform, which matches the usual SVG behavior and keeps the current transform path intact.

This impacts the shared `Svg` component path used by native platforms. I also made sure `x` and `y` are not forwarded as stray native view props once they have been converted into the transform.

## Test Plan

Commands run locally:

```sh
yarn install --frozen-lockfile
yarn test
yarn jest __tests__/svg.test.tsx --runInBand --globalSetup= --globalTeardown=
npx prettier --check src/elements/Svg.tsx __tests__/svg.test.tsx
```

The Jest command disables the repo-level E2E websocket setup for this focused unit test; otherwise the runner waits for an example-app client connection.

### What's required for testing (prerequisites)?

Install dependencies with `yarn install --frozen-lockfile`.

### What are the steps to reproduce (after prerequisites)?

Render a nested `<Svg x={20} y={30}>` inside another `Svg`. The inner SVG should render offset by those values, and existing transforms should still be preserved.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |     ✅      |
| MacOS   |     ✅      |
| Android |     ✅      |
| Web     |     ❌      |

## Checklist

- [ ] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [ ] I updated the typed files (typescript)
- [X] I added a test for the API in the `__tests__` folder