### PR TITLE
feat(css): add cssVars prop and resolveCssVars middleware

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -331,6 +331,27 @@ const xml = `
 export default () => <SvgCss xml={xml} width="100%" height="100%" />;
 ```
 
+### Supplying CSS variables from JS
+
+To resolve `var(--name)` references using values supplied from JavaScript, pass them via the `cssVars` prop. Keys must be `--`-prefixed. Variables declared by an inline `<style>` take precedence.
+
+```jsx
+import * as React from 'react';
+import { SvgCss } from 'react-native-svg/css';
+
+const xml = `
+  <svg width="32" height="32" viewBox="0 0 32 32">
+    <rect fill="var(--brand)" x="0" y="0" width="32" height="32" />
+  </svg>
+`;
+
+export default () => (
+  <SvgCss xml={xml} cssVars={{ '--brand': '#ff0000' }} />
+);
+```
+
+The same prop is accepted by `SvgCssUri`, `SvgWithCss`, and `SvgWithCssUri`.
+
 # Common props:
 
 | Name             | Default  | Description                                                                                                                                                            |

--- a/__tests__/__snapshots__/css.test.tsx.snap
+++ b/__tests__/__snapshots__/css.test.tsx.snap
@@ -1,5 +1,68 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`SvgCss renders with cssVars prop 1`] = `
+<RNSVGSvgView
+  align="xMidYMid"
+  bbHeight="100%"
+  bbWidth="100%"
+  cssVars={
+    Object {
+      "--brand": "#ff0000",
+    }
+  }
+  focusable={false}
+  meetOrSlice={0}
+  minX={0}
+  minY={0}
+  style={
+    Array [
+      Object {
+        "backgroundColor": "transparent",
+        "borderWidth": 0,
+      },
+      Object {
+        "flex": 0,
+        "height": "100%",
+        "width": "100%",
+      },
+    ]
+  }
+  vbHeight={10}
+  vbWidth={10}
+  xml="<svg xmlns=\\"http://www.w3.org/2000/svg\\" viewBox=\\"0 0 10 10\\">
+    <rect width=\\"10\\" height=\\"10\\" fill=\\"var(--brand)\\" />
+  </svg>"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <RNSVGGroup
+    fill={
+      Object {
+        "payload": 4278190080,
+        "type": 0,
+      }
+    }
+  >
+    <RNSVGRect
+      fill={
+        Object {
+          "payload": 4294901760,
+          "type": 0,
+        }
+      }
+      height={10}
+      propList={
+        Array [
+          "fill",
+        ]
+      }
+      width={10}
+      x={0}
+      y={0}
+    />
+  </RNSVGGroup>
+</RNSVGSvgView>
+`;
+
 exports[`inlines styles 1`] = `
 Object {
   "Tag": [Function],

--- a/__tests__/css.test.tsx
+++ b/__tests__/css.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import renderer from 'react-test-renderer';
 import { parse } from '../src/ReactNativeSVG';
-import { SvgCss, inlineStyles } from '../css';
+import { SvgCss, inlineStyles, resolveCssVars } from '../css';
 
 const xml = `<?xml version="1.0" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
@@ -51,5 +51,39 @@ test('inlines styles', () => {
 
 test('supports CSS in style element', () => {
   const tree = renderer.create(<SvgCss xml={xml} />).toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+test('resolveCssVars resolves var() when no <style> is present', () => {
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10">
+    <rect width="10" height="10" fill="var(--brand)" />
+  </svg>`;
+  const ast = parse(svg, resolveCssVars({ '--brand': 'red' })) as {
+    children: { props?: { fill?: string } }[];
+  };
+  const rect = ast.children.find((c) => c.props && 'fill' in c.props);
+  expect(rect?.props?.fill).toBe('red');
+});
+
+test('composing resolveCssVars over inlineStyles lets <style> win', () => {
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10">
+    <style>:root { --brand: green; }</style>
+    <rect width="10" height="10" fill="var(--brand)" />
+  </svg>`;
+  const resolve = resolveCssVars({ '--brand': 'red' });
+  const ast = parse(svg, (a) => resolve(inlineStyles(a))) as {
+    children: { props?: { fill?: string } }[];
+  };
+  const rect = ast.children.find((c) => c.props && 'fill' in c.props);
+  expect(rect?.props?.fill).toBe('green');
+});
+
+test('SvgCss renders with cssVars prop', () => {
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10">
+    <rect width="10" height="10" fill="var(--brand)" />
+  </svg>`;
+  const tree = renderer
+    .create(<SvgCss xml={svg} cssVars={{ '--brand': '#ff0000' }} />)
+    .toJSON();
   expect(tree).toMatchSnapshot();
 });

--- a/src/css/css.tsx
+++ b/src/css/css.tsx
@@ -765,13 +765,45 @@ export const inlineStyles: Middleware = function inlineStyles(
   return document;
 };
 
-export function SvgCss(props: XmlProps) {
-  const { xml, override, fallback, onError = err } = props;
-  try {
-    const ast = useMemo<JsxAST | null>(
-      () => (xml !== null ? parse(xml, inlineStyles) : null),
-      [xml]
+/**
+ * Map of caller-supplied CSS custom properties. Keys must be `--`-prefixed,
+ * e.g. `{ '--brand': '#ff0000' }`.
+ */
+export type CssVars = Record<string, string>;
+
+/**
+ * Middleware that resolves `var(--name)` references on color-like props
+ * (color, fill, floodColor, lightingColor, stopColor, stroke) against a
+ * caller-supplied variable map. Compose with `inlineStyles` so that
+ * `<style>`-declared variables win:
+ *
+ *   parse(xml, (ast) => resolveCssVars(vars)(inlineStyles(ast)))
+ */
+export const resolveCssVars =
+  (vars: CssVars): Middleware =>
+  (document: XmlAST) => {
+    const variables = new Map<string, string>(Object.entries(vars));
+    const elementsWithColor = cssSelect(
+      '*[color], *[fill], *[floodColor], *[lightingColor], *[stopColor], *[stroke]',
+      document,
+      cssSelectOpts
     );
+    for (const element of elementsWithColor) {
+      resolveElementVariables(element, variables);
+    }
+    return document;
+  };
+
+export function SvgCss(props: XmlProps & { cssVars?: CssVars }) {
+  const { xml, override, fallback, onError = err, cssVars } = props;
+  try {
+    const ast = useMemo<JsxAST | null>(() => {
+      if (xml === null) return null;
+      const middleware: Middleware = cssVars
+        ? (ast) => resolveCssVars(cssVars)(inlineStyles(ast))
+        : inlineStyles;
+      return parse(xml, middleware);
+    }, [xml, cssVars]);
     return <SvgAst ast={ast} override={override || props} />;
   } catch (error) {
     onError(error);
@@ -779,8 +811,8 @@ export function SvgCss(props: XmlProps) {
   }
 }
 
-export function SvgCssUri(props: UriProps) {
-  const { uri, onError = err, onLoad, fallback } = props;
+export function SvgCssUri(props: UriProps & { cssVars?: CssVars }) {
+  const { uri, onError = err, onLoad, fallback, cssVars } = props;
   const [xml, setXml] = useState<string | null>(null);
   const [isError, setIsError] = useState(false);
   useEffect(() => {
@@ -799,27 +831,36 @@ export function SvgCssUri(props: UriProps) {
   if (isError) {
     return fallback ?? null;
   }
-  return <SvgCss xml={xml} override={props} fallback={fallback} />;
+  return (
+    <SvgCss xml={xml} override={props} fallback={fallback} cssVars={cssVars} />
+  );
 }
 
 // Extending Component is required for Animated support.
 
-export class SvgWithCss extends Component<XmlProps, XmlState> {
+export class SvgWithCss extends Component<
+  XmlProps & { cssVars?: CssVars },
+  XmlState
+> {
   state = { ast: null };
   componentDidMount() {
     this.parse(this.props.xml);
   }
 
-  componentDidUpdate(prevProps: { xml: string | null }) {
-    const { xml } = this.props;
-    if (xml !== prevProps.xml) {
+  componentDidUpdate(prevProps: { xml: string | null; cssVars?: CssVars }) {
+    const { xml, cssVars } = this.props;
+    if (xml !== prevProps.xml || cssVars !== prevProps.cssVars) {
       this.parse(xml);
     }
   }
 
   parse(xml: string | null) {
     try {
-      this.setState({ ast: xml ? parse(xml, inlineStyles) : null });
+      const { cssVars } = this.props;
+      const middleware: Middleware = cssVars
+        ? (ast) => resolveCssVars(cssVars)(inlineStyles(ast))
+        : inlineStyles;
+      this.setState({ ast: xml ? parse(xml, middleware) : null });
     } catch (e) {
       this.props.onError ? this.props.onError(e as Error) : console.error(e);
     }
@@ -834,7 +875,10 @@ export class SvgWithCss extends Component<XmlProps, XmlState> {
   }
 }
 
-export class SvgWithCssUri extends Component<UriProps, UriState> {
+export class SvgWithCssUri extends Component<
+  UriProps & { cssVars?: CssVars },
+  UriState
+> {
   state = { xml: null };
   componentDidMount() {
     this.fetch(this.props.uri);
@@ -861,6 +905,6 @@ export class SvgWithCssUri extends Component<UriProps, UriState> {
       props,
       state: { xml },
     } = this;
-    return <SvgWithCss xml={xml} override={props} />;
+    return <SvgWithCss xml={xml} override={props} cssVars={props.cssVars} />;
   }
 }

--- a/src/css/index.tsx
+++ b/src/css/index.tsx
@@ -4,7 +4,9 @@ import {
   SvgWithCss,
   SvgWithCssUri,
   inlineStyles,
+  resolveCssVars,
 } from './css';
+import type { CssVars } from './css';
 
 import { LocalSvg, WithLocalSvg, loadLocalRawResource } from './LocalSvg';
 
@@ -14,7 +16,9 @@ export {
   SvgWithCss,
   SvgWithCssUri,
   inlineStyles,
+  resolveCssVars,
   LocalSvg,
   WithLocalSvg,
   loadLocalRawResource,
 };
+export type { CssVars };


### PR DESCRIPTION
# Summary

Closes #2853. Supplies CSS custom properties from JS for SVGs that reference `var(--name)` without defining the variables inline — useful for theming or when prepending values to an SVG string received from elsewhere.

```tsx
<SvgCss xml={svg} cssVars={{ '--brand': theme.primary }} />
```

## How

Adds two new exports from `react-native-svg/css`:

- **`resolveCssVars(vars): Middleware`** — a new `Middleware` that resolves `var()` references on color-like props (color, fill, floodColor, lightingColor, stopColor, stroke) against a caller-supplied variable map. Reuses the existing `cssSelect` query and `resolveElementVariables` helpers from `inlineStyles`.
- **`CssVars`** — the variable map type.

The intended composition is to run `inlineStyles` first and `resolveCssVars` second, so `<style>`-declared variables win over caller-supplied ones:

```ts
parse(xml, (ast) => resolveCssVars(vars)(inlineStyles(ast)))
```

For convenience, `SvgCss`, `SvgCssUri`, `SvgWithCss`, and `SvgWithCssUri` accept an optional `cssVars` prop that performs the composition internally. 

## Scope

- Pure JS layer (`src/css/css.tsx`, `src/css/index.tsx`). No native code.
- `inlineStyles` is **unchanged**. The `Middleware` type is **unchanged**.
- Existing call sites (`parse(xml, inlineStyles)`, `<SvgCss xml={...} />` without `cssVars`) take exactly the same code path as before.

## Test Plan

1. `yarn jest css.test` — three new tests pass:
   - `resolveCssVars resolves var() when no <style> is present`
   - `composing resolveCssVars over inlineStyles lets <style> win`
   - `SvgCss renders with cssVars prop`

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |     ✅      |
| MacOS   |     ✅      |
| Android |     ✅      |
| Web     |     ✅      |

JS-only change — runs everywhere the existing `SvgCss` components run.

## Checklist

- [ ] I have tested this on a device and a simulator
- [x] I added documentation in `USAGE.md` (the project's user-facing docs; `README.md` links here)
- [x] I updated the typed files (typescript)
- [x] I added a test for the API in the `__tests__` folder
