### PR TITLE
fix: iOS hitTest should not check fill area when fill is none (#1256)

### DIFF
--- a/apple/RNSVGRenderable.mm
+++ b/apple/RNSVGRenderable.mm
@@ -695,9 +695,12 @@ UInt32 saturate(CGFloat value)
   }
 
   BOOL evenodd = self.fillRule == kRNSVGCGFCRuleEvenodd;
-  if (!CGPathContainsPoint(_hitArea, nil, transformed, evenodd) &&
-      !CGPathContainsPoint(self.strokePath, nil, transformed, NO) &&
-      !CGPathContainsPoint(self.markerPath, nil, transformed, NO)) {
+  BOOL inFillArea = self.fill != nil && _hitArea && CGPathContainsPoint(_hitArea, nil, transformed, evenodd);
+  BOOL inStrokeArea =
+      self.stroke != nil && self.strokePath && CGPathContainsPoint(self.strokePath, nil, transformed, NO);
+  BOOL inMarkerArea = self.markerPath && CGPathContainsPoint(self.markerPath, nil, transformed, NO);
+
+  if (!inFillArea && !inStrokeArea && !inMarkerArea) {
     return nil;
   }
 


### PR DESCRIPTION
## Summary

Fixes #1256 — iOS: `onPress` not working correctly on SVG Path with `fill="none"` and only a visible stroke.

## Problem

When a `<Path>` has `fill="none"` and only a visible stroke, the `hitTest` method on iOS was still checking `_hitArea` (the fill path) alongside `strokePath`. This caused inconsistent `onPress` behavior — touches on the stroke were sometimes missed because the fill-area check was used regardless of whether there was actually a fill.

**Before:** The hit test checked all three areas (fill, stroke, marker) unconditionally:
```objc
if (!CGPathContainsPoint(_hitArea, nil, transformed, evenodd) &&
    !CGPathContainsPoint(self.strokePath, nil, transformed, NO) &&
    !CGPathContainsPoint(self.markerPath, nil, transformed, NO)) {
    return nil;
}
```

**After:** Each area is only checked if the corresponding property is set:
```objc
BOOL inFillArea = self.fill != nil && _hitArea && CGPathContainsPoint(_hitArea, nil, transformed, evenodd);
BOOL inStrokeArea = self.stroke != nil && self.strokePath && CGPathContainsPoint(self.strokePath, nil, transformed, NO);
BOOL inMarkerArea = self.markerPath && CGPathContainsPoint(self.markerPath, nil, transformed, NO);

if (!inFillArea && !inStrokeArea && !inMarkerArea) {
    return nil;
}
```

## Test Plan

1. Create a `<Path>` with `fill="none"`, a visible `stroke`, and an `onPress` handler
2. Tap on the stroked line on iOS — `onPress` should fire consistently
3. Verify that elements with only a fill (no stroke) continue to work as before
4. Verify that elements with both fill and stroke are touchable in both areas

## Related

- Issue: https://github.com/software-mansion/react-native-svg/issues/1256