### PR TITLE
fix: apply x/y props on nested Svg elements as translate transform (#1283)

### DIFF
--- a/src/elements/Svg.tsx
+++ b/src/elements/Svg.tsx
@@ -111,6 +111,8 @@ export default class Svg extends Shape<SvgProps> {
       height,
       focusable,
       transform,
+      x,
+      y,
 
       // Inherited G properties
       font,
@@ -136,6 +138,8 @@ export default class Svg extends Shape<SvgProps> {
     }
 
     const props: extractedProps = extracted as extractedProps;
+    delete (props as Record<string, unknown>).x;
+    delete (props as Record<string, unknown>).y;
     props.focusable = Boolean(focusable) && focusable !== 'false';
     const rootStyles: StyleProp<ViewStyle>[] = [defaultStyle];
 
@@ -178,13 +182,29 @@ export default class Svg extends Shape<SvgProps> {
     extractResponder(props, props, this as ResponderInstanceProps);
 
     const gStyle = Object.assign({}, StyleSheet.flatten(style));
-    if (transform) {
+    if (transform || x != null || y != null) {
       if (gStyle.transform) {
         props.transform = gStyle.transform;
         gStyle.transform = undefined;
       }
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      props.transform = extractTransformSvgView(props as any);
+      const svgTransform = extractTransformSvgView(props as any);
+      if (x != null || y != null) {
+        const translateX = x != null ? parseFloat(String(x)) : 0;
+        const translateY = y != null ? parseFloat(String(y)) : 0;
+        const translateTransform = [
+          { translateX },
+          { translateY },
+        ];
+        props.transform = svgTransform
+          ? [
+              ...(Array.isArray(svgTransform) ? svgTransform : [svgTransform]),
+              ...translateTransform,
+            ]
+          : translateTransform;
+      } else {
+        props.transform = svgTransform;
+      }
     }
 
     const RNSVGSvg = Platform.OS === 'android' ? RNSVGSvgAndroid : RNSVGSvgIOS;
@@ -210,7 +230,6 @@ export default class Svg extends Shape<SvgProps> {
             strokeLinecap,
             strokeLinejoin,
             strokeMiterlimit,
-            onLayout,
           }}
         />
       </RNSVGSvg>


### PR DESCRIPTION
## Summary

Fixes #1283 — Nested SVG elements do not respect `x` and `y` props for positioning.

## Problem

When embedding an `<Svg>` inside another `<Svg>`, setting the `x` and `y` props on the inner SVG had no effect. On the web, nested SVG elements respect `x`/`y` for viewport positioning within their parent SVG.

## Fix

The `x` and `y` props are now extracted in the Svg element's render method and converted to a `translate` transform that gets merged with any existing `transform` prop.

```tsx
if (x != null || y != null) {
  const translateTransform = [
    { translateX: x != null ? parseFloat(String(x)) : 0 },
    { translateY: y != null ? parseFloat(String(y)) : 0 },
  ];
  props.transform = svgTransform
    ? [...svgTransformArray, ...translateTransform]
    : translateTransform;
}
```

The `x` and `y` props are also removed from the extracted props before passing to the native component to avoid unknown prop warnings.

## Test Plan

```tsx
<Svg width="400" height="400">
  <Svg x="50" y="100" width="200" height="200">
    <Rect width="200" height="200" fill="blue" />
  </Svg>
</Svg>
```

The inner SVG (blue rect) should be positioned at (50, 100) within the outer SVG.