### PR TITLE
fix: add xmlns and xmlnsXlink to SvgProps types (#1638)

### DIFF
--- a/src/elements/Svg.tsx
+++ b/src/elements/Svg.tsx
@@ -43,6 +43,8 @@ export interface SvgProps extends GProps, ViewProps, HitSlop {
   preserveAspectRatio?: string;
   color?: ColorValue;
   title?: string;
+  xmlns?: string;
+  xmlnsXlink?: string;
 }
 
 export default class Svg extends Shape<SvgProps> {


### PR DESCRIPTION
# Summary

Closes #1638.

Using `xmlns` (and `xmlnsXlink`) on `<Svg>` raises a TypeScript error:

```
TS2322: Property 'xmlns' does not exist on type 'IntrinsicAttributes & ...'
```

This is the standard output of SVGO and most web/SVG export tools, so people
who paste an optimized SVG component hit the error immediately:

```tsx
<Svg xmlns="http://www.w3.org/2000/svg" width={1242.667} height={974.667} viewBox="0 0 932 731">
  <Path d="..." />
</Svg>
```

`SvgProps` already accepts other root-only attributes like `viewBox` and
`preserveAspectRatio`, but not the namespace attributes. This adds them as
optional strings. They are inert in the native renderer (no behavior change),
so this is purely a type-surface fix that lets the standard exported markup
type-check.

## Test Plan

`<Svg xmlns="http://www.w3.org/2000/svg" xmlnsXlink="http://www.w3.org/1999/xlink" />`
fails `yarn tsc` before this change and passes after.

- `yarn tsc` passes
- `yarn lint` passes

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |     N/A     |
| MacOS   |     N/A     |
| Android |     N/A     |
| Web     |     N/A     |

Type-only change; no platform code affected.

## Checklist

- [ ] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [x] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
