### PR TITLE
VO-6881:Add VizioOS SvgUri support via native RNSVGSvgView component

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 3.20)
+
+# ViziOS platform implementation for react-native-svg
+add_subdirectory(vizios)

--- a/src/fabric/IOSSvgViewNativeComponent.vizios.ts
+++ b/src/fabric/IOSSvgViewNativeComponent.vizios.ts
@@ -1,0 +1,13 @@
+import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
+import type { Float } from 'react-native/Libraries/Types/CodegenTypes';
+import type { ViewProps } from './utils';
+
+interface NativeProps extends ViewProps {
+  svgUri?: string;
+  minX?: Float;
+  minY?: Float;
+  vbWidth?: Float;
+  vbHeight?: Float;
+}
+
+export default codegenNativeComponent<NativeProps>('RNSVGSvgView');

--- a/src/xml.tsx
+++ b/src/xml.tsx
@@ -1,9 +1,11 @@
 import type { ComponentType, ComponentProps, JSX } from 'react';
 import * as React from 'react';
 import { Component, useEffect, useMemo, useState } from 'react';
+import { Platform } from 'react-native';
 import { fetchText } from './utils/fetchData';
 import type { SvgProps } from './elements/Svg';
 import { tags } from './xmlTags';
+import RNSVGSvgVizios from './fabric/IOSSvgViewNativeComponent';
 
 function missingTag() {
   return null;
@@ -81,6 +83,19 @@ export function SvgXml(props: XmlProps) {
 
 export function SvgUri(props: UriProps) {
   const { onError = err, uri, onLoad, fallback } = props;
+
+  // On VizioOS, pass the URI directly to the native SvgView component.
+  // Loki's image pipeline handles SVG fetching & rasterization via ThorVG.
+  if (Platform.OS === 'vizios') {
+    const { width, height, style, ...rest } = props;
+    return (
+      <RNSVGSvgVizios
+        style={[{ width: width as any, height: height as any }, style]}
+        svgUri={uri ?? undefined}
+      />
+    );
+  }
+
   const [xml, setXml] = useState<string | null>(null);
   const [isError, setIsError] = useState(false);
   useEffect(() => {

--- a/vizios/CMakeLists.txt
+++ b/vizios/CMakeLists.txt
@@ -1,0 +1,30 @@
+cmake_minimum_required(VERSION 3.16)
+
+set(RNSVG_VIZIOS_SOURCES
+    RNSVGSvgViewProps.cpp
+    RNSVGSvgViewShadowNode.cpp
+    RNSVGRegistration.cpp
+)
+
+add_library(rnsvg_vizios OBJECT ${RNSVG_VIZIOS_SOURCES})
+
+target_include_directories(rnsvg_vizios PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+target_link_libraries(rnsvg_vizios
+    folly_runtime
+    glog
+    glog_init
+    jsi
+    logger
+    react_debug
+    rrc_view
+    react_render_core
+    react_render_css
+    react_render_debug
+    react_render_graphics
+    yoga
+)
+
+target_compile_reactnative_options(rnsvg_vizios PRIVATE)

--- a/vizios/RNSVGRegistration.cpp
+++ b/vizios/RNSVGRegistration.cpp
@@ -1,0 +1,16 @@
+#include "RNSVGRegistration.h"
+#include "RNSVGSvgViewComponentDescriptor.h"
+
+namespace facebook::react {
+
+void rnsvg_registerComponentDescriptors(
+    ComponentDescriptorProviderRegistry& registry) {
+  registry.add(concreteComponentDescriptorProvider<RNSVGSvgViewComponentDescriptor>());
+}
+
+void rnsvg_addSupportedComponents(
+    std::set<std::string, std::less<>>& components) {
+  components.insert("RNSVGSvgView");
+}
+
+} // namespace facebook::react

--- a/vizios/RNSVGRegistration.h
+++ b/vizios/RNSVGRegistration.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <react/renderer/componentregistry/ComponentDescriptorProviderRegistry.h>
+#include <set>
+#include <string>
+
+namespace facebook::react {
+
+void rnsvg_registerComponentDescriptors(
+    ComponentDescriptorProviderRegistry& registry);
+
+void rnsvg_addSupportedComponents(
+    std::set<std::string, std::less<>>& components);
+
+} // namespace facebook::react

--- a/vizios/RNSVGSvgViewComponentDescriptor.h
+++ b/vizios/RNSVGSvgViewComponentDescriptor.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <react/renderer/core/ConcreteComponentDescriptor.h>
+#include "RNSVGSvgViewShadowNode.h"
+
+namespace facebook::react {
+
+class RNSVGSvgViewComponentDescriptor final
+    : public ConcreteComponentDescriptor<RNSVGSvgViewShadowNode> {
+ public:
+  explicit RNSVGSvgViewComponentDescriptor(const ComponentDescriptorParameters& p)
+      : ConcreteComponentDescriptor(p) {}
+};
+
+} // namespace facebook::react

--- a/vizios/RNSVGSvgViewProps.cpp
+++ b/vizios/RNSVGSvgViewProps.cpp
@@ -1,0 +1,21 @@
+#include "RNSVGSvgViewProps.h"
+
+#include <react/renderer/core/RawProps.h>
+#include <react/renderer/core/propsConversions.h>
+
+namespace facebook::react {
+
+RNSVGSvgViewProps::RNSVGSvgViewProps() = default;
+
+RNSVGSvgViewProps::RNSVGSvgViewProps(
+    const PropsParserContext& context,
+    const RNSVGSvgViewProps& sourceProps,
+    const RawProps& rawProps)
+    : ViewProps(context, sourceProps, rawProps),
+      svgUri(convertRawProp(context, rawProps, "svgUri", sourceProps.svgUri, std::string{})),
+      minX(convertRawProp(context, rawProps, "minX", sourceProps.minX, 0.0f)),
+      minY(convertRawProp(context, rawProps, "minY", sourceProps.minY, 0.0f)),
+      vbWidth(convertRawProp(context, rawProps, "vbWidth", sourceProps.vbWidth, 0.0f)),
+      vbHeight(convertRawProp(context, rawProps, "vbHeight", sourceProps.vbHeight, 0.0f)) {}
+
+} // namespace facebook::react

--- a/vizios/RNSVGSvgViewProps.h
+++ b/vizios/RNSVGSvgViewProps.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <react/renderer/components/view/ViewProps.h>
+#include <react/renderer/core/PropsParserContext.h>
+
+namespace facebook::react {
+
+class RNSVGSvgViewProps final : public ViewProps {
+ public:
+  RNSVGSvgViewProps();
+  RNSVGSvgViewProps(
+      const PropsParserContext& context,
+      const RNSVGSvgViewProps& sourceProps,
+      const RawProps& rawProps);
+
+  // URI for loading SVG from a remote/local source (used by SvgUri)
+  std::string svgUri;
+
+  // viewBox components (optional)
+  Float minX{0.0f};
+  Float minY{0.0f};
+  Float vbWidth{0.0f};
+  Float vbHeight{0.0f};
+};
+
+} // namespace facebook::react

--- a/vizios/RNSVGSvgViewShadowNode.cpp
+++ b/vizios/RNSVGSvgViewShadowNode.cpp
@@ -1,0 +1,7 @@
+#include "RNSVGSvgViewShadowNode.h"
+
+namespace facebook::react {
+
+const char RNSVGSvgViewComponentName[] = "RNSVGSvgView";
+
+} // namespace facebook::react

--- a/vizios/RNSVGSvgViewShadowNode.h
+++ b/vizios/RNSVGSvgViewShadowNode.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <react/renderer/components/view/ConcreteViewShadowNode.h>
+#include "RNSVGSvgViewProps.h"
+
+namespace facebook::react {
+
+extern const char RNSVGSvgViewComponentName[];
+
+using RNSVGSvgViewShadowNode = ConcreteViewShadowNode<
+    RNSVGSvgViewComponentName,
+    RNSVGSvgViewProps,
+    ViewEventEmitter>;
+
+} // namespace facebook::react


### PR DESCRIPTION
https://vizio.atlassian.net/browse/VO-6881

**Summary**:

Changes done in [VO-6881](https://vizio.atlassian.net/browse/VO-6881) : 

React Native Thirdparty module for SVG changes for SVG URI and Static SVG

- [x] Your code builds clean without any errors
- [x] You tested your changes, and they work on TV
- [x] You documented your changes, added references