### PR TITLE
fix: update iOS/tvOS deployment target to 15.1 for Xcode 27 compatibility

### DIFF
--- a/RNSVG.podspec
+++ b/RNSVG.podspec
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
   s.visionos.exclude_files = '**/*.macos.{h,m,mm}' if s.respond_to?(:visionos)
   s.osx.exclude_files = '**/*.ios.{h,m,mm}'
   s.requires_arc      = true
-  s.platforms         = { :osx => "10.14", :ios => "12.4", :tvos => "12.4", :visionos => "1.0" }
+  s.platforms         = { :osx => "10.15", :ios => "15.1", :tvos => "15.1", :visionos => "1.0" }
   
   s.osx.resource_bundles  = {'RNSVGFilters' => ['apple/**/*.macosx.metallib']}
   s.ios.resource_bundles  = {'RNSVGFilters' => ['apple/**/*.iphoneos.metallib']}


### PR DESCRIPTION
## Summary

Updates the minimum deployment targets in  to fix build failures with Xcode 27 / iOS 27 SDK.

## Problem

Xcode 27 only supports deployment targets from **15.0 to 27.0.x**. The previous value of  caused the  resource bundle target to fail:



## Changes

- : 12.4 → 15.1
- : 12.4 → 15.1
- : 10.14 → 10.15

## Why 15.1?

React Native 0.76+ already requires iOS 15.1 as minimum. This aligns with the React Native ecosystem's current baseline.

Fixes #2992