### PR TITLE
docs: fix 'Exmaple' typo in filters section

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -1327,7 +1327,7 @@ Not supported yet:
 - FeTile
 - FeTurbulence
 
-Exmaple use of filters:
+Example use of filters:
 
 ```jsx
 import React from 'react';


### PR DESCRIPTION
## Summary
Fixes a spelling typo in `USAGE.md` under the filters section: `Exmaple` → `Example`.

## Test plan
- [ ] Confirm the filters documentation heading reads correctly

Made with [Cursor](https://cursor.com)