### PR TITLE
fix: support generic font families on Apple platforms

### DIFF
--- a/apple/Text/RNSVGGlyphContext.mm
+++ b/apple/Text/RNSVGGlyphContext.mm
@@ -104,6 +104,33 @@
 - (void)pushContext:(RNSVGGroup *)node font:(NSDictionary *)font;
 @end
 
+static NSString *RNSVGResolveGenericFontFamily(NSString *fontFamily)
+{
+  if ([fontFamily length] == 0) {
+    return nil;
+  }
+
+  NSString *normalizedFontFamily = [fontFamily lowercaseString];
+
+  if ([normalizedFontFamily isEqualToString:@"serif"]) {
+    return @"Georgia";
+  }
+  if ([normalizedFontFamily isEqualToString:@"sans-serif"]) {
+    return @"System";
+  }
+  if ([normalizedFontFamily isEqualToString:@"monospace"]) {
+    return @"Menlo";
+  }
+  if ([normalizedFontFamily isEqualToString:@"cursive"]) {
+    return @"Snell Roundhand";
+  }
+  if ([normalizedFontFamily isEqualToString:@"fantasy"]) {
+    return @"Papyrus";
+  }
+
+  return fontFamily;
+}
+
 @implementation RNSVGGlyphContext
 
 - (NSArray *)getFontContext
@@ -118,7 +145,7 @@
   NSString *fontStyle = RNSVGFontStyleStrings[topFont_->fontStyle];
   NSString *fontWeight = RNSVGFontWeightStrings[topFont_->fontWeight];
   UIFont *font = [RCTFont updateFont:nil
-                          withFamily:[fontFamily isEqualToString:@""] ? nil : fontFamily
+                          withFamily:RNSVGResolveGenericFontFamily(fontFamily)
                                 size:@(isnan(size) ? 0 : size)
                               weight:fontWeight
                                style:fontStyle

--- a/apps/common/test/Test2976.tsx
+++ b/apps/common/test/Test2976.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import {View} from 'react-native';
+import {Svg, Text} from 'react-native-svg';
+
+export default function Test2976() {
+  return (
+    <View style={{flex: 1, justifyContent: 'center', paddingHorizontal: 24}}>
+      <Svg height="160" width="100%">
+        <Text y="45" fontSize={28}>
+          System font: The quick brown fox
+        </Text>
+        <Text y="105" fontFamily="serif" fontSize={28}>
+          Serif font: The quick brown fox
+        </Text>
+      </Svg>
+    </View>
+  );
+}

--- a/apps/common/test/index.tsx
+++ b/apps/common/test/index.tsx
@@ -37,6 +37,7 @@ import Test2471 from './Test2471';
 import Test2520 from './Test2520';
 import Test2670 from './Test2670';
 import Test2923 from './Test2923';
+import Test2976 from './Test2976';
 
 export default function App() {
   return <ColorTest />;


### PR DESCRIPTION
# Summary

Closes #2976.

This fixes generic CSS font family names on Apple platforms. Previously, values like `fontFamily="serif"` were passed directly to React Native's `RCTFont` helper. `RCTFont` does not resolve CSS generic family keywords such as `serif`, so iOS reported the family as unrecognized and fell back to the default system sans-serif font.

The Apple text glyph path now resolves generic family keywords before calling `RCTFont updateFont`:

- `serif` -> `Georgia`
- `sans-serif` -> `System`
- `monospace` -> `Menlo`
- `cursive` -> `Snell Roundhand`
- `fantasy` -> `Papyrus`

I also added a common test screen reproducing the issue with a default system text line and a `fontFamily="serif"` line.

## Test Plan

Commands run locally:

- `yarn lint` ✅
- `yarn tsc` ✅
- `git diff --check` ✅

### What's required for testing (prerequisites)?

An iOS simulator or device running the example app.

### What are the steps to reproduce (after prerequisites)?

1. Open the common test app.
2. Render `Test2976`.
3. Confirm the first SVG text line uses the default system sans-serif font.
4. Confirm the second SVG text line with `fontFamily="serif"` renders with a serif font instead of falling back to the default system font.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |      ✅      |
| MacOS   |      ✅      |
| Android |      ❌      |
| Web     |      ❌      |

Android and Web are not changed by this PR; the issue was reported for iOS and the fix is in the Apple text implementation.

## Checklist

- [ ] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [ ] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
