### PR TITLE
Set the default value for RadialGradientView

### DIFF
--- a/android/src/main/java/com/horcrux/svg/RadialGradientView.java
+++ b/android/src/main/java/com/horcrux/svg/RadialGradientView.java
@@ -26,7 +26,7 @@ class RadialGradientView extends DefinitionView {
   private SVGLength mCx;
   private SVGLength mCy;
   private ReadableArray mGradient;
-  private Brush.BrushUnits mGradientUnits;
+  private Brush.BrushUnits mGradientUnits = Brush.BrushUnits.OBJECT_BOUNDING_BOX;
 
   private static final float[] sRawMatrix =
       new float[] {


### PR DESCRIPTION
# Summary

This sets a default value for `RadialGradient` (same issue as `LinearGradient` which was fixed in https://github.com/software-mansion/react-native-svg/pull/2949 ). This is important when enabling props 2.0 diffing mode. There is more context for this issue in https://github.com/software-mansion/react-native-svg/pull/2948 .

## Test Plan

### What's required for testing (prerequisites)?

Try to set the feature flags mentioned above and then observe the issues with radial gradient

### What are the steps to reproduce (after prerequisites)?

^

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌      |
| MacOS   |    ❌      |
| Android |    ✅      |
| Web     |    ❌      |

## Checklist

- [x] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [ ] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
