### PR TITLE
refactor: inline the Touchable press state machine

### DIFF
--- a/__tests__/touchable.test.tsx
+++ b/__tests__/touchable.test.tsx
@@ -1,0 +1,363 @@
+import renderer from 'react-test-renderer';
+import Svg, { Rect } from '../src';
+
+// Fake native ref: measure() reports a 100x100 view at page offset (0, 0).
+const createTarget = () => ({
+  measure: (
+    callback: (
+      x: number,
+      y: number,
+      width: number,
+      height: number,
+      pageX: number,
+      pageY: number
+    ) => void
+  ) => callback(0, 0, 100, 100, 0, 0), // eslint-disable-line n/no-callback-literal
+});
+
+const createTouchEvent = (target: unknown, pageX = 50, pageY = 50) => ({
+  persist: jest.fn(),
+  currentTarget: target,
+  nativeEvent: {
+    pageX,
+    pageY,
+    locationX: pageX,
+    locationY: pageY,
+    identifier: 1,
+    target,
+    timestamp: 100,
+    touches: [],
+    changedTouches: [],
+  },
+});
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+type Handlers = {
+  onStartShouldSetResponder: (e: any) => boolean;
+  onResponderGrant: (e: any) => void;
+  onResponderMove: (e: any) => void;
+  onResponderRelease: (e: any) => void;
+  onResponderTerminate: (e: any) => void;
+  onResponderTerminationRequest: (e: any) => boolean;
+};
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+const renderRect = (props: object) => {
+  let tree!: renderer.ReactTestRenderer;
+  renderer.act(() => {
+    tree = renderer.create(
+      <Svg width="200" height="200">
+        <Rect x="0" y="0" width="100" height="100" {...props} />
+      </Svg>
+    );
+  });
+  const nodes = tree.root.findAll(
+    (node) =>
+      typeof node.type === 'string' &&
+      node.props.onStartShouldSetResponder != null
+  );
+  return { tree, handlers: (nodes[0]?.props ?? {}) as Handlers, nodes };
+};
+
+describe('touchable behavior of SVG elements', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test('does not attach responder handlers without touchable props', () => {
+    let tree!: renderer.ReactTestRenderer;
+    renderer.act(() => {
+      tree = renderer.create(
+        <Svg width="200" height="200">
+          <Rect x="0" y="0" width="100" height="100" fill="red" />
+        </Svg>
+      );
+    });
+    const responders = tree.root.findAll(
+      (node) =>
+        typeof node.type === 'string' &&
+        node.props.onStartShouldSetResponder != null
+    );
+    expect(responders).toHaveLength(0);
+  });
+
+  test('attaches all responder handlers when onPress is set', () => {
+    const { handlers, nodes } = renderRect({ onPress: jest.fn() });
+    expect(nodes).toHaveLength(1);
+    expect(typeof handlers.onStartShouldSetResponder).toBe('function');
+    expect(typeof handlers.onResponderGrant).toBe('function');
+    expect(typeof handlers.onResponderMove).toBe('function');
+    expect(typeof handlers.onResponderRelease).toBe('function');
+    expect(typeof handlers.onResponderTerminate).toBe('function');
+    expect(typeof handlers.onResponderTerminationRequest).toBe('function');
+    expect((handlers as { responsible?: boolean }).responsible).toBe(true);
+  });
+
+  test('keeps accessibility props on the host element', () => {
+    const { nodes } = renderRect({
+      onPress: jest.fn(),
+      accessible: true,
+      accessibilityLabel: 'a rectangle',
+    });
+    const props = nodes[0].props as {
+      accessible?: boolean;
+      accessibilityLabel?: string;
+    };
+    expect(props.accessible).toBe(true);
+    expect(props.accessibilityLabel).toBe('a rectangle');
+  });
+
+  test('calls onPressIn, onPress and onPressOut on tap', () => {
+    const onPress = jest.fn();
+    const onPressIn = jest.fn();
+    const onPressOut = jest.fn();
+
+    const { handlers } = renderRect({ onPress, onPressIn, onPressOut });
+    const target = createTarget();
+
+    expect(handlers.onStartShouldSetResponder(createTouchEvent(target))).toBe(
+      true
+    );
+
+    handlers.onResponderGrant(createTouchEvent(target));
+    expect(onPressIn).toHaveBeenCalledTimes(1);
+    expect(onPress).not.toHaveBeenCalled();
+
+    handlers.onResponderRelease(createTouchEvent(target));
+    expect(onPress).toHaveBeenCalledTimes(1);
+    expect(onPressOut).toHaveBeenCalledTimes(1);
+
+    const pressInOrder = onPressIn.mock.invocationCallOrder[0];
+    const pressOrder = onPress.mock.invocationCallOrder[0];
+    expect(pressInOrder).toBeLessThan(pressOrder);
+  });
+
+  test('respects delayPressIn', () => {
+    const onPressIn = jest.fn();
+
+    const { handlers } = renderRect({
+      onPress: jest.fn(),
+      onPressIn,
+      delayPressIn: 100,
+    });
+
+    const target = createTarget();
+    handlers.onResponderGrant(createTouchEvent(target));
+    expect(onPressIn).not.toHaveBeenCalled();
+    jest.advanceTimersByTime(99);
+    expect(onPressIn).not.toHaveBeenCalled();
+    jest.advanceTimersByTime(1);
+    expect(onPressIn).toHaveBeenCalledTimes(1);
+  });
+
+  test('respects delayPressOut', () => {
+    const onPressOut = jest.fn();
+
+    const { handlers } = renderRect({
+      onPress: jest.fn(),
+      onPressOut,
+      delayPressOut: 100,
+    });
+
+    const target = createTarget();
+    handlers.onResponderGrant(createTouchEvent(target));
+    handlers.onResponderRelease(createTouchEvent(target));
+    expect(onPressOut).not.toHaveBeenCalled();
+    jest.advanceTimersByTime(100);
+    expect(onPressOut).toHaveBeenCalledTimes(1);
+  });
+
+  test('calls onLongPress after 500ms and suppresses onPress', () => {
+    const onPress = jest.fn();
+    const onLongPress = jest.fn();
+    const { handlers } = renderRect({ onPress, onLongPress });
+    const target = createTarget();
+
+    handlers.onResponderGrant(createTouchEvent(target));
+    jest.advanceTimersByTime(499);
+    expect(onLongPress).not.toHaveBeenCalled();
+    jest.advanceTimersByTime(1);
+    expect(onLongPress).toHaveBeenCalledTimes(1);
+
+    handlers.onResponderRelease(createTouchEvent(target));
+    expect(onPress).not.toHaveBeenCalled();
+  });
+
+  test('respects delayLongPress', () => {
+    const onLongPress = jest.fn();
+
+    const { handlers } = renderRect({
+      onPress: jest.fn(),
+      onLongPress,
+      delayLongPress: 200,
+    });
+
+    const target = createTarget();
+    handlers.onResponderGrant(createTouchEvent(target));
+    jest.advanceTimersByTime(199);
+    expect(onLongPress).not.toHaveBeenCalled();
+    jest.advanceTimersByTime(1);
+    expect(onLongPress).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not call onLongPress when released early', () => {
+    const onPress = jest.fn();
+    const onLongPress = jest.fn();
+    const { handlers } = renderRect({ onPress, onLongPress });
+    const target = createTarget();
+
+    handlers.onResponderGrant(createTouchEvent(target));
+    jest.advanceTimersByTime(100);
+    handlers.onResponderRelease(createTouchEvent(target));
+    jest.advanceTimersByTime(1000);
+    expect(onLongPress).not.toHaveBeenCalled();
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  test('cancels long press when the touch moves more than 10px', () => {
+    const onPress = jest.fn();
+    const onLongPress = jest.fn();
+    const { handlers } = renderRect({ onPress, onLongPress });
+    const target = createTarget();
+
+    handlers.onResponderGrant(createTouchEvent(target, 50, 50));
+    handlers.onResponderMove(createTouchEvent(target, 70, 50));
+    jest.advanceTimersByTime(1000);
+    expect(onLongPress).not.toHaveBeenCalled();
+
+    handlers.onResponderRelease(createTouchEvent(target, 70, 50));
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  test('cancels the press when the touch leaves the press rect', () => {
+    const onPress = jest.fn();
+    const onPressOut = jest.fn();
+    const { handlers } = renderRect({ onPress, onPressOut });
+    const target = createTarget();
+
+    handlers.onResponderGrant(createTouchEvent(target, 50, 50));
+    handlers.onResponderMove(createTouchEvent(target, 200, 50));
+    expect(onPressOut).toHaveBeenCalledTimes(1);
+
+    handlers.onResponderRelease(createTouchEvent(target, 200, 50));
+    expect(onPress).not.toHaveBeenCalled();
+  });
+
+  test('keeps the press within the default press retention offset', () => {
+    const onPress = jest.fn();
+    const onPressOut = jest.fn();
+    const { handlers } = renderRect({ onPress, onPressOut });
+    const target = createTarget();
+
+    handlers.onResponderGrant(createTouchEvent(target, 50, 50));
+    // 100px wide + 20px default retention offset: 115 stays inside.
+    handlers.onResponderMove(createTouchEvent(target, 115, 50));
+    expect(onPressOut).not.toHaveBeenCalled();
+
+    handlers.onResponderRelease(createTouchEvent(target, 115, 50));
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  test('restores the press when the touch re-enters the press rect', () => {
+    const onPress = jest.fn();
+    const onPressIn = jest.fn();
+    const { handlers } = renderRect({ onPress, onPressIn });
+    const target = createTarget();
+
+    handlers.onResponderGrant(createTouchEvent(target, 50, 50));
+    handlers.onResponderMove(createTouchEvent(target, 200, 50));
+    handlers.onResponderMove(createTouchEvent(target, 50, 50));
+    expect(onPressIn).toHaveBeenCalledTimes(2);
+
+    handlers.onResponderRelease(createTouchEvent(target, 50, 50));
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  test('extends the press rect with hitSlop', () => {
+    const onPress = jest.fn();
+
+    const { handlers } = renderRect({
+      onPress,
+      hitSlop: { top: 0, left: 0, right: 80, bottom: 0 },
+    });
+
+    const target = createTarget();
+    handlers.onResponderGrant(createTouchEvent(target, 50, 50));
+    // 100px wide + 20px retention + 80px hitSlop: 190 stays inside.
+    handlers.onResponderMove(createTouchEvent(target, 190, 50));
+    handlers.onResponderRelease(createTouchEvent(target, 190, 50));
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not become responder when disabled', () => {
+    const onPress = jest.fn();
+    const { handlers } = renderRect({ onPress, disabled: true });
+    const target = createTarget();
+
+    expect(handlers.onStartShouldSetResponder(createTouchEvent(target))).toBe(
+      false
+    );
+  });
+
+  test('prefers user-supplied responder handlers', () => {
+    const onStartShouldSetResponder = jest.fn(() => false);
+    const onResponderTerminationRequest = jest.fn(() => false);
+
+    const { handlers } = renderRect({
+      onPress: jest.fn(),
+      onStartShouldSetResponder,
+      onResponderTerminationRequest,
+    });
+
+    const target = createTarget();
+
+    expect(handlers.onStartShouldSetResponder(createTouchEvent(target))).toBe(
+      false
+    );
+    expect(onStartShouldSetResponder).toHaveBeenCalledTimes(1);
+    expect(
+      handlers.onResponderTerminationRequest(createTouchEvent(target))
+    ).toBe(false);
+    expect(onResponderTerminationRequest).toHaveBeenCalledTimes(1);
+  });
+
+  test('allows responder termination by default', () => {
+    const { handlers } = renderRect({ onPress: jest.fn() });
+    expect(
+      handlers.onResponderTerminationRequest(createTouchEvent(createTarget()))
+    ).toBe(true);
+  });
+
+  test('termination cancels the press', () => {
+    const onPress = jest.fn();
+    const onPressOut = jest.fn();
+    const { handlers } = renderRect({ onPress, onPressOut });
+    const target = createTarget();
+
+    handlers.onResponderGrant(createTouchEvent(target));
+    handlers.onResponderTerminate(createTouchEvent(target));
+    expect(onPressOut).toHaveBeenCalledTimes(1);
+    expect(onPress).not.toHaveBeenCalled();
+  });
+
+  test('clears pending long press timer on unmount', () => {
+    const onLongPress = jest.fn();
+
+    const { tree, handlers } = renderRect({
+      onPress: jest.fn(),
+      onLongPress,
+    });
+
+    const target = createTarget();
+    handlers.onResponderGrant(createTouchEvent(target));
+    renderer.act(() => {
+      tree.unmount();
+    });
+    jest.advanceTimersByTime(1000);
+    expect(onLongPress).not.toHaveBeenCalled();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -32,7 +32,12 @@
     "targets": [
       "commonjs",
       "module",
-      "typescript"
+      [
+        "typescript",
+        {
+          "project": "tsconfig.build.json"
+        }
+      ]
     ]
   },
   "keywords": [
@@ -78,11 +83,12 @@
     "@react-native/babel-preset": "^0.77.0",
     "@react-native/eslint-config": "^0.77.0",
     "@types/css-tree": "^1.0.3",
-    "@types/jest": "^27.5.2",
+    "@types/jest": "^28.1.0",
     "@types/node": "*",
     "@types/pixelmatch": "^5.2.0",
     "@types/pngjs": "^6.0.5",
     "@types/react": "^18.3.12",
+    "@types/react-test-renderer": "^18.2.0",
     "@types/ws": "^8.5.13",
     "@typescript-eslint/eslint-plugin": "^5.11.0",
     "@typescript-eslint/parser": "^5.11.0",
@@ -109,7 +115,7 @@
     "puppeteer": "^22.12.1",
     "react": "^18.3.1",
     "react-native": "^0.77.0",
-    "react-native-builder-bob": "^0.20.4",
+    "react-native-builder-bob": "^0.22.0",
     "react-native-windows": "^0.77.0",
     "react-test-renderer": "^18.2.0",
     "ts-node": "^10.9.2",

--- a/src/lib/SvgTouchableMixin.ts
+++ b/src/lib/SvgTouchableMixin.ts
@@ -1,129 +1,672 @@
-import type { GestureResponderEvent } from 'react-native';
-import { Touchable } from 'react-native';
+import type { GestureResponderEvent, Insets } from 'react-native';
+
+/**
+ * Self-contained port of the press interaction state machine from
+ * react-native's deprecated `Touchable.Mixin`. It only depends on the
+ * gesture responder system, so it works without the core `Touchable` API.
+ *
+ * Differences with the original implementation:
+ * - No Android tap sound on press (`SoundManager` has no public export).
+ * - Measurement uses the granted responder node or the instance `root` ref
+ *   instead of `UIManager.measure`.
+ */
+
 const PRESS_RETENTION_OFFSET = { top: 20, left: 20, right: 20, bottom: 30 };
-// @ts-expect-error: Mixin is not typed
-const { Mixin } = Touchable;
-const {
-  touchableHandleStartShouldSetResponder,
-  touchableHandleResponderTerminationRequest,
-  touchableHandleResponderGrant,
-  touchableHandleResponderMove,
-  touchableHandleResponderRelease,
-  touchableHandleResponderTerminate,
-  touchableGetInitialState,
-} = Mixin;
+const HIGHLIGHT_DELAY_MS = 130;
+const LONG_PRESS_THRESHOLD = 500;
+const LONG_PRESS_DELAY_MS = LONG_PRESS_THRESHOLD - HIGHLIGHT_DELAY_MS;
+const LONG_PRESS_ALLOWED_MOVEMENT = 10;
+const PRESS_EXPAND_PX = 20;
+
+const States = {
+  NOT_RESPONDER: 'NOT_RESPONDER',
+  RESPONDER_INACTIVE_PRESS_IN: 'RESPONDER_INACTIVE_PRESS_IN',
+  RESPONDER_INACTIVE_PRESS_OUT: 'RESPONDER_INACTIVE_PRESS_OUT',
+  RESPONDER_ACTIVE_PRESS_IN: 'RESPONDER_ACTIVE_PRESS_IN',
+  RESPONDER_ACTIVE_PRESS_OUT: 'RESPONDER_ACTIVE_PRESS_OUT',
+  RESPONDER_ACTIVE_LONG_PRESS_IN: 'RESPONDER_ACTIVE_LONG_PRESS_IN',
+  RESPONDER_ACTIVE_LONG_PRESS_OUT: 'RESPONDER_ACTIVE_LONG_PRESS_OUT',
+  ERROR: 'ERROR',
+} as const;
+
+type State = (typeof States)[keyof typeof States];
+
+const IsActive: Partial<Record<State, boolean>> = {
+  RESPONDER_ACTIVE_PRESS_OUT: true,
+  RESPONDER_ACTIVE_PRESS_IN: true,
+};
+
+const IsPressingIn: Partial<Record<State, boolean>> = {
+  RESPONDER_INACTIVE_PRESS_IN: true,
+  RESPONDER_ACTIVE_PRESS_IN: true,
+  RESPONDER_ACTIVE_LONG_PRESS_IN: true,
+};
+
+const IsLongPressingIn: Partial<Record<State, boolean>> = {
+  RESPONDER_ACTIVE_LONG_PRESS_IN: true,
+};
+
+const Signals = {
+  DELAY: 'DELAY',
+  RESPONDER_GRANT: 'RESPONDER_GRANT',
+  RESPONDER_RELEASE: 'RESPONDER_RELEASE',
+  RESPONDER_TERMINATED: 'RESPONDER_TERMINATED',
+  ENTER_PRESS_RECT: 'ENTER_PRESS_RECT',
+  LEAVE_PRESS_RECT: 'LEAVE_PRESS_RECT',
+  LONG_PRESS_DETECTED: 'LONG_PRESS_DETECTED',
+} as const;
+
+type Signal = (typeof Signals)[keyof typeof Signals];
+
+const Transitions: Record<State, Record<Signal, State>> = {
+  NOT_RESPONDER: {
+    DELAY: States.ERROR,
+    RESPONDER_GRANT: States.RESPONDER_INACTIVE_PRESS_IN,
+    RESPONDER_RELEASE: States.ERROR,
+    RESPONDER_TERMINATED: States.ERROR,
+    ENTER_PRESS_RECT: States.ERROR,
+    LEAVE_PRESS_RECT: States.ERROR,
+    LONG_PRESS_DETECTED: States.ERROR,
+  },
+  RESPONDER_INACTIVE_PRESS_IN: {
+    DELAY: States.RESPONDER_ACTIVE_PRESS_IN,
+    RESPONDER_GRANT: States.ERROR,
+    RESPONDER_RELEASE: States.NOT_RESPONDER,
+    RESPONDER_TERMINATED: States.NOT_RESPONDER,
+    ENTER_PRESS_RECT: States.RESPONDER_INACTIVE_PRESS_IN,
+    LEAVE_PRESS_RECT: States.RESPONDER_INACTIVE_PRESS_OUT,
+    LONG_PRESS_DETECTED: States.ERROR,
+  },
+  RESPONDER_INACTIVE_PRESS_OUT: {
+    DELAY: States.RESPONDER_ACTIVE_PRESS_OUT,
+    RESPONDER_GRANT: States.ERROR,
+    RESPONDER_RELEASE: States.NOT_RESPONDER,
+    RESPONDER_TERMINATED: States.NOT_RESPONDER,
+    ENTER_PRESS_RECT: States.RESPONDER_INACTIVE_PRESS_IN,
+    LEAVE_PRESS_RECT: States.RESPONDER_INACTIVE_PRESS_OUT,
+    LONG_PRESS_DETECTED: States.ERROR,
+  },
+  RESPONDER_ACTIVE_PRESS_IN: {
+    DELAY: States.ERROR,
+    RESPONDER_GRANT: States.ERROR,
+    RESPONDER_RELEASE: States.NOT_RESPONDER,
+    RESPONDER_TERMINATED: States.NOT_RESPONDER,
+    ENTER_PRESS_RECT: States.RESPONDER_ACTIVE_PRESS_IN,
+    LEAVE_PRESS_RECT: States.RESPONDER_ACTIVE_PRESS_OUT,
+    LONG_PRESS_DETECTED: States.RESPONDER_ACTIVE_LONG_PRESS_IN,
+  },
+  RESPONDER_ACTIVE_PRESS_OUT: {
+    DELAY: States.ERROR,
+    RESPONDER_GRANT: States.ERROR,
+    RESPONDER_RELEASE: States.NOT_RESPONDER,
+    RESPONDER_TERMINATED: States.NOT_RESPONDER,
+    ENTER_PRESS_RECT: States.RESPONDER_ACTIVE_PRESS_IN,
+    LEAVE_PRESS_RECT: States.RESPONDER_ACTIVE_PRESS_OUT,
+    LONG_PRESS_DETECTED: States.ERROR,
+  },
+  RESPONDER_ACTIVE_LONG_PRESS_IN: {
+    DELAY: States.ERROR,
+    RESPONDER_GRANT: States.ERROR,
+    RESPONDER_RELEASE: States.NOT_RESPONDER,
+    RESPONDER_TERMINATED: States.NOT_RESPONDER,
+    ENTER_PRESS_RECT: States.RESPONDER_ACTIVE_LONG_PRESS_IN,
+    LEAVE_PRESS_RECT: States.RESPONDER_ACTIVE_LONG_PRESS_OUT,
+    LONG_PRESS_DETECTED: States.RESPONDER_ACTIVE_LONG_PRESS_IN,
+  },
+  RESPONDER_ACTIVE_LONG_PRESS_OUT: {
+    DELAY: States.ERROR,
+    RESPONDER_GRANT: States.ERROR,
+    RESPONDER_RELEASE: States.NOT_RESPONDER,
+    RESPONDER_TERMINATED: States.NOT_RESPONDER,
+    ENTER_PRESS_RECT: States.RESPONDER_ACTIVE_LONG_PRESS_IN,
+    LEAVE_PRESS_RECT: States.RESPONDER_ACTIVE_LONG_PRESS_OUT,
+    LONG_PRESS_DETECTED: States.ERROR,
+  },
+  ERROR: {
+    DELAY: States.NOT_RESPONDER,
+    RESPONDER_GRANT: States.RESPONDER_INACTIVE_PRESS_IN,
+    RESPONDER_RELEASE: States.NOT_RESPONDER,
+    RESPONDER_TERMINATED: States.NOT_RESPONDER,
+    ENTER_PRESS_RECT: States.NOT_RESPONDER,
+    LEAVE_PRESS_RECT: States.NOT_RESPONDER,
+    LONG_PRESS_DETECTED: States.NOT_RESPONDER,
+  },
+};
+
+type NativeTouchEvent = GestureResponderEvent['nativeEvent'];
+
+const extractSingleTouch = (nativeEvent: NativeTouchEvent) => {
+  const touches = nativeEvent.touches;
+  const changedTouches = nativeEvent.changedTouches;
+  const hasTouches = touches && touches.length > 0;
+  const hasChangedTouches = changedTouches && changedTouches.length > 0;
+
+  return !hasTouches && hasChangedTouches
+    ? changedTouches[0]
+    : hasTouches
+    ? touches[0]
+    : nativeEvent;
+};
+
+type MeasureCallback = (
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  pageX: number,
+  pageY: number
+) => void;
+
+type Measurable = { measure: (callback: MeasureCallback) => void };
+
+const isMeasurable = (node: unknown): node is Measurable =>
+  node != null &&
+  typeof node === 'object' &&
+  typeof (node as Measurable).measure === 'function';
+
+interface TouchableProps {
+  disabled?: boolean;
+  onPress?: (e: GestureResponderEvent) => void;
+  onPressIn?: (e: GestureResponderEvent) => void;
+  onPressOut?: (e: GestureResponderEvent) => void;
+  onLongPress?: (e: GestureResponderEvent) => void;
+  delayPressIn?: number;
+  delayPressOut?: number;
+  delayLongPress?: number;
+  pressRetentionOffset?: Insets;
+  hitSlop?: Insets;
+  rejectResponderTermination?: boolean;
+  onStartShouldSetResponder?: (e: GestureResponderEvent) => boolean;
+  onResponderTerminationRequest?: (e: GestureResponderEvent) => boolean;
+  onResponderGrant?: (e: GestureResponderEvent) => void;
+  onResponderMove?: (e: GestureResponderEvent) => void;
+  onResponderRelease?: (e: GestureResponderEvent) => void;
+  onResponderTerminate?: (e: GestureResponderEvent) => void;
+  onFocus?: (e: unknown) => void;
+  onBlur?: (e: unknown) => void;
+}
+
+interface TouchableState {
+  touchable: {
+    touchState: State | undefined;
+    responderID: unknown;
+    positionOnActivate?: { left: number; top: number } | null;
+    dimensionsOnActivate?: { width: number; height: number } | null;
+  };
+}
+
+interface TouchableInstance {
+  props: TouchableProps;
+  state: TouchableState;
+  root?: unknown;
+  touchableDelayTimeout?: ReturnType<typeof setTimeout> | null;
+  longPressDelayTimeout?: ReturnType<typeof setTimeout> | null;
+  pressOutDelayTimeout?: ReturnType<typeof setTimeout> | null;
+  pressInLocation?: {
+    pageX: number;
+    pageY: number;
+    locationX: number;
+    locationY: number;
+  } | null;
+  _remeasureMetricsOnActivation: () => void;
+  _handleQueryLayout: MeasureCallback;
+  _handleDelay: (e: GestureResponderEvent) => void;
+  _handleLongDelay: (e: GestureResponderEvent) => void;
+  _receiveSignal: (signal: Signal, e: GestureResponderEvent) => void;
+  _cancelLongPressDelayTimeout: () => void;
+  _isHighlight: (state: State) => boolean;
+  _savePressInLocation: (e: GestureResponderEvent) => void;
+  _getDistanceBetweenPoints: (
+    aX: number,
+    aY: number,
+    bX: number,
+    bY: number
+  ) => number;
+  _performSideEffectsForTransition: (
+    curState: State,
+    nextState: State,
+    signal: Signal,
+    e: GestureResponderEvent
+  ) => void;
+  _startHighlight: (e: GestureResponderEvent) => void;
+  _endHighlight: (e: GestureResponderEvent) => void;
+  touchableHandlePress: (e: GestureResponderEvent) => void;
+  touchableHandleActivePressIn: (e: GestureResponderEvent) => void;
+  touchableHandleActivePressOut: (e: GestureResponderEvent) => void;
+  touchableHandleLongPress: (e: GestureResponderEvent) => void;
+  touchableLongPressCancelsPress: () => boolean;
+  touchableGetPressRectOffset: () => Insets;
+  touchableGetHitSlop: () => Insets | undefined;
+  touchableGetHighlightDelayMS: () => number;
+  touchableGetLongPressDelayMS: () => number;
+  touchableGetPressOutDelayMS: () => number;
+}
+
+const touchableGetInitialState = (): TouchableState => ({
+  touchable: { touchState: undefined, responderID: null },
+});
 
 const SvgTouchableMixin = {
-  ...Mixin,
+  componentWillUnmount(this: TouchableInstance) {
+    this.touchableDelayTimeout && clearTimeout(this.touchableDelayTimeout);
+    this.longPressDelayTimeout && clearTimeout(this.longPressDelayTimeout);
+    this.pressOutDelayTimeout && clearTimeout(this.pressOutDelayTimeout);
+  },
 
-  touchableHandleStartShouldSetResponder(e: GestureResponderEvent) {
+  touchableGetInitialState,
+
+  touchableHandleStartShouldSetResponder(
+    this: TouchableInstance,
+    e: GestureResponderEvent
+  ): boolean {
     const { onStartShouldSetResponder } = this.props;
     if (onStartShouldSetResponder) {
       return onStartShouldSetResponder(e);
-    } else {
-      return touchableHandleStartShouldSetResponder.call(this, e);
     }
+    return !this.props.disabled;
   },
 
-  touchableHandleResponderTerminationRequest(e: GestureResponderEvent) {
+  touchableHandleResponderTerminationRequest(
+    this: TouchableInstance,
+    e: GestureResponderEvent
+  ): boolean {
     const { onResponderTerminationRequest } = this.props;
     if (onResponderTerminationRequest) {
       return onResponderTerminationRequest(e);
-    } else {
-      return touchableHandleResponderTerminationRequest.call(this, e);
     }
+    return !this.props.rejectResponderTermination;
   },
 
-  touchableHandleResponderGrant(e: GestureResponderEvent) {
+  touchableLongPressCancelsPress(): boolean {
+    return true;
+  },
+
+  touchableHandleResponderGrant(
+    this: TouchableInstance,
+    e: GestureResponderEvent
+  ) {
     const { onResponderGrant } = this.props;
     if (onResponderGrant) {
       return onResponderGrant(e);
-    } else {
-      return touchableHandleResponderGrant.call(this, e);
     }
+
+    const dispatchID = e.currentTarget;
+    // The event is reused in timer callbacks, so it must leave the pool.
+    e.persist();
+
+    this.pressOutDelayTimeout && clearTimeout(this.pressOutDelayTimeout);
+    this.pressOutDelayTimeout = null;
+
+    this.state.touchable.touchState = States.NOT_RESPONDER;
+    this.state.touchable.responderID = dispatchID;
+    this._receiveSignal(Signals.RESPONDER_GRANT, e);
+
+    let delayMS = Math.max(this.touchableGetHighlightDelayMS(), 0);
+    delayMS = isNaN(delayMS) ? HIGHLIGHT_DELAY_MS : delayMS;
+    if (delayMS !== 0) {
+      this.touchableDelayTimeout = setTimeout(
+        () => this._handleDelay(e),
+        delayMS
+      );
+    } else {
+      this._handleDelay(e);
+    }
+
+    let longDelayMS = Math.max(this.touchableGetLongPressDelayMS(), 10);
+    longDelayMS = isNaN(longDelayMS) ? LONG_PRESS_DELAY_MS : longDelayMS;
+    this.longPressDelayTimeout = setTimeout(
+      () => this._handleLongDelay(e),
+      longDelayMS + delayMS
+    );
   },
 
-  touchableHandleResponderMove(e: GestureResponderEvent) {
-    const { onResponderMove } = this.props;
-    if (onResponderMove) {
-      return onResponderMove(e);
-    } else {
-      return touchableHandleResponderMove.call(this, e);
-    }
-  },
-
-  touchableHandleResponderRelease(e: GestureResponderEvent) {
+  touchableHandleResponderRelease(
+    this: TouchableInstance,
+    e: GestureResponderEvent
+  ) {
     const { onResponderRelease } = this.props;
     if (onResponderRelease) {
       return onResponderRelease(e);
-    } else {
-      return touchableHandleResponderRelease.call(this, e);
     }
+    this.pressInLocation = null;
+    this._receiveSignal(Signals.RESPONDER_RELEASE, e);
   },
 
-  touchableHandleResponderTerminate(e: GestureResponderEvent) {
+  touchableHandleResponderTerminate(
+    this: TouchableInstance,
+    e: GestureResponderEvent
+  ) {
     const { onResponderTerminate } = this.props;
     if (onResponderTerminate) {
       return onResponderTerminate(e);
+    }
+    this.pressInLocation = null;
+    this._receiveSignal(Signals.RESPONDER_TERMINATED, e);
+  },
+
+  touchableHandleResponderMove(
+    this: TouchableInstance,
+    e: GestureResponderEvent
+  ) {
+    const { onResponderMove } = this.props;
+    if (onResponderMove) {
+      return onResponderMove(e);
+    }
+
+    const { positionOnActivate, dimensionsOnActivate } = this.state.touchable;
+
+    // Measurement may not have returned yet.
+    if (!positionOnActivate || !dimensionsOnActivate) {
+      return;
+    }
+
+    const pressRectOffset = this.touchableGetPressRectOffset();
+
+    let pressExpandLeft = pressRectOffset.left ?? PRESS_EXPAND_PX;
+    let pressExpandTop = pressRectOffset.top ?? PRESS_EXPAND_PX;
+    let pressExpandRight = pressRectOffset.right ?? PRESS_EXPAND_PX;
+    let pressExpandBottom = pressRectOffset.bottom ?? PRESS_EXPAND_PX;
+
+    const hitSlop = this.touchableGetHitSlop();
+    if (hitSlop) {
+      pressExpandLeft += hitSlop.left || 0;
+      pressExpandTop += hitSlop.top || 0;
+      pressExpandRight += hitSlop.right || 0;
+      pressExpandBottom += hitSlop.bottom || 0;
+    }
+
+    const touch = extractSingleTouch(e.nativeEvent);
+    const pageX = touch && touch.pageX;
+    const pageY = touch && touch.pageY;
+
+    if (this.pressInLocation) {
+      const movedDistance = this._getDistanceBetweenPoints(
+        pageX,
+        pageY,
+        this.pressInLocation.pageX,
+        this.pressInLocation.pageY
+      );
+      if (movedDistance > LONG_PRESS_ALLOWED_MOVEMENT) {
+        this._cancelLongPressDelayTimeout();
+      }
+    }
+
+    const isTouchWithinActive =
+      pageX > positionOnActivate.left - pressExpandLeft &&
+      pageY > positionOnActivate.top - pressExpandTop &&
+      pageX <
+        positionOnActivate.left +
+          dimensionsOnActivate.width +
+          pressExpandRight &&
+      pageY <
+        positionOnActivate.top +
+          dimensionsOnActivate.height +
+          pressExpandBottom;
+
+    if (isTouchWithinActive) {
+      const prevState = this.state.touchable.touchState;
+      this._receiveSignal(Signals.ENTER_PRESS_RECT, e);
+      const curState = this.state.touchable.touchState;
+      if (
+        curState === States.RESPONDER_INACTIVE_PRESS_IN &&
+        prevState !== States.RESPONDER_INACTIVE_PRESS_IN
+      ) {
+        this._cancelLongPressDelayTimeout();
+      }
     } else {
-      return touchableHandleResponderTerminate.call(this, e);
+      this._cancelLongPressDelayTimeout();
+      this._receiveSignal(Signals.LEAVE_PRESS_RECT, e);
     }
   },
 
-  touchableHandlePress(e: GestureResponderEvent) {
+  touchableHandleFocus(this: TouchableInstance, e: unknown) {
+    this.props.onFocus && this.props.onFocus(e);
+  },
+
+  touchableHandleBlur(this: TouchableInstance, e: unknown) {
+    this.props.onBlur && this.props.onBlur(e);
+  },
+
+  touchableHandlePress(this: TouchableInstance, e: GestureResponderEvent) {
     const { onPress } = this.props;
     onPress && onPress(e);
   },
 
-  touchableHandleActivePressIn(e: GestureResponderEvent) {
+  touchableHandleActivePressIn(
+    this: TouchableInstance,
+    e: GestureResponderEvent
+  ) {
     const { onPressIn } = this.props;
     onPressIn && onPressIn(e);
   },
 
-  touchableHandleActivePressOut(e: GestureResponderEvent) {
+  touchableHandleActivePressOut(
+    this: TouchableInstance,
+    e: GestureResponderEvent
+  ) {
     const { onPressOut } = this.props;
     onPressOut && onPressOut(e);
   },
 
-  touchableHandleLongPress(e: GestureResponderEvent) {
+  touchableHandleLongPress(this: TouchableInstance, e: GestureResponderEvent) {
     const { onLongPress } = this.props;
     onLongPress && onLongPress(e);
   },
 
-  touchableGetPressRectOffset() {
+  touchableGetPressRectOffset(this: TouchableInstance): Insets {
     const { pressRetentionOffset } = this.props;
     return pressRetentionOffset || PRESS_RETENTION_OFFSET;
   },
 
-  touchableGetHitSlop() {
+  touchableGetHitSlop(this: TouchableInstance): Insets | undefined {
     const { hitSlop } = this.props;
     return hitSlop;
   },
 
-  touchableGetHighlightDelayMS() {
+  touchableGetHighlightDelayMS(this: TouchableInstance): number {
     const { delayPressIn } = this.props;
     return delayPressIn || 0;
   },
 
-  touchableGetLongPressDelayMS() {
+  touchableGetLongPressDelayMS(this: TouchableInstance): number {
     const { delayLongPress } = this.props;
-    return delayLongPress === 0 ? 0 : delayLongPress || 500;
+    return delayLongPress === 0 ? 0 : delayLongPress || LONG_PRESS_THRESHOLD;
   },
 
-  touchableGetPressOutDelayMS() {
+  touchableGetPressOutDelayMS(this: TouchableInstance): number {
     const { delayPressOut } = this.props;
     return delayPressOut || 0;
   },
+
+  _remeasureMetricsOnActivation(this: TouchableInstance) {
+    const responderID = this.state.touchable.responderID;
+    if (responderID == null) {
+      return;
+    }
+    if (isMeasurable(responderID)) {
+      responderID.measure(this._handleQueryLayout);
+    } else if (isMeasurable(this.root)) {
+      this.root.measure(this._handleQueryLayout);
+    }
+  },
+
+  _handleQueryLayout(
+    this: TouchableInstance,
+    l: number,
+    t: number,
+    w: number,
+    h: number,
+    globalX: number,
+    globalY: number
+  ) {
+    // Ignore empty results from a failed measurement.
+    if (!l && !t && !w && !h && !globalX && !globalY) {
+      return;
+    }
+    this.state.touchable.positionOnActivate = { left: globalX, top: globalY };
+    this.state.touchable.dimensionsOnActivate = { width: w, height: h };
+  },
+
+  _handleDelay(this: TouchableInstance, e: GestureResponderEvent) {
+    this.touchableDelayTimeout = null;
+    this._receiveSignal(Signals.DELAY, e);
+  },
+
+  _handleLongDelay(this: TouchableInstance, e: GestureResponderEvent) {
+    this.longPressDelayTimeout = null;
+    const curState = this.state.touchable.touchState;
+    if (
+      curState === States.RESPONDER_ACTIVE_PRESS_IN ||
+      curState === States.RESPONDER_ACTIVE_LONG_PRESS_IN
+    ) {
+      this._receiveSignal(Signals.LONG_PRESS_DETECTED, e);
+    }
+  },
+
+  _receiveSignal(
+    this: TouchableInstance,
+    signal: Signal,
+    e: GestureResponderEvent
+  ) {
+    const responderID = this.state.touchable.responderID;
+    const curState = this.state.touchable.touchState;
+    const nextState = curState && Transitions[curState][signal];
+    if (!responderID && signal === Signals.RESPONDER_RELEASE) {
+      return;
+    }
+    if (!nextState) {
+      throw new Error(
+        `Unrecognized signal \`${signal}\` or state \`${curState}\` for responder`
+      );
+    }
+    if (nextState === States.ERROR) {
+      throw new Error(
+        `Cannot transition from \`${curState}\` with signal \`${signal}\` for responder`
+      );
+    }
+    if (curState !== nextState) {
+      this._performSideEffectsForTransition(curState, nextState, signal, e);
+      this.state.touchable.touchState = nextState;
+    }
+  },
+
+  _cancelLongPressDelayTimeout(this: TouchableInstance) {
+    this.longPressDelayTimeout && clearTimeout(this.longPressDelayTimeout);
+    this.longPressDelayTimeout = null;
+  },
+
+  _isHighlight(state: State): boolean {
+    return (
+      state === States.RESPONDER_ACTIVE_PRESS_IN ||
+      state === States.RESPONDER_ACTIVE_LONG_PRESS_IN
+    );
+  },
+
+  _savePressInLocation(this: TouchableInstance, e: GestureResponderEvent) {
+    const touch = extractSingleTouch(e.nativeEvent);
+    const pageX = touch && touch.pageX;
+    const pageY = touch && touch.pageY;
+    const locationX = touch && touch.locationX;
+    const locationY = touch && touch.locationY;
+    this.pressInLocation = { pageX, pageY, locationX, locationY };
+  },
+
+  _getDistanceBetweenPoints(
+    aX: number,
+    aY: number,
+    bX: number,
+    bY: number
+  ): number {
+    const deltaX = aX - bX;
+    const deltaY = aY - bY;
+    return Math.sqrt(deltaX * deltaX + deltaY * deltaY);
+  },
+
+  _performSideEffectsForTransition(
+    this: TouchableInstance,
+    curState: State,
+    nextState: State,
+    signal: Signal,
+    e: GestureResponderEvent
+  ) {
+    const curIsHighlight = this._isHighlight(curState);
+    const newIsHighlight = this._isHighlight(nextState);
+
+    const isFinalSignal =
+      signal === Signals.RESPONDER_TERMINATED ||
+      signal === Signals.RESPONDER_RELEASE;
+
+    if (isFinalSignal) {
+      this._cancelLongPressDelayTimeout();
+    }
+
+    const isInitialTransition =
+      curState === States.NOT_RESPONDER &&
+      nextState === States.RESPONDER_INACTIVE_PRESS_IN;
+
+    const isActiveTransition = !IsActive[curState] && IsActive[nextState];
+    if (isInitialTransition || isActiveTransition) {
+      this._remeasureMetricsOnActivation();
+    }
+
+    if (IsPressingIn[curState] && signal === Signals.LONG_PRESS_DETECTED) {
+      this.touchableHandleLongPress(e);
+    }
+
+    if (newIsHighlight && !curIsHighlight) {
+      this._startHighlight(e);
+    } else if (!newIsHighlight && curIsHighlight) {
+      this._endHighlight(e);
+    }
+
+    if (IsPressingIn[curState] && signal === Signals.RESPONDER_RELEASE) {
+      const hasLongPressHandler = !!this.props.onLongPress;
+
+      const pressIsLongButStillCallOnPress =
+        !!IsLongPressingIn[curState] &&
+        (!hasLongPressHandler || !this.touchableLongPressCancelsPress());
+
+      const shouldInvokePress =
+        !IsLongPressingIn[curState] || pressIsLongButStillCallOnPress;
+
+      if (shouldInvokePress) {
+        if (!newIsHighlight && !curIsHighlight) {
+          // The highlight never fired because of the delay. Fire it now.
+          this._startHighlight(e);
+          this._endHighlight(e);
+        }
+        this.touchableHandlePress(e);
+      }
+    }
+
+    this.touchableDelayTimeout && clearTimeout(this.touchableDelayTimeout);
+    this.touchableDelayTimeout = null;
+  },
+
+  _startHighlight(this: TouchableInstance, e: GestureResponderEvent) {
+    this._savePressInLocation(e);
+    this.touchableHandleActivePressIn(e);
+  },
+
+  _endHighlight(this: TouchableInstance, e: GestureResponderEvent) {
+    const delayMS = this.touchableGetPressOutDelayMS();
+    if (delayMS) {
+      this.pressOutDelayTimeout = setTimeout(() => {
+        this.touchableHandleActivePressOut(e);
+      }, delayMS);
+    } else {
+      this.touchableHandleActivePressOut(e);
+    }
+  },
 };
 
-const touchKeys = Object.keys(SvgTouchableMixin);
-const touchVals = touchKeys.map((key) => SvgTouchableMixin[key]);
-const numTouchKeys = touchKeys.length;
+const touchKeys = Object.keys(SvgTouchableMixin) as Array<
+  keyof typeof SvgTouchableMixin
+>;
 
 export default (target: { [x: string]: unknown; state: unknown }) => {
-  for (let i = 0; i < numTouchKeys; i++) {
-    const key = touchKeys[i];
-    const val = touchVals[i];
+  for (const key of touchKeys) {
+    const val = SvgTouchableMixin[key];
     if (typeof val === 'function') {
       target[key] = val.bind(target);
     } else {

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,25 +1,34 @@
 {
   "compilerOptions": {
-    "baseUrl": ".",
     "declaration": true,
+    "types": [
+      "css-tree",
+      "jest",
+      "node",
+      "pixelmatch",
+      "pngjs",
+      "react",
+      "react-test-renderer",
+      "ws"
+    ],
     "paths": {
       "react-native-svg": ["./src"],
       "react-native-svg/css": ["./src/css/index.tsx"],
       "react-native-svg/filter-image": ["./src/filter-image/index.tsx"]
     },
     "preserveSymlinks": true,
-    "target": "es6",
+    "target": "es2015",
     "module": "ESNext",
     "jsx": "react-native",
     "skipLibCheck": true,
     "allowSyntheticDefaultImports": true,
-    "moduleResolution": "node",
-    "lib": ["es6", "dom"],
+    "moduleResolution": "bundler",
+    "lib": ["DOM", "ES2015"],
     "esModuleInterop": true,
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
     "isolatedModules": true
   },
-  "include": ["src"]
+  "include": ["src", "__tests__", "e2e"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2320,13 +2320,13 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
-"@types/jest@^27.5.2":
-  version "27.5.2"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-27.5.2.tgz#ec49d29d926500ffb9fd22b84262e862049c026c"
-  integrity sha512-mpT8LJJ4CMeeahobofYWIjFo0xonRS/HfxnVEPMPFSQdGUt1uHCnoPT7Zhb+sjDU2wz0oKV0OLUR0WzrHNgfeA==
+"@types/jest@^28.1.0":
+  version "28.1.8"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-28.1.8.tgz#6936409f3c9724ea431efd412ea0238a0f03b09b"
+  integrity sha512-8TJkV++s7B6XqnDrzR1m/TT0A0h948Pnl/097veySPN67VRAgQ4gZ7n2KfJo2rVq6njQjdxU3GCCyDvAeuHoiw==
   dependencies:
-    jest-matcher-utils "^27.0.0"
-    pretty-format "^27.0.0"
+    expect "^28.0.0"
+    pretty-format "^28.0.0"
 
 "@types/json-schema@^7.0.9":
   version "7.0.15"
@@ -2381,13 +2381,20 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.15.tgz#e6e5a86d602beaca71ce5163fadf5f95d70931c7"
   integrity sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==
 
-"@types/react@^18.3.12":
-  version "18.3.23"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.3.23.tgz#86ae6f6b95a48c418fecdaccc8069e0fbb63696a"
-  integrity sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==
+"@types/react-test-renderer@^18.2.0":
+  version "18.3.1"
+  resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-18.3.1.tgz#225bfe8d4ad7ee3b04c2fa27642bb74274a5961d"
+  integrity sha512-vAhnk0tG2eGa37lkU9+s5SoroCsRI08xnsWFiAXOuPH2jqzMbcXvKExXViPi1P5fIklDeCvXqyrdmipFaSkZrA==
+  dependencies:
+    "@types/react" "^18"
+
+"@types/react@^18", "@types/react@^18.3.12":
+  version "18.3.31"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.3.31.tgz#b5e95e28ffcceab8d982f33f2eb076e17653c2a4"
+  integrity sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==
   dependencies:
     "@types/prop-types" "*"
-    csstype "^3.0.2"
+    csstype "^3.2.2"
 
 "@types/semver@^7.3.12":
   version "7.7.0"
@@ -3630,10 +3637,10 @@ css-what@^6.1.0:
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-6.2.2.tgz#cdcc8f9b6977719fdfbd1de7aec24abf756b9dea"
   integrity sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==
 
-csstype@^3.0.2:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.3.tgz#d80ff294d114fb0e6ac500fbf85b60137d7eff81"
-  integrity sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==
+csstype@^3.0.2, csstype@^3.2.2:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.2.3.tgz#ec48c0f3e993e50648c86da559e2610995cf989a"
+  integrity sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==
 
 data-uri-to-buffer@^6.0.2:
   version "6.0.2"
@@ -3792,11 +3799,6 @@ devtools-protocol@0.0.1312386:
   version "0.0.1312386"
   resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.1312386.tgz#5ab824d6f1669ec6c6eb0fba047e73601d969052"
   integrity sha512-DPnhUXvmvKT2dFA/j7B+riVLUt9Q6RKJlcppojL5CoRywJJKLDYnRlw0gTFKfgDPHP5E04UoB71SxoJlVZy8FA==
-
-diff-sequences@^27.5.1:
-  version "27.5.1"
-  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-27.5.1.tgz#eaecc0d327fd68c8d9672a1e64ab8dccb2ef5327"
-  integrity sha512-k1gCAXAsNgLwEL+Y8Wvl+M6oEFj5bgazfZULpS5CneoPPXRaCCW7dm+q21Ky2VEE5X+VeRDBVg1Pcvvsr4TtNQ==
 
 diff-sequences@^28.1.1:
   version "28.1.1"
@@ -4477,7 +4479,7 @@ exit@^0.1.2:
   resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
   integrity sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==
 
-expect@^28.1.3:
+expect@^28.0.0, expect@^28.1.3:
   version "28.1.3"
   resolved "https://registry.yarnpkg.com/expect/-/expect-28.1.3.tgz#90a7c1a124f1824133dd4533cce2d2bdcb6603ec"
   integrity sha512-eEh0xn8HlsuOBxFgIss+2mX85VAS4Qy3OSkjV7rlBWljtA4oWH37glVGyOZSZvErDT/yBywZdPGwCXuTvSG85g==
@@ -5591,16 +5593,6 @@ jest-config@^28.1.3:
     slash "^3.0.0"
     strip-json-comments "^3.1.1"
 
-jest-diff@^27.5.1:
-  version "27.5.1"
-  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-27.5.1.tgz#a07f5011ac9e6643cf8a95a462b7b1ecf6680def"
-  integrity sha512-m0NvkX55LDt9T4mctTEgnZk3fmEg3NRYutvMPWM/0iPnkFj2wIeF45O1718cMSOFO1vINkqmxqD8vE37uTEbqw==
-  dependencies:
-    chalk "^4.0.0"
-    diff-sequences "^27.5.1"
-    jest-get-type "^27.5.1"
-    pretty-format "^27.5.1"
-
 jest-diff@^28.1.3:
   version "28.1.3"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-28.1.3.tgz#948a192d86f4e7a64c5264ad4da4877133d8792f"
@@ -5652,11 +5644,6 @@ jest-environment-node@^29.6.3:
     "@types/node" "*"
     jest-mock "^29.7.0"
     jest-util "^29.7.0"
-
-jest-get-type@^27.5.1:
-  version "27.5.1"
-  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-27.5.1.tgz#3cd613c507b0f7ace013df407a1c1cd578bcb4f1"
-  integrity sha512-2KY95ksYSaK7DMBWQn6dQz3kqAf3BB64y2udeG+hv4KfSOb9qwcYQstTJc1KCbsix+wLZWZYN8t7nwX3GOBLRw==
 
 jest-get-type@^28.0.2:
   version "28.0.2"
@@ -5721,16 +5708,6 @@ jest-leak-detector@^28.1.3:
   dependencies:
     jest-get-type "^28.0.2"
     pretty-format "^28.1.3"
-
-jest-matcher-utils@^27.0.0:
-  version "27.5.1"
-  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-27.5.1.tgz#9c0cdbda8245bc22d2331729d1091308b40cf8ab"
-  integrity sha512-z2uTx/T6LBaCoNWNFWwChLBKYxTMcGBRjAt+2SbP929/Fflb9aa5LGma654Rz8z9HLxsrUaYzxE9T/EFIL/PAw==
-  dependencies:
-    chalk "^4.0.0"
-    jest-diff "^27.5.1"
-    jest-get-type "^27.5.1"
-    pretty-format "^27.5.1"
 
 jest-matcher-utils@^28.1.3:
   version "28.1.3"
@@ -6001,11 +5978,6 @@ jest@^28.1.0:
     "@jest/types" "^28.1.3"
     import-local "^3.0.2"
     jest-cli "^28.1.3"
-
-jetifier@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/jetifier/-/jetifier-2.0.0.tgz#699391367ca1fe7bc4da5f8bf691eb117758e4cb"
-  integrity sha512-J4Au9KuT74te+PCCCHKgAjyLlEa+2VyIAEPNCdE5aNkAJ6FAJcAqcdzEkSnzNksIa9NkGmC4tPiClk2e7tCJuQ==
 
 joi@^17.2.1:
   version "17.13.3"
@@ -7348,16 +7320,7 @@ pretty-format@^26.6.2:
     ansi-styles "^4.0.0"
     react-is "^17.0.1"
 
-pretty-format@^27.0.0, pretty-format@^27.5.1:
-  version "27.5.1"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.5.1.tgz#2181879fdea51a7a5851fb39d920faa63f01d88e"
-  integrity sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==
-  dependencies:
-    ansi-regex "^5.0.1"
-    ansi-styles "^5.0.0"
-    react-is "^17.0.1"
-
-pretty-format@^28.1.3:
+pretty-format@^28.0.0, pretty-format@^28.1.3:
   version "28.1.3"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-28.1.3.tgz#c9fba8cedf99ce50963a11b27d982a9ae90970d5"
   integrity sha512-8gFb/To0OmxHR9+ZTb14Df2vNxdGCX8g1xWGUTqUw5TiZvcQf5sHKObd5UcPyLLyowNwDAMTF3XWOG1B6mxl1Q==
@@ -7498,10 +7461,10 @@ react-is@^17.0.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
-react-native-builder-bob@^0.20.4:
-  version "0.20.4"
-  resolved "https://registry.yarnpkg.com/react-native-builder-bob/-/react-native-builder-bob-0.20.4.tgz#02df01b8dc02f1bb2d566f820e33c5d42bfb9c99"
-  integrity sha512-3ZmYP8H7Fg2D8/JAPvxT78I4VWzf5DNMUf69cxWPw7Pukt+hHp1PSQ303af63uv1QXxWMJtrQ11+nuUfVqQf0Q==
+react-native-builder-bob@^0.22.0:
+  version "0.22.0"
+  resolved "https://registry.yarnpkg.com/react-native-builder-bob/-/react-native-builder-bob-0.22.0.tgz#6b55e073888c0f69421c024e7e524d194a887df6"
+  integrity sha512-dp4CmeF5rC9iehQaSZaZAfMyE3QWeU4xjsJ05oOty09qQB7PzC5bwo1RLlP1dCb+TbQqRcoP2gDoUQW1m+f4Mw==
   dependencies:
     "@babel/core" "^7.18.5"
     "@babel/plugin-proposal-class-properties" "^7.17.12"
@@ -7522,8 +7485,6 @@ react-native-builder-bob@^0.20.4:
     prompts "^2.4.2"
     which "^2.0.2"
     yargs "^17.5.1"
-  optionalDependencies:
-    jetifier "^2.0.0"
 
 react-native-windows@^0.77.0:
   version "0.77.11"


### PR DESCRIPTION
# Summary

`Shape` handles presses by mixing in `Touchable.Mixin`, a private and deprecated API of `react-native`. react-native cannot delete `Touchable` while this library uses it.

From `packages/react-native/index.js` at `v0.87.0`:

```js
// `Touchable` has been removed from the public API types, but remains
// re-exported at runtime here because of a hanging `react-native-svg` call
// site (fbsource).
// TODO(huntie): Remove this re-export once `react-native-svg` is updated.
```

## How it is implemented

`src/lib/SvgTouchableMixin.ts` now holds its own copy of the press state machine, ported from `Touchable.Mixin`. Same states, same signals, same transition table, same method names, so the callers are unchanged. It only depends on the gesture responder system, which is public API.

Two differences with the original implementation:

- No Android tap sound on press. `SoundManager` has no public export.
- Measurement calls `measure()` on the granted responder node, falling back to the instance `root` ref, instead of `UIManager.measure`.

The mixin is also fully typed now, so the `// @ts-expect-error: Mixin is not typed` is gone.

## Areas impacted

Press props on every shape element: `onPress`, `onPressIn`, `onPressOut`, `onLongPress`, `delayPressIn`, `delayPressOut`, `delayLongPress`, `pressRetentionOffset`, `hitSlop`, `disabled`, and the user supplied `onResponder*` overrides.

Plus the config needed to type check the new test file:

- `tsconfig.json` includes `__tests__` and `e2e`, and lists `types` explicitly
- new `tsconfig.build.json`, narrowed back to `src`, used by the `bob` typescript target so test globals never reach the published types
- devDependency bumps: `@types/jest`, new `@types/react-test-renderer`, `react-native-builder-bob`

## Test Plan

### What's required for testing (prerequisites)?

`yarn install` at the repo root, then `yarn install` in the example app.

### What are the steps to reproduce (after prerequisites)?

`__tests__/touchable.test.tsx` is new. Its 19 cases cover handler attachment, press order, `delayPressIn` / `delayPressOut` / `delayLongPress`, the 500ms long press threshold, long press cancelling `onPress`, the 10px movement cancel, leaving and re-entering the press rect, the default retention offset, `hitSlop`, `disabled`, user supplied responder handlers, termination, and timer cleanup on unmount.

```sh
yarn jest __tests__/touchable.test.tsx
yarn lint
yarn tsc
```

Then check the `TouchEvents` example screen, which covers `onPress` on `Circle`, `onLongPress` on `Rect`, `onPressIn` / `onPressOut` with `delayPressIn={0}`, and `onPress` on `G` and `Text`:

```sh
cd apps/fabric-example && yarn ios # or yarn android
```

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |     ✅      |
| MacOS   |     ✅      |
| Android |     ✅      |

The change is JavaScript only and shared by every platform. No native code is touched.

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [x] I updated the typed files (typescript)
- [x] I added a test for the API in the `__tests__` folder

## Demos

https://github.com/user-attachments/assets/0000deed-32d4-4fe3-bca0-00c005633bb8

https://github.com/user-attachments/assets/a0798cec-6261-4215-9c30-d40a19588c59