### PR TITLE
ci: Update Apple CI workflows to Xcode 26.6

### DIFF
--- a/.github/workflows/e2e-ios.yml
+++ b/.github/workflows/e2e-ios.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Use latest stable Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '16.4'
+          xcode-version: '26.6'
 
       - name: Get react-native-svg node_modules cache
         uses: actions/cache@v4

--- a/.github/workflows/ios-build-test.yml
+++ b/.github/workflows/ios-build-test.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Use latest stable Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '16.4'
+          xcode-version: '26.6'
 
       - name: Get react-native-svg node_modules cache
         uses: actions/cache@v4

--- a/.github/workflows/macos-build-test.yml
+++ b/.github/workflows/macos-build-test.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Use latest stable Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '16.4'
+          xcode-version: '26.6'
 
       - name: Get react-native-svg node_modules cache
         uses: actions/cache@v4


### PR DESCRIPTION
# Summary

Update iOS E2E, iOS build, and macOS build workflows to use Xcode 26.6.