### PR TITLE
Update CI build tests to target the tests example app

### DIFF
--- a/.github/workflows/android-build-test.yml
+++ b/.github/workflows/android-build-test.yml
@@ -6,8 +6,8 @@ on:
       - 'android/**'
       - 'src/fabric/**'
       - 'package.json'
-      - 'apps/fabric-example/android/**'
-      - 'apps/fabric-example/package.json'
+      - 'apps/tests-example/android/**'
+      - 'apps/tests-example/package.json'
   push:
     branches:
       - main
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        working-directory: [fabric-example]
+        working-directory: [tests-example]
       fail-fast: false
     concurrency:
       group: android-${{ matrix.working-directory }}-${{ github.ref }}

--- a/.github/workflows/ios-build-test.yml
+++ b/.github/workflows/ios-build-test.yml
@@ -7,8 +7,8 @@ on:
       - apple/**
       - src/fabric/**
       - package.json
-      - apps/fabric-example/package.json
-      - apps/fabric-example/ios/**
+      - apps/tests-example/package.json
+      - apps/tests-example/ios/**
   push:
     branches:
       - main
@@ -19,7 +19,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        working-directory: [fabric-example]
+        working-directory: [tests-example]
       fail-fast: false
     env:
       DEVICE: iPhone 17 Pro


### PR DESCRIPTION
## Summary

- Update CI build workflows to `apps/tests-example` to speed up things (no rea/screens/gesture handler).
