### PR TITLE
fix: support CSS asset resolution on React Native 0.87

### DIFF
--- a/__tests__/resolveAssetUri.test.ts
+++ b/__tests__/resolveAssetUri.test.ts
@@ -1,0 +1,91 @@
+import { Image } from 'react-native';
+
+import { resolveAssetUri } from '../src/lib/resolveAssetUri';
+import { resolveAssetUri as resolveAssetUriWeb } from '../src/lib/resolveAssetUri.web';
+
+jest.mock('@react-native/assets-registry/registry', () => ({
+  getAssetByID: jest.fn(),
+}));
+
+const { getAssetByID: mockedGetAssetByID } = jest.requireMock(
+  '@react-native/assets-registry/registry'
+) as { getAssetByID: jest.Mock };
+
+describe('resolveAssetUri', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    mockedGetAssetByID.mockReset();
+  });
+
+  it('uses the public Image resolver for numeric native assets', () => {
+    const asset = {
+      uri: 'http://localhost:8081/assets/icon@2x.svg',
+      width: 24,
+      height: 24,
+      scale: 2,
+    };
+    const resolveAssetSource = jest
+      .spyOn(Image, 'resolveAssetSource')
+      .mockReturnValue(asset);
+
+    expect(resolveAssetUri(7)).toEqual(asset);
+    expect(resolveAssetSource).toHaveBeenCalledWith(7);
+  });
+
+  it('throws when the public Image resolver cannot find a native asset', () => {
+    const resolveAssetSource = jest
+      .spyOn(Image, 'resolveAssetSource')
+      .mockReturnValue(null as never);
+
+    expect(() => resolveAssetUri(404)).toThrow(
+      'Image: asset with ID "404" could not be found.'
+    );
+    expect(resolveAssetSource).toHaveBeenCalledWith(404);
+  });
+
+  it('keeps using the web asset registry for numeric web assets', () => {
+    mockedGetAssetByID.mockReturnValue({
+      __packager_asset: true,
+      fileSystemLocation: '/app/assets',
+      httpServerLocation: '/assets',
+      width: 24,
+      height: 24,
+      scales: [1],
+      hash: 'hash',
+      name: 'icon',
+      type: 'svg',
+    });
+
+    expect(resolveAssetUriWeb(3)).toEqual({
+      uri: '/assets/icon.svg',
+      width: 24,
+      height: 24,
+      scale: 1,
+    });
+    expect(mockedGetAssetByID).toHaveBeenCalledWith(3);
+  });
+
+  it('throws when the web asset registry cannot find an asset', () => {
+    mockedGetAssetByID.mockReturnValue(null);
+
+    expect(() => resolveAssetUriWeb(404)).toThrow(
+      'Image: asset with ID "404" could not be found.'
+    );
+    expect(mockedGetAssetByID).toHaveBeenCalledWith(404);
+  });
+
+  it.each([resolveAssetUri, resolveAssetUriWeb])(
+    'keeps string, object and inline SVG URI behavior unchanged',
+    (resolve) => {
+      expect(resolve('https://example.com/icon.svg')).toEqual({
+        uri: 'https://example.com/icon.svg',
+      });
+      expect(resolve({ uri: 'file:///tmp/icon.svg' })).toEqual({
+        uri: 'file:///tmp/icon.svg',
+      });
+      expect(resolve('data:image/svg+xml;utf8,<svg fill="#fff" />')).toEqual({
+        uri: 'data:image/svg+xml;utf8,%3Csvg%20fill%3D%22%23fff%22%20%2F%3E',
+      });
+    }
+  );
+});

--- a/src/lib/resolveAssetUri.web.ts
+++ b/src/lib/resolveAssetUri.web.ts
@@ -1,8 +1,10 @@
 import {
-  Image,
   ImageResolvedAssetSource,
+  PixelRatio,
   type ImageProps as RNImageProps,
 } from 'react-native';
+// @ts-expect-error react-native/assets-registry doesn't export types.
+import { getAssetByID } from '@react-native/assets-registry/registry';
 
 export type PackagerAsset = {
   __packager_asset: boolean;
@@ -24,13 +26,31 @@ export function resolveAssetUri(
 ): Partial<ImageResolvedAssetSource> | null {
   let src: Partial<ImageResolvedAssetSource> = {};
   if (typeof source === 'number') {
-    const asset = Image.resolveAssetSource(source);
+    // get the URI from the packager
+    const asset: PackagerAsset | null = getAssetByID(source);
     if (asset == null) {
       throw new Error(
         `Image: asset with ID "${source}" could not be found. Please check the image source or packager.`
       );
     }
-    src = asset;
+    src = {
+      width: asset.width,
+      height: asset.height,
+      scale: asset.scales[0],
+    };
+    if (asset.scales.length > 1) {
+      const preferredScale = PixelRatio.get();
+      // Get the scale which is closest to the preferred scale
+      src.scale = asset.scales.reduce((prev, curr) =>
+        Math.abs(curr - preferredScale) < Math.abs(prev - preferredScale)
+          ? curr
+          : prev
+      );
+    }
+    const scaleSuffix = src.scale !== 1 ? `@${src.scale}x` : '';
+    src.uri = asset
+      ? `${asset.httpServerLocation}/${asset.name}${scaleSuffix}.${asset.type}`
+      : '';
   } else if (typeof source === 'string') {
     src.uri = source;
   } else if (


### PR DESCRIPTION
# Summary

Fixes #3015.

React Native 0.87 no longer installs `@react-native/assets-registry` transitively, so importing `react-native-svg/css` failed while Metro resolved `LocalSvg` and `resolveAssetUri`.

This change resolves native numeric assets through the public `Image.resolveAssetSource` API instead. That API is available across react-native-svg's supported React Native range and delegates to the registry owned by the installed React Native version.

The existing registry-based implementation is retained in `resolveAssetUri.web.ts`. React Native Web does not expose `Image.resolveAssetSource`, so using a platform file avoids changing its asset behavior.

I did not use either suggested React Native 0.87-only entry point:

- `react-native/asset-registry` is first exported in React Native 0.87;
- the root `AssetRegistry` named export is also absent in React Native 0.78–0.86.

Adding a standalone registry dependency would also risk resolving a different registry version/instance from the one used by React Native. The public Image resolver keeps the library compatible with React Native 0.78 through 0.87 without adding a dependency.

## Test Plan

### React Native 0.87 package-consumption reproduction

I packed the actual package, installed it into the repository's React Native 0.87 test app, removed access to parent `node_modules`, and bundled an entry importing `react-native-svg/css`.

Before the change:

```text
error Unable to resolve module @react-native/assets-registry/registry from
node_modules/react-native-svg/src/lib/resolveAssetUri.ts:
@react-native/assets-registry/registry could not be found within the project
or in these directories:
  node_modules
```

The app had no direct `node_modules/@react-native/assets-registry` installation. With a tarball built from this branch, the same command succeeds:

```text
Welcome to Metro v0.87.0
Writing bundle output to: /private/tmp/rnsvg3015-fixed.bundle
Done writing bundle output
Done in 1.89s.
```

### Oldest supported representative

The same fixed tarball bundles successfully in an isolated React Native 0.78.3 consumer:

```text
0.78.3 / react-native-svg 15.15.5 / assets-registry 0.78.3
Welcome to Metro v0.81.5
Writing bundle output to: /private/tmp/rnsvg3015-rn078.bundle
Done writing bundle output
```

### Regression tests

Keeping the final tests while reverting only the native source change produces:

```text
FAIL __tests__/resolveAssetUri.test.ts
  ✕ uses the public Image resolver for numeric native assets
  ✕ throws when the public Image resolver cannot find a native asset
  ✓ keeps using the web asset registry for numeric web assets
  ✓ throws when the web asset registry cannot find an asset
  ✓ keeps string, object and inline SVG URI behavior unchanged
  ✓ keeps string, object and inline SVG URI behavior unchanged

Tests: 2 failed, 4 passed, 6 total
```

Restoring the change gives 6/6 passing. I also inserted a deliberate failing sentinel into the new suite and confirmed Jest reported that exact assertion, proving the harness collects the file.

Final checks:

```text
yarn test
# lint + tsc: pass

yarn bob
# commonjs + module + typescript: pass

yarn jest __tests__/resolveAssetUri.test.ts --runInBand \
  --config '{"rootDir":".","preset":"react-native","testEnvironment":"node"}'
# 1 suite, 6 tests: pass

npm pack --dry-run --ignore-scripts --json
# includes source, CommonJS, module, and type outputs for both platform files

yarn prettier --check src/lib/resolveAssetUri.ts \
  src/lib/resolveAssetUri.web.ts __tests__/resolveAssetUri.test.ts
# pass
```

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |     ✅      |
| MacOS   |     ✅      |
| Android |     ✅      |
| Web     |     ✅      |

## Checklist

- [x] I have tested this on a device and a simulator (module-resolution change; verified through Metro bundles)
- [ ] I added documentation in `README.md` (not applicable)
- [x] I updated the typed files (typescript)
- [x] I added a test for the API in the `__tests__` folder
