### PR TITLE
fix(ios): clear stroke dasharray on recycled Fabric views

### DIFF
--- a/apple/Utils/RNSVGFabricConversions.h
+++ b/apple/Utils/RNSVGFabricConversions.h
@@ -135,6 +135,8 @@ void setCommonRenderableProps(const T &renderableProps, RNSVGRenderable *rendera
   id strokeDasharray = RNSVGConvertFollyDynamicToId(renderableProps.strokeDasharray);
   if (strokeDasharray != nil) {
     renderableNode.strokeDasharray = [RCTConvert RNSVGLengthArray:strokeDasharray];
+  } else {
+    renderableNode.strokeDasharray = nil;
   }
   renderableNode.strokeDashoffset = renderableProps.strokeDashoffset;
   renderableNode.strokeMiterlimit = renderableProps.strokeMiterlimit;

--- a/apps/common/test/Test3020.tsx
+++ b/apps/common/test/Test3020.tsx
@@ -1,0 +1,58 @@
+import React, {useState} from 'react';
+import {Button, Text, View} from 'react-native';
+import Svg, {Circle} from 'react-native-svg';
+
+type Mode = 'dashed' | 'omitted' | 'none';
+
+export default function Test3020() {
+  const [mode, setMode] = useState<Mode>('dashed');
+
+  const nextMode = () => {
+    setMode(current =>
+      current === 'dashed'
+        ? 'omitted'
+        : current === 'omitted'
+        ? 'none'
+        : 'dashed',
+    );
+  };
+
+  return (
+    <View style={{flex: 1, alignItems: 'center', justifyContent: 'center'}}>
+      <Svg width={180} height={180}>
+        {mode === 'dashed' ? (
+          <Circle
+            cx={90}
+            cy={90}
+            r={70}
+            stroke="#888888"
+            strokeWidth={10}
+            fill="none"
+            strokeDasharray="1 6"
+          />
+        ) : mode === 'none' ? (
+          <Circle
+            cx={90}
+            cy={90}
+            r={70}
+            stroke="#22aa77"
+            strokeWidth={10}
+            fill="none"
+            strokeDasharray="none"
+          />
+        ) : (
+          <Circle
+            cx={90}
+            cy={90}
+            r={70}
+            stroke="#2277aa"
+            strokeWidth={10}
+            fill="none"
+          />
+        )}
+      </Svg>
+      <Text>{mode}</Text>
+      <Button title="Change stroke dasharray" onPress={nextMode} />
+    </View>
+  );
+}

--- a/apps/common/test/index.tsx
+++ b/apps/common/test/index.tsx
@@ -37,6 +37,7 @@ import Test2471 from './Test2471';
 import Test2520 from './Test2520';
 import Test2670 from './Test2670';
 import Test2923 from './Test2923';
+import Test3020 from './Test3020';
 
 export default function App() {
   return <ColorTest />;


### PR DESCRIPTION
# Summary

Fixes #3006.

Fabric passes an omitted `strokeDasharray` and `strokeDasharray="none"` through the Apple conversion layer as `nil`. The conversion previously skipped the setter in that case, so a mounted renderable that had already received a dash pattern kept it when React reused the same native view for a solid stroke.

This change assigns `nil` in the missing branch. `RNSVGRenderable`'s setter invalidates the node, while its draw path already treats a nil/empty array as a solid stroke. The old architecture, Android, and web paths are unchanged.

A focused `Test3020` screen cycles one keyless `Circle` through dashed, omitted, and `none` states so the recycled-view behavior remains easy to reproduce in the example app.

## Test Plan

### Prerequisites

- Xcode 26.2
- iOS 26.3 simulator, iPhone 17 Pro
- React Native 0.85.3 with Fabric enabled
- Expo SDK 56 repro from #3006
- `react-native-svg` built and packed from this branch (15.15.5)

### Reproduction and result

1. Start with `strokeDasharray="1 6"` on a keyless `Circle`.
2. Reuse the same native view for a branch that omits `strokeDasharray`.
3. Repeat from dashed to `strokeDasharray="none"`.
4. Use distinct keys as a control.

Before this change, steps 2 and 3 both remained dashed; the keyed control was solid. After this change, omitted and `none` are solid, while the dashed state remains dashed.

Counterfactual verification kept the final test screen, reverted only the two-line native reset, rebuilt the iOS app, and reproduced the stale blue dash pattern again. Restoring the reset and rebuilding returned the solid blue and green rings.

Commands/checks:

- `yarn test`
- `yarn bob`
- `yarn check-archs-consistency`
- focused Jest unit suite: 19/19 passing
- current `main` package built and installed into the Expo 56 repro on the iOS simulator
- three incremental iOS Fabric builds: fixed, reverted, restored; all succeeded with 0 errors

### What's required for testing (prerequisites)?

An iOS Fabric app. The issue's reproduction repository can be used directly.

### What are the steps to reproduce (after prerequisites)?

Run the test screen, change `dashed` to `omitted`, then cycle `dashed` to `none`. Both solid branches should render without a dash pattern.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |      ✅      |
| MacOS   | Not tested  |
| Android |     N/A     |
| Web     |     N/A     |

## Checklist

- [ ] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [ ] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder

The new regression screen lives in the repository's `apps/common/test` area rather than the Jest `__tests__` folder because the behavior is specific to native Fabric view reuse.
