### PR TITLE
fix: honor CSS font-family fallback lists

### DIFF
--- a/__tests__/extractText.test.tsx
+++ b/__tests__/extractText.test.tsx
@@ -1,0 +1,29 @@
+import { extractFont } from '../src/lib/extract/extractText';
+
+describe('extractFont font-family fallbacks', () => {
+  it('keeps a single family unchanged after trimming quotes', () => {
+    expect(extractFont({ fontFamily: 'Georgia' }).fontFamily).toBe('Georgia');
+    expect(extractFont({ fontFamily: '"Times New Roman"' }).fontFamily).toBe(
+      'Times New Roman'
+    );
+  });
+
+  it('preserves the full CSS font-family fallback list', () => {
+    expect(extractFont({ fontFamily: 'MissingFont, serif' }).fontFamily).toBe(
+      'MissingFont, serif'
+    );
+  });
+
+  it('strips quotes around each family in a fallback list', () => {
+    expect(
+      extractFont({ fontFamily: '"Times New Roman", Georgia, serif' })
+        .fontFamily
+    ).toBe('Times New Roman, Georgia, serif');
+  });
+
+  it('preserves fallbacks from a CSS font shorthand', () => {
+    expect(
+      extractFont({ font: 'bold 16px MissingFont, serif' }).fontFamily
+    ).toBe('MissingFont, serif');
+  });
+});

--- a/android/src/main/java/com/horcrux/svg/TSpanView.java
+++ b/android/src/main/java/com/horcrux/svg/TSpanView.java
@@ -1198,12 +1198,26 @@ class TSpanView extends TextView {
     return typeface;
   }
 
+  private static boolean isResolvedFontFamily(String family, Typeface typeface, int style) {
+    if (typeface == null) {
+      return false;
+    }
+    if (isGenericOrDefaultFontFamily(family)) {
+      return true;
+    }
+    // Typeface.equals includes style. Compare against a same-style missing
+    // sentinel so bold/italic text still walks the fallback list.
+    Typeface missing = Typeface.create(MISSING_FONT_SENTINEL, style);
+    return !typeface.equals(missing)
+        && !typeface.equals(Typeface.DEFAULT)
+        && !typeface.equals(Typeface.DEFAULT_BOLD);
+  }
+
   private Typeface resolveTypefaceFromFontFamily(
       String fontFamily, int style, int weight, boolean isItalic, String fontVariationSettings) {
     if (fontFamily == null || fontFamily.length() == 0) {
       return null;
     }
-    Typeface missing = Typeface.create(MISSING_FONT_SENTINEL, Typeface.NORMAL);
     Typeface resolved = null;
     for (String rawFamily : fontFamily.split(",")) {
       String family = trimFontFamilyName(rawFamily);
@@ -1215,7 +1229,7 @@ class TSpanView extends TextView {
       if (typeface == null) {
         continue;
       }
-      if (isGenericOrDefaultFontFamily(family) || !typeface.equals(missing)) {
+      if (isResolvedFontFamily(family, typeface, style)) {
         resolved = typeface;
         break;
       }

--- a/android/src/main/java/com/horcrux/svg/TSpanView.java
+++ b/android/src/main/java/com/horcrux/svg/TSpanView.java
@@ -42,6 +42,7 @@ import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.views.text.ReactFontManager;
 import java.text.Bidi;
 import java.util.ArrayList;
+import java.util.Locale;
 import javax.annotation.Nullable;
 
 @SuppressLint("ViewConstructor")
@@ -1124,6 +1125,107 @@ class TSpanView extends TextView {
     }
   }
 
+  private static final String MISSING_FONT_SENTINEL = "__rnsvg_missing_font__";
+
+  private static String trimFontFamilyName(String raw) {
+    String family = raw.trim();
+    if (family.length() >= 2) {
+      char first = family.charAt(0);
+      char last = family.charAt(family.length() - 1);
+      if ((first == '"' && last == '"') || (first == '\'' && last == '\'')) {
+        family = family.substring(1, family.length() - 1).trim();
+      }
+    }
+    return family;
+  }
+
+  private static boolean isGenericOrDefaultFontFamily(String family) {
+    String normalized = family.toLowerCase(Locale.US);
+    return normalized.equals("serif")
+        || normalized.equals("sans-serif")
+        || normalized.equals("monospace")
+        || normalized.equals("cursive")
+        || normalized.equals("fantasy")
+        || normalized.equals("system-ui")
+        || normalized.equals("ui-sans-serif")
+        || normalized.equals("ui-serif")
+        || normalized.equals("ui-monospace")
+        || normalized.equals("system")
+        || normalized.equals("roboto")
+        || normalized.equals("sans-serif-thin")
+        || normalized.equals("sans-serif-light")
+        || normalized.equals("sans-serif-medium")
+        || normalized.equals("sans-serif-black")
+        || normalized.equals("sans-serif-condensed");
+  }
+
+  private Typeface loadTypefaceForFamily(
+      String family, int style, int weight, boolean isItalic, String fontVariationSettings) {
+    Typeface typeface = null;
+    String otfpath = FONTS + family + OTF;
+    String ttfpath = FONTS + family + TTF;
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+      Typeface.Builder builder = new Typeface.Builder(assets, otfpath);
+      builder.setFontVariationSettings("'wght' " + weight + fontVariationSettings);
+      builder.setWeight(weight);
+      builder.setItalic(isItalic);
+      typeface = builder.build();
+      if (typeface == null) {
+        builder = new Typeface.Builder(assets, ttfpath);
+        builder.setFontVariationSettings("'wght' " + weight + fontVariationSettings);
+        builder.setWeight(weight);
+        builder.setItalic(isItalic);
+        typeface = builder.build();
+      }
+    } else {
+      try {
+        typeface = Typeface.createFromAsset(assets, otfpath);
+        typeface = Typeface.create(typeface, style);
+      } catch (Exception ignored) {
+        try {
+          typeface = Typeface.createFromAsset(assets, ttfpath);
+          typeface = Typeface.create(typeface, style);
+        } catch (Exception ignored2) {
+        }
+      }
+    }
+    if (typeface == null) {
+      try {
+        typeface = ReactFontManager.getInstance().getTypeface(family, style, assets);
+      } catch (Exception ignored) {
+      }
+    }
+    return typeface;
+  }
+
+  private Typeface resolveTypefaceFromFontFamily(
+      String fontFamily, int style, int weight, boolean isItalic, String fontVariationSettings) {
+    if (fontFamily == null || fontFamily.length() == 0) {
+      return null;
+    }
+    Typeface missing = Typeface.create(MISSING_FONT_SENTINEL, Typeface.NORMAL);
+    Typeface resolved = null;
+    for (String rawFamily : fontFamily.split(",")) {
+      String family = trimFontFamilyName(rawFamily);
+      if (family.length() == 0) {
+        continue;
+      }
+      Typeface typeface =
+          loadTypefaceForFamily(family, style, weight, isItalic, fontVariationSettings);
+      if (typeface == null) {
+        continue;
+      }
+      if (isGenericOrDefaultFontFamily(family) || !typeface.equals(missing)) {
+        resolved = typeface;
+        break;
+      }
+      if (resolved == null) {
+        resolved = typeface;
+      }
+    }
+    return resolved;
+  }
+
   private void applyTextPropertiesToPaint(Paint paint, FontData font) {
     boolean isBold = font.fontWeight == FontWeight.Bold || font.absoluteFontWeight >= 550;
     boolean isItalic = font.fontStyle == FontStyle.italic;
@@ -1139,45 +1241,10 @@ class TSpanView extends TextView {
       style = Typeface.NORMAL;
     }
 
-    Typeface typeface = null;
     int weight = font.absoluteFontWeight;
-    final String fontFamily = font.fontFamily;
-    if (fontFamily != null && fontFamily.length() > 0) {
-      String otfpath = FONTS + fontFamily + OTF;
-      String ttfpath = FONTS + fontFamily + TTF;
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-        Typeface.Builder builder = new Typeface.Builder(assets, otfpath);
-        builder.setFontVariationSettings("'wght' " + weight + font.fontVariationSettings);
-        builder.setWeight(weight);
-        builder.setItalic(isItalic);
-        typeface = builder.build();
-        if (typeface == null) {
-          builder = new Typeface.Builder(assets, ttfpath);
-          builder.setFontVariationSettings("'wght' " + weight + font.fontVariationSettings);
-          builder.setWeight(weight);
-          builder.setItalic(isItalic);
-          typeface = builder.build();
-        }
-      } else {
-        try {
-          typeface = Typeface.createFromAsset(assets, otfpath);
-          typeface = Typeface.create(typeface, style);
-        } catch (Exception ignored) {
-          try {
-            typeface = Typeface.createFromAsset(assets, ttfpath);
-            typeface = Typeface.create(typeface, style);
-          } catch (Exception ignored2) {
-          }
-        }
-      }
-    }
-
-    if (typeface == null) {
-      try {
-        typeface = ReactFontManager.getInstance().getTypeface(fontFamily, style, assets);
-      } catch (Exception ignored) {
-      }
-    }
+    Typeface typeface =
+        resolveTypefaceFromFontFamily(
+            font.fontFamily, style, weight, isItalic, font.fontVariationSettings);
 
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
       typeface = Typeface.create(typeface, weight, isItalic);

--- a/apple/Text/RNSVGGlyphContext.mm
+++ b/apple/Text/RNSVGGlyphContext.mm
@@ -1,5 +1,6 @@
 #import "RNSVGGlyphContext.h"
 #import <React/RCTFont.h>
+#import <TargetConditionals.h>
 #import "RNSVGFontData.h"
 #import "RNSVGNode.h"
 #import "RNSVGPropHelper.h"
@@ -111,10 +112,68 @@
   return mFontContext_;
 }
 
+static NSArray<NSString *> *RNSVGFontFamilyList(NSString *fontFamily)
+{
+  if (fontFamily.length == 0) {
+    return @[];
+  }
+  NSArray<NSString *> *parts = [fontFamily componentsSeparatedByString:@","];
+  NSMutableArray<NSString *> *families = [NSMutableArray new];
+  NSCharacterSet *trimSet = [NSCharacterSet characterSetWithCharactersInString:@" \t\"'"];
+  for (NSString *part in parts) {
+    NSString *family = [part stringByTrimmingCharactersInSet:trimSet];
+    if (family.length > 0) {
+      [families addObject:family];
+    }
+  }
+  return families;
+}
+
+static BOOL RNSVGFontFamilyIsAvailable(NSString *family)
+{
+  if (family.length == 0) {
+    return NO;
+  }
+#if !TARGET_OS_OSX
+  if ([UIFont fontNamesForFamilyName:family].count > 0) {
+    return YES;
+  }
+  if ([UIFont fontWithName:family size:12] != nil) {
+    return YES;
+  }
+#endif
+  UIFont *resolved = [RCTFont updateFont:nil
+                              withFamily:family
+                                    size:@12
+                                  weight:nil
+                                   style:nil
+                                 variant:nil
+                         scaleMultiplier:1.0];
+  UIFont *systemFallback = [RCTFont updateFont:nil
+                                    withFamily:nil
+                                          size:@12
+                                        weight:nil
+                                         style:nil
+                                       variant:nil
+                               scaleMultiplier:1.0];
+  return resolved != nil && ![resolved.fontName isEqualToString:systemFallback.fontName];
+}
+
+static NSString *RNSVGSelectFontFamily(NSString *fontFamily)
+{
+  NSArray<NSString *> *families = RNSVGFontFamilyList(fontFamily);
+  for (NSString *family in families) {
+    if (RNSVGFontFamilyIsAvailable(family)) {
+      return family;
+    }
+  }
+  return families.firstObject ?: fontFamily;
+}
+
 - (CTFontRef)getGlyphFont
 {
   CGFloat size = topFont_->fontSize;
-  NSString *fontFamily = topFont_->fontFamily;
+  NSString *fontFamily = RNSVGSelectFontFamily(topFont_->fontFamily);
   NSString *fontStyle = RNSVGFontStyleStrings[topFont_->fontStyle];
   NSString *fontWeight = RNSVGFontWeightStrings[topFont_->fontWeight];
   UIFont *font = [RCTFont updateFont:nil

--- a/apps/common/test/Test2974.tsx
+++ b/apps/common/test/Test2974.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react';
+import {Platform, View} from 'react-native';
+import {Svg, Text} from 'react-native-svg';
+
+const fallbackFamily =
+  Platform.OS === 'ios' || Platform.OS === 'macos'
+    ? 'MissingFont, Georgia'
+    : 'MissingFont, serif';
+
+export default function Test2974() {
+  return (
+    <View style={{paddingTop: 60, paddingHorizontal: 16, gap: 16}}>
+      <Svg height="50" width="100%">
+        <Text y="36" fontSize={28}>
+          The quick brown fox
+        </Text>
+      </Svg>
+      <Svg height="50" width="100%">
+        <Text
+          y="36"
+          fontSize={28}
+          fontFamily={
+            Platform.OS === 'ios' || Platform.OS === 'macos'
+              ? 'Georgia'
+              : 'serif'
+          }>
+          The quick brown fox
+        </Text>
+      </Svg>
+      <Svg height="50" width="100%">
+        <Text y="36" fontSize={28} fontFamily={fallbackFamily}>
+          The quick brown fox
+        </Text>
+      </Svg>
+    </View>
+  );
+}

--- a/apps/common/test/index.tsx
+++ b/apps/common/test/index.tsx
@@ -37,6 +37,7 @@ import Test2471 from './Test2471';
 import Test2520 from './Test2520';
 import Test2670 from './Test2670';
 import Test2923 from './Test2923';
+import Test2974 from './Test2974';
 
 export default function App() {
   return <ColorTest />;

--- a/src/lib/extract/extractText.tsx
+++ b/src/lib/extract/extractText.tsx
@@ -20,16 +20,19 @@ const cachedFontObjectsFromString: {
   } | null;
 } = {};
 
-function extractSingleFontFamily(fontFamilyString?: string) {
-  // SVG on the web allows for multiple font-families to be specified.
-  // For compatibility, we extract the first font-family, hoping
-  // we'll get a match.
-  return fontFamilyString
-    ? fontFamilyString
-        .split(commaReg)[0]
-        .replace(fontFamilyPrefix, '')
-        .replace(fontFamilySuffix, '')
-    : null;
+function extractFontFamily(fontFamilyString?: string) {
+  // CSS/SVG font-family is a prioritized list. Keep every family so native
+  // renderers can fall back when the first name is not installed.
+  if (!fontFamilyString) {
+    return null;
+  }
+  const families = fontFamilyString
+    .split(commaReg)
+    .map((family) =>
+      family.replace(fontFamilyPrefix, '').replace(fontFamilySuffix, '')
+    )
+    .filter((family) => family.length > 0);
+  return families.length > 0 ? families.join(', ') : null;
 }
 
 function parseFontString(font: string) {
@@ -47,7 +50,7 @@ function parseFontString(font: string) {
     fontSize: match[2] || 12,
     fontWeight: isBold ? 'bold' : 'normal',
     fontStyle: isItalic ? 'italic' : 'normal',
-    fontFamily: extractSingleFontFamily(match[3]),
+    fontFamily: extractFontFamily(match[3]),
   };
   return cachedFontObjectsFromString[font];
 }
@@ -95,7 +98,7 @@ export function extractFont(props: fontProps) {
     fontWeight,
     fontStretch,
     fontSize,
-    fontFamily: extractSingleFontFamily(fontFamily),
+    fontFamily: extractFontFamily(fontFamily),
     textAnchor,
     textDecoration,
     letterSpacing,

--- a/windows/RNSVG/TSpanView.cpp
+++ b/windows/RNSVG/TSpanView.cpp
@@ -5,6 +5,7 @@
 #endif
 
 #include <codecvt>
+#include <string>
 
 #include "Utils.h"
 
@@ -12,6 +13,51 @@ using namespace winrt;
 using namespace Microsoft::ReactNative;
 
 namespace winrt::RNSVG::implementation {
+namespace {
+
+std::wstring TrimFontFamilyName(std::wstring value) {
+  auto const isTrim = [](wchar_t ch) { return ch == L' ' || ch == L'\t' || ch == L'"' || ch == L'\''; };
+  while (!value.empty() && isTrim(value.front())) {
+    value.erase(value.begin());
+  }
+  while (!value.empty() && isTrim(value.back())) {
+    value.pop_back();
+  }
+  return value;
+}
+
+hstring SelectAvailableFontFamily(IDWriteFactory *factory, hstring const &fontFamily) {
+  com_ptr<IDWriteFontCollection> collection;
+  if (FAILED(factory->GetSystemFontCollection(collection.put())) || !collection) {
+    return fontFamily;
+  }
+
+  std::wstring raw{fontFamily.c_str()};
+  hstring firstFamily;
+  size_t start = 0;
+  while (start <= raw.size()) {
+    size_t const comma = raw.find(L',', start);
+    std::wstring part = TrimFontFamilyName(
+        raw.substr(start, comma == std::wstring::npos ? std::wstring::npos : comma - start));
+    if (!part.empty()) {
+      if (firstFamily.empty()) {
+        firstFamily = hstring{part};
+      }
+      UINT32 index = 0;
+      BOOL exists = FALSE;
+      if (SUCCEEDED(collection->FindFamilyName(part.c_str(), &index, &exists)) && exists) {
+        return hstring{part};
+      }
+    }
+    if (comma == std::wstring::npos) {
+      break;
+    }
+    start = comma + 1;
+  }
+  return firstFamily.empty() ? fontFamily : firstFamily;
+}
+
+} // namespace
 
 void TSpanView::UpdateProperties(IJSValueReader const &reader, bool forceUpdate, bool invalidate) {
   const JSValueObject &propertyMap{JSValue::ReadObjectFrom(reader)};
@@ -52,8 +98,9 @@ void TSpanView::Draw(RNSVG::D2DDeviceContext const &context, Size const &size) {
       reinterpret_cast<::IUnknown **>(dwriteFactory.put_void())));
 
   com_ptr<IDWriteTextFormat> textFormat;
+  hstring const resolvedFamily{SelectAvailableFontFamily(dwriteFactory.get(), FontFamily())};
   check_hresult(dwriteFactory->CreateTextFormat(
-      FontFamily().c_str(),
+      resolvedFamily.c_str(),
       nullptr, // Font collection (nullptr sets it to use the system font collection).
       D2DHelpers::FontWeightFrom(SvgParent(), FontWeight()),
       DWRITE_FONT_STYLE_NORMAL,


### PR DESCRIPTION
# Summary

Fixes #2974.

`fontFamily="MissingFont, serif"` (and the equivalent CSS `font` shorthand) currently renders with the platform default font instead of the next family in the list. That is because `extractFont` kept only the first name, so native never saw a fallback.

This change:

- Keeps the full, quote-stripped family list in JS (`MissingFont, serif`).
- Picks the first installed family on Apple, Android, and Windows.
- Leaves generic CSS keywords such as `serif` on iOS to #2976 — the iOS test screen uses `Georgia` as the fallback, matching the issue report.

## Test Plan

Commands run locally:

- `yarn lint` ✅
- `yarn tsc` ✅
- `yarn jest __tests__/extractText.test.tsx --globalSetup='' --globalTeardown=''` ✅
- Sabotage: restoring first-family-only extract makes the new tests fail ✅

### What's required for testing (prerequisites)?

An iOS simulator or Android emulator running the common test app.

### What are the steps to reproduce (after prerequisites)?

1. Open `Test2974`.
2. Line 1 is the platform default font.
3. Line 2 is an available serif (`Georgia` on iOS/macOS, `serif` on Android).
4. Line 3 uses `MissingFont, <serif fallback>` and should match line 2, not line 1.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |      ✅      |
| MacOS   |      ✅      |
| Android |      ✅      |
| Web     |      ✅      |

Web already honors CSS fallback lists once the full `font-family` string is preserved.

## Checklist

- [ ] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [x] I updated the typed files (typescript)
- [x] I added a test for the API in the `__tests__` folder
